### PR TITLE
Fix WSL auto-start wedging on an orphaned keepalive

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -131,14 +131,32 @@ function startServerIfNeeded() {
       : WSL_DISTRO
         ? 'in this WSL distro (' + WSL_DISTRO + ')'
         : 'in your default WSL distro'
+    // Detach the server into its OWN session via `setsid`, so it outlives THIS
+    // bootstrap's wsl.exe session. Without it, a bootstrap that LOSES the flock
+    // keepalive race below -- because a *previous*, now-serverless keepalive
+    // still holds the lock -- exec-fails straight out of `flock -n`, tearing
+    // its session down and SIGHUP-killing the serve it just backgrounded. An
+    // orphaned keepalive then wedges auto-start permanently: the distro stays
+    // up (the stale keepalive holds it) but every new serve dies before it can
+    // bind, so the app sits on "Connecting…" forever (2026-07-27 WSL incident).
+    // setsid puts serve in a new session immune to that teardown; the stale
+    // keepalive now merely keeps the distro alive long enough for it to bind.
+    // `command -v setsid` guards it: setsid ships with util-linux (present
+    // wherever the flock keepalive is) but NOT on macOS, whose native path has
+    // no keepalive and already detaches via spawn({detached}) -- there $SETSID
+    // is empty and this collapses back to the original bare exec.
+    const setsidPrefix = 'SETSID="$(command -v setsid || true)"; '
+    const redirect = ' </dev/null >>"$MF_LOG" 2>&1'
     const launch = WSL_REPO
-      ? 'cd ' + shq(WSL_REPO) + ' && exec .venv/bin/python backend/web/run.py'
-      : 'MF="$(command -v mindflock || true)";'
+      ? setsidPrefix + 'cd ' + shq(WSL_REPO)
+        + ' && exec $SETSID .venv/bin/python backend/web/run.py' + redirect
+      : setsidPrefix
+        + 'MF="$(command -v mindflock || true)";'
         + ' [ -z "$MF" ] && [ -x "$HOME/.local/bin/mindflock" ] && MF="$HOME/.local/bin/mindflock";'
         // cd "$HOME" first: wsl.exe starts the shell in the Windows cwd of the
         // app (C:\Program Files\MindFlock -> /mnt/c/...), and `mindflock serve`
         // manages whatever repo it is started from.
-        + ' if [ -n "$MF" ]; then cd "$HOME"; exec "$MF" serve;'
+        + ' if [ -n "$MF" ]; then cd "$HOME"; exec $SETSID "$MF" serve' + redirect + ';'
         + ' else echo "mindflock is not installed ' + where + '."'
         + ' && echo "Install it:  curl -LsSf https://raw.githubusercontent.com/MindFlock/MindFlock/main/install.sh | sh";'
         + ' fi'


### PR DESCRIPTION
## Problem

On Windows/WSL, the desktop app would sit on **"Connecting automatically…"** indefinitely — the server only came up if the user manually ran `mindflock serve` in a terminal. The bootstrap log showed only repeated `===== desktop bootstrap … =====` banners with no server output.

## Root cause

`electron/main.js` auto-starts `mindflock serve` in WSL by backgrounding it (`( … ) &`) inside the bootstrap's `wsl.exe` session, then parking a `flock -n` keepalive to hold the distro open. Because the serve was a plain background job **in that session**, its survival depended on the session staying alive.

That only holds for the *first* bootstrap after a distro boot (it wins the `flock` and `sleep`s forever). Any later bootstrap fired while a **previous, now-serverless keepalive still holds the lock** loses the `flock -n` race, `exec`-fails straight out of the keepalive, tears its session down, and SIGHUP-kills the serve it just backgrounded — before it can bind. The stale keepalive keeps the distro up, so nothing self-heals. Killing the orphaned keepalive (`pkill -f mindflock-wsl-keepalive`) unwedged it, confirming the mechanism.

## Fix

Detach serve into its **own session** via `setsid`, so it outlives the bootstrap session regardless of who wins the keepalive lock; the stale keepalive now merely keeps the distro alive long enough for it to bind. Guarded with `command -v setsid` (util-linux — present wherever the `flock` keepalive is, absent on macOS) so the native path (no keepalive, already detached via `spawn({detached})`) collapses back to the original bare `exec`.

## Verification

- `bash -n` on the generated bootstrap script — both installed and dev (`MINDFLOCK_REPO`) modes parse clean.
- `node --check electron/main.js` passes.
- Reproduced the exact wedge (stale keepalive + a losing `flock -n` bootstrap) and confirmed a `setsid`-detached child survives the parent session teardown, whereas the old plain-background child did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)