### PR TITLE
Clear the WSL engine when uninstalling the Windows app

### DIFF
--- a/electron/build/installer.nsh
+++ b/electron/build/installer.nsh
@@ -39,3 +39,62 @@
   Pop $1
   Pop $0
 !macroend
+
+; Uninstall — take the WSL engine with the app, so removing MindFlock from
+; Add/Remove Programs clears the whole product. The shell alone would strand
+; the `uv` tool + ~/.local/bin/mindflock shim, the git worktrees MindFlock
+; registered inside the user's own repos, and the activity hooks it merged
+; into their repo settings.
+;
+; GUARDED by ${isUpdated}: electron-builder runs THIS uninstaller during an
+; UPDATE too (uninstall old → install new), passing --updated. Tearing the
+; engine down then would wipe it on every auto-update, so only a genuine,
+; user-initiated uninstall (no --updated) touches it. LogicLib + ${isUpdated}
+; are in scope here — uninstaller.nsh guards its own file removal the same way.
+;
+; SAFE default: `mindflock uninstall --yes` runs WITHOUT --purge, so the user's
+; ~/.mindflock[-assistant] history + settings survive and a reinstall resumes.
+; The repo footprint (worktrees, hooks) IS reversed — that must not be stranded
+; — then the uv tool + CLI shim are removed as a separate process (the CLI only
+; PRINTS that line itself: it can't delete the venv it is running from).
+;
+; The teardown is a base64-encoded bash script decoded + run inside WSL — the
+; exact transport main.js uses — chosen so no shell quoting has to survive the
+; NSIS → CreateProcess → wsl.exe → bash gauntlet (the blob is pure
+; [A-Za-z0-9+/=], so only the outer quote pair matters). Decoded it is:
+;   MF="$(command -v mindflock || true)"
+;   [ -z "$MF" ] && [ -x "$HOME/.local/bin/mindflock" ] && MF="$HOME/.local/bin/mindflock"
+;   pkill -f 'mindflock serve'          # stop the server (uninstall refuses while it answers)
+;   pkill -f 'backend/web/run.py'
+;   pkill -f 'mindflock-wsl-keepalive'  # our own wsl.exe session keeps the distro up meanwhile
+;   sleep 1
+;   MINDFLOCK_NONINTERACTIVE=1 "$MF" uninstall --yes   # reverse repo footprint, keep home dirs
+;   uv tool uninstall mindflock         # remove the venv + ~/.local/bin shim
+; To change it: edit the script, re-run `base64 -w0`, and replace the blob below.
+!macro customUnInstall
+  ${ifNot} ${isUpdated}
+    Push $0
+    Push $1
+
+    SetDetailsPrint both
+
+    ; wsl.exe: Sysnative alias first (32-bit uninstaller on 64-bit Windows),
+    ; then plain System32 — the same lookup customInstall uses.
+    StrCpy $1 "$WINDIR\Sysnative\wsl.exe"
+    IfFileExists "$1" mf_un_have_wsl 0
+    StrCpy $1 "$SYSDIR\wsl.exe"
+    IfFileExists "$1" mf_un_have_wsl 0
+      DetailPrint "MindFlock: WSL not found — leaving the WSL engine (if any) in place."
+      Goto mf_un_end
+
+    mf_un_have_wsl:
+    DetailPrint "MindFlock: removing the engine inside WSL (worktrees + hooks + the mindflock tool)…"
+    nsExec::ExecToLog '"$1" -e bash --login -c "echo TUY9IiQoY29tbWFuZCAtdiBtaW5kZmxvY2sgfHwgdHJ1ZSkiClsgLXogIiRNRiIgXSAmJiBbIC14ICIkSE9NRS8ubG9jYWwvYmluL21pbmRmbG9jayIgXSAmJiBNRj0iJEhPTUUvLmxvY2FsL2Jpbi9taW5kZmxvY2siCnBraWxsIC1mICdtaW5kZmxvY2sgc2VydmUnIDI+L2Rldi9udWxsIHx8IHRydWUKcGtpbGwgLWYgJ2JhY2tlbmQvd2ViL3J1bi5weScgMj4vZGV2L251bGwgfHwgdHJ1ZQpwa2lsbCAtZiAnbWluZGZsb2NrLXdzbC1rZWVwYWxpdmUnIDI+L2Rldi9udWxsIHx8IHRydWUKc2xlZXAgMQppZiBbIC1uICIkTUYiIF07IHRoZW4gTUlOREZMT0NLX05PTklOVEVSQUNUSVZFPTEgIiRNRiIgdW5pbnN0YWxsIC0teWVzIHx8IHRydWU7IGZpCmNvbW1hbmQgLXYgdXYgPi9kZXYvbnVsbCAyPiYxICYmIHV2IHRvb2wgdW5pbnN0YWxsIG1pbmRmbG9jayAyPi9kZXYvbnVsbCB8fCB0cnVlCmVjaG8gIk1pbmRGbG9jayBlbmdpbmUgdGVhcmRvd24gY29tcGxldGUuIgo= | base64 -d | bash"'
+    Pop $0
+    DetailPrint "MindFlock: engine teardown finished (exit $0)."
+
+    mf_un_end:
+    Pop $1
+    Pop $0
+  ${endIf}
+!macroend


### PR DESCRIPTION
## What

Uninstalling the desktop shell from **Add/Remove Programs** left the engine behind — the `uv` tool + `~/.local/bin/mindflock` shim, the git worktrees MindFlock registered in the user's own repos, and the activity hooks it merged into their repo settings. Users had to separately run `mindflock uninstall` + `uv tool uninstall mindflock` inside WSL.

This adds a `customUnInstall` macro (`electron/build/installer.nsh`) that runs the engine teardown inside WSL, so a normal Windows uninstall removes the whole product.

## Safety

- **Update-safe** — guarded by `${isUpdated}`. electron-builder runs this uninstaller during an update too (uninstall old → install new, passing `--updated`); the teardown only fires on a genuine user-initiated uninstall, so auto-updates never wipe the engine.
- **Data-safe by default** — `mindflock uninstall --yes` runs **without** `--purge`, so `~/.mindflock[-assistant]` (history, settings) survives and a reinstall resumes. The repo footprint (worktrees, hooks) *is* reversed since it must not be stranded; the uv tool + CLI shim are removed as a separate process (the CLI only *prints* that line — it can't delete the venv it runs from).
- **Quoting-safe** — the teardown is a base64-encoded bash payload decoded and run in WSL (the same transport `main.js` uses), so no shell quoting has to survive NSIS → CreateProcess → wsl.exe → bash. The embedded blob was verified to round-trip and `bash -n` clean.

## Verification

- Payload `bash -n` clean; embedded base64 byte-matches the source and decodes exactly.
- NSIS compile validated via the `release.yml` dry-run (native Windows runner) — see linked run.

## Scope / follow-up

Windows only. macOS (`.dmg`) and Linux (`.AppImage`) have **no OS hook** on app deletion — dragging to Trash / deleting the AppImage runs no code — so "delete app → engine goes" can't be done natively there. The equivalent is an in-app "Uninstall MindFlock…" action; proposed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)