### PR TITLE
macOS self-signing + settings-toggle & native-control theming fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,6 +46,12 @@ body:
     attributes:
       label: Relevant logs
       description: >
-        Server terminal output around the failure, and/or
-        `mindflock events --follow` output while reproducing.
+        **Please include logs — they're usually what makes a bug fixable.**
+        Open **Settings → System logs** in the app and paste the tail of the
+        relevant source: **Server** for UI/CLI/API issues, **Ingestion
+        pipeline** for PR-review or ticket-ingestion issues (that's the raw
+        capture; the structured one is there too). Click the file path shown
+        under the toolbar to reveal it in Finder / your file manager if you'd
+        rather attach the whole file. `mindflock events --follow` output while
+        reproducing helps too.
       render: text

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,18 @@ jobs:
   # same tag release. Depends on `release` both for the tag/version check
   # (which runs there) and because `gh release upload` needs the release to
   # exist already.
-  # TODO: code signing — these artifacts are UNSIGNED. macOS needs a
-  # Developer ID cert + notarization (CSC_LINK / CSC_KEY_PASSWORD /
-  # APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD secrets) before Gatekeeper trusts
-  # the dmg, and Windows needs an Authenticode cert before SmartScreen
-  # trusts the nsis installer.
+  # Signing status:
+  #  - macOS: signed with a SELF-SIGNED cert when the MAC_CSC_LINK /
+  #    MAC_CSC_KEY_PASSWORD secrets are set (scripts/make-mac-selfsigned-cert.sh
+  #    mints them). That is NOT a Developer ID and does NOT satisfy Gatekeeper —
+  #    users still clear the "unverified developer" prompt once — but it gives
+  #    the app a stable code identity so macOS TCC remembers folder-access
+  #    grants instead of re-prompting every launch. Without the secrets (forks,
+  #    or before they're configured) the build falls back to unsigned.
+  #  - Windows still needs an Authenticode cert before SmartScreen trusts the
+  #    nsis installer.
+  # A true Gatekeeper-clean dmg needs a Developer ID + notarization (CSC_LINK /
+  # CSC_KEY_PASSWORD / APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD), still a TODO.
   desktop:
     # On a tag: wait for `release`, which creates the release these artifacts
     # attach to (and runs the version guard). On a dry run `release` is
@@ -107,11 +114,62 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build (unsigned)
+      # macOS only: import the self-signed cert into a throwaway keychain AND
+      # mark it trusted for code signing. electron-builder's identity search
+      # (`security find-identity -v -p codesigning`) lists *trusted* identities
+      # only; a p12 imported without a trust setting shows as
+      # CSSMERR_TP_NOT_TRUSTED and gets skipped — which silently leaves the app
+      # unsigned and TCC re-prompting. Trusting it here (only on this ephemeral
+      # runner — end users never trust it, and don't need to: TCC keys folder
+      # grants on the signature, Gatekeeper is the only thing that wants trust)
+      # is what makes electron-builder actually sign. No-op when the secret is
+      # absent, so forks fall back to an unsigned build below.
+      - name: Prepare self-signed signing keychain (macOS)
+        if: matrix.os == 'macos-latest'
         env:
-          # Don't look for a signing identity on the macOS runner keychain —
-          # build unsigned instead of failing (see the code-signing TODO).
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MAC_CSC_LINK:-}" ]; then
+            echo "No MAC_CSC_LINK secret — will build unsigned."
+            exit 0
+          fi
+          KEYCHAIN="$RUNNER_TEMP/mindflock-signing.keychain-db"
+          KPASS="$(openssl rand -hex 16)"
+          P12="$RUNNER_TEMP/mindflock.p12"
+          CER="$RUNNER_TEMP/mindflock.pem"
+          printf '%s' "$MAC_CSC_LINK" | base64 --decode > "$P12"
+          security create-keychain -p "$KPASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KPASS" "$KEYCHAIN"
+          security import "$P12" -k "$KEYCHAIN" -P "$MAC_CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          # Let codesign use the key headlessly (no keychain-access GUI prompt).
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KPASS" "$KEYCHAIN" >/dev/null
+          # Prepend our keychain to the search list, keeping the existing ones.
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | sed 's/"//g')
+          # Trust the self-signed root for the code-signing policy so
+          # find-identity -v accepts it. System domain needs sudo, which is
+          # passwordless on GitHub runners.
+          openssl pkcs12 -in "$P12" -passin "pass:$MAC_CSC_KEY_PASSWORD" -legacy \
+            -nokeys -clcerts -out "$CER"
+          sudo security add-trusted-cert -d -r trustRoot -p codeSign \
+            -k /Library/Keychains/System.keychain "$CER"
+          echo "Signing identities now visible:"
+          security find-identity -v -p codesigning "$KEYCHAIN"
+          # Hand electron-builder the keychain + identity name to sign with.
+          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+          echo "CSC_NAME=MindFlock Self-Signed" >> "$GITHUB_ENV"
+
+      - name: Build
+        env:
+          # Sign on macOS only when the step above found the identity (CSC_NAME
+          # lands in GITHUB_ENV then, and CSC_KEYCHAIN with it). Otherwise —
+          # forks, Windows, Linux — disable identity discovery so the build is
+          # unsigned rather than failing.
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ env.CSC_NAME != '' && 'true' || 'false' }}
         run: npx electron-builder --publish never
 
       # One .sha256 next to each installer. Unsigned binaries downloaded from a

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,10 @@ Thumbs.db
 !.env.example
 *.pem
 *.key
+# Self-signed macOS code-signing key (scripts/make-mac-selfsigned-cert.sh).
+# The private key must never be committed — it lives only in the CI secret.
+*.p12
+mindflock-selfsigned.p12.base64
 secrets.*
 # secrets.py is a source module (the secret *resolver*), not secret data — keep it tracked
 !secrets.py

--- a/README.md
+++ b/README.md
@@ -74,16 +74,41 @@ steps. If the engine is missing, the app's waiting page says so and shows the
 exact command.
 
 <details>
-<summary>These builds are unsigned — what you'll see on first launch</summary>
+<summary>These builds aren't from a paid developer account — what you'll see on first launch</summary>
 
-Code-signing certificates are on the roadmap, not in this release. Until then:
+MindFlock has no Apple Developer ID or Windows Authenticode certificate (both
+are paid, per-year subscriptions). The macOS build *is* signed, but with a
+free self-signed certificate — enough to keep macOS from re-asking for folder
+permission on every launch, not enough to satisfy Gatekeeper. So on first
+launch:
 
-- **macOS** — *"Apple could not verify MindFlock is free of malware."* That
-  dialog has no **Open** button, and the old Control-click → **Open** bypass
-  was removed in macOS Sequoia. Dismiss it, then go to **System Settings →
-  Privacy & Security**, scroll to Security, and click **Open Anyway** next to
-  MindFlock. From a terminal the equivalent is
-  `xattr -dr com.apple.quarantine /Applications/MindFlock.app`.
+**macOS — "Apple could not verify MindFlock is free of malware."**
+
+That dialog has no **Open** button, and the old Control-click → **Open**
+shortcut was removed in macOS Sequoia. To open it anyway (you only do this
+once):
+
+1. Drag **MindFlock** into your **Applications** folder and try to open it. The
+   warning appears — click **Done** to dismiss it.
+2. Open the  menu → **System Settings…** → **Privacy & Security**.
+3. Scroll down to the **Security** section. You'll see a line like
+   *"MindFlock was blocked to protect your Mac."* with an **Open Anyway**
+   button next to it. Click it.
+4. Confirm with **Open Anyway** again and authenticate with Touch ID or your
+   password. MindFlock launches, and macOS remembers the choice — you won't be
+   asked again.
+
+Prefer the terminal? This does the same thing in one line:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/MindFlock.app
+```
+
+The **first time** MindFlock reads a folder under Documents, Desktop,
+Downloads, or an external drive, macOS asks *"MindFlock would like to access
+files…"* — click **Allow**. Because the app is signed, that grant sticks; it
+won't ask again for that folder.
+
 - **Windows** — SmartScreen's "Windows protected your PC". Click **More
   info** → **Run anyway**.
 - **Linux** — no prompt; AppImages aren't signed by convention.

--- a/backend/ticket_ingestion/config.py
+++ b/backend/ticket_ingestion/config.py
@@ -133,7 +133,10 @@ class PipelineConfig:
     workspace_dir: Path = Path("./workspaces")
     min_description_length: int = 20
     log_file: Path = Path("./logs/pipeline.log")
-    log_level: str = "INFO"
+    # DEBUG by default so Settings → System logs shows detailed ingestion
+    # activity (only the backend.ticket_ingestion loggers — propagation is off,
+    # so third-party libs don't flood it). Override with logging.log_level.
+    log_level: str = "DEBUG"
     poll_interval_seconds: int = 20
     # Generic workspace setup: shell commands run in each fresh workspace
     # (None = auto-detect from workspace contents) and warm cache seeds.
@@ -272,7 +275,7 @@ def _merge_layers(raw: dict) -> dict:
         "log_file",
         logging_section.get("log_file") or "./logs/pipeline.log",
     )
-    _put(logging_section, "log_level", logging_section.get("log_level") or "INFO")
+    _put(logging_section, "log_level", logging_section.get("log_level") or "DEBUG")
 
     # --- github block (only materialize when something is set) --------------
     _put(
@@ -569,7 +572,7 @@ def _parse_generic_config(
     ):
         type_errors.append("validation.min_description_length must be an integer")
     log_file = logging_section.get("log_file") or "./logs/pipeline.log"
-    log_level = logging_section.get("log_level") or "INFO"
+    log_level = logging_section.get("log_level") or "DEBUG"
 
     problems = missing + type_errors
     if problems:

--- a/backend/ticket_ingestion/logging_config.py
+++ b/backend/ticket_ingestion/logging_config.py
@@ -14,12 +14,14 @@ _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 def _log_max_bytes() -> int:
     """Rolling-window size for the pipeline log so it can't grow unbounded.
-    Keeps the last ~50 KB (current file ≤ this, plus one rollover backup).
-    Override with MINDFLOCK_PIPELINE_LOG_MAX_BYTES."""
+    Keeps the last ~2 MB (current file ≤ this, plus one rollover backup) — big
+    enough that DEBUG-level ingestion history survives long enough to read in
+    Settings → System logs (whose tail reads the last 256 KB). Override with
+    MINDFLOCK_PIPELINE_LOG_MAX_BYTES."""
     try:
-        return int(os.environ.get("MINDFLOCK_PIPELINE_LOG_MAX_BYTES", 50 * 1024))
+        return int(os.environ.get("MINDFLOCK_PIPELINE_LOG_MAX_BYTES", 2 * 1024 * 1024))
     except (TypeError, ValueError):
-        return 50 * 1024
+        return 2 * 1024 * 1024
 
 
 def setup_logging(config: PipelineConfig) -> None:

--- a/backend/web/core/system_logs.py
+++ b/backend/web/core/system_logs.py
@@ -36,23 +36,26 @@ def _resolve_repo_root() -> Path:
 
 def _log_sources() -> list:
     """Log files worth surfacing in Settings → System logs: the server's own
-    log always, plus the ingestion pipeline's logs when they exist. The pipeline
-    runs as a subprocess from the repo root, so its logs live under
+    log always, plus the ingestion pipeline's log when it exists. The pipeline
+    runs as a subprocess from the repo root, so its log lives under
     ``<repo root>/logs/`` — resolved here rather than relative to this server's
-    cwd. Both the raw stdout/stderr capture (what the sidebar tails) and the
-    structured pipeline log are offered so nothing about a run is hidden."""
+    cwd. We surface the raw stdout/stderr capture (the same file the sidebar
+    tails); the pipeline writes the exact same lines to a second structured file
+    (pipeline.log), so offering both only confused people — one source is it."""
     sources = [{"name": "server", "label": "Server", "path": str(log.logFileName)}]
     root = _resolve_repo_root()
-    candidates = [
-        ("ingestion", "Ingestion pipeline", root / "logs" / "ticket-ingestion.log"),
-        ("pipeline", "Ingestion (structured)", root / "logs" / "pipeline.log"),
-    ]
-    for name, label, path in candidates:
-        try:
-            if path.is_file():
-                sources.append({"name": name, "label": label, "path": str(path)})
-        except OSError:
-            pass
+    ingestion = root / "logs" / "ticket-ingestion.log"
+    try:
+        if ingestion.is_file():
+            sources.append(
+                {
+                    "name": "ingestion",
+                    "label": "Ingestion pipeline",
+                    "path": str(ingestion),
+                }
+            )
+    except OSError:
+        pass
     return sources
 
 

--- a/backend/web/core/system_logs.py
+++ b/backend/web/core/system_logs.py
@@ -10,6 +10,7 @@ Split out of ``backend.web.server`` (which re-imports these names — the
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from backend import log
@@ -17,22 +18,41 @@ from backend import log
 _LOG_TAIL_MAX = 256 * 1024  # only ever read/return the last 256 KB of a log
 
 
+def _resolve_repo_root() -> Path:
+    """The directory the ingestion pipeline runs in — where ``config.toml`` and
+    its ``logs/`` live. Same resolution the ingestion addon uses to launch the
+    subprocess (``MINDFLOCK_REPO_ROOT`` env → nearest ancestor with
+    ``config.toml`` → cwd), because THIS server's cwd is not guaranteed to
+    match the pipeline's — which is exactly why a hard-coded relative
+    ``logs/pipeline.log`` never resolved and the ingestion log went missing."""
+    env = (os.environ.get("MINDFLOCK_REPO_ROOT") or "").strip()
+    if env:
+        return Path(env).expanduser().resolve()
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "config.toml").is_file():
+            return parent
+    return Path.cwd()
+
+
 def _log_sources() -> list:
-    """Log files worth surfacing: the server's own log always, plus the
-    ingestion pipeline log when it exists (default ``./logs/pipeline.log``)."""
+    """Log files worth surfacing in Settings → System logs: the server's own
+    log always, plus the ingestion pipeline's logs when they exist. The pipeline
+    runs as a subprocess from the repo root, so its logs live under
+    ``<repo root>/logs/`` — resolved here rather than relative to this server's
+    cwd. Both the raw stdout/stderr capture (what the sidebar tails) and the
+    structured pipeline log are offered so nothing about a run is hidden."""
     sources = [{"name": "server", "label": "Server", "path": str(log.logFileName)}]
-    ing = Path("logs/pipeline.log")
-    try:
-        if ing.exists():
-            sources.append(
-                {
-                    "name": "ingestion",
-                    "label": "Ingestion pipeline",
-                    "path": str(ing.resolve()),
-                }
-            )
-    except OSError:
-        pass
+    root = _resolve_repo_root()
+    candidates = [
+        ("ingestion", "Ingestion pipeline", root / "logs" / "ticket-ingestion.log"),
+        ("pipeline", "Ingestion (structured)", root / "logs" / "pipeline.log"),
+    ]
+    for name, label, path in candidates:
+        try:
+            if path.is_file():
+                sources.append({"name": name, "label": label, "path": str(path)})
+        except OSError:
+            pass
     return sources
 
 

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -31344,6 +31344,11 @@ function SystemLogs({ onOpenSysLogsPane }) {
     const ok = await copyText(path);
     toast(ok ? "Log path copied to clipboard" : path);
   }, [path]);
+  const copyLog = reactExports.useCallback(async () => {
+    if (!text) return;
+    const ok = await copyText(text);
+    toast(ok ? "Log copied to clipboard" : "Copy failed");
+  }, [text]);
   const load2 = reactExports.useCallback(async () => {
     let d;
     try {
@@ -31391,6 +31396,17 @@ function SystemLogs({ onOpenSysLogsPane }) {
         }
       ),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "logs-refresh", className: "test-btn", onClick: load2, children: "Refresh" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          id: "logs-copy",
+          className: "test-btn",
+          title: "Copy everything shown here (the last 256 KB) to the clipboard",
+          onClick: copyLog,
+          children: "Copy log"
+        }
+      ),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "button",
         {

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -28966,13 +28966,13 @@ function GettingStarted() {
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Getting started" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Tips and a guided tour to help you set up MindFlock's features." }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "label",
+      "div",
       {
         className: "set-row set-switch-row",
         title: "Small inline 💡 tips that point out features around the app. Turn them back on any time to see the ones you dismissed again.",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Show getting-started hints" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "input",
               {
@@ -29012,12 +29012,12 @@ function GettingStarted() {
 function ReduceMotionRow() {
   const reduceMotion = useUi((s) => s.reduceMotion);
   const setReduceMotion = useUi((s) => s.setReduceMotion);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "set-row set-switch-row", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row set-switch-row", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "notif-rule-text", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Reduce motion" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint notif-rule-desc", children: `While an agent is running, the Agent tab's live terminal scrolls constantly, which some people find tiring to look at. With this on, a running agent's terminal is hidden behind a still "running" panel instead. Clicking, scrolling, or typing anywhere in that window brings the live output back; it returns to the panel after 10 seconds with no input. Only the Agent tab is affected — Terminal, Diff, and Queue are never covered. Off by default.` })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "input",
         {
@@ -29183,13 +29183,13 @@ function Mobile(_) {
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Open MindFlock on your phone. Scan the QR from a device on your Tailscale network, or use one of the URLs below." }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "mobile-body", children: !tailscale ? null : error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "error", children: error }) : !data ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Loading…" }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "label",
+        "div",
         {
           className: "set-row set-switch-row",
           title: "Bind the server to all interfaces so phones on your tailnet can reach it",
           children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Tailscale mode" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx(
                 "input",
                 {
@@ -29312,14 +29312,14 @@ function Notifications(_) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Browser notifications" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "label",
+      "div",
       {
         className: "set-row set-switch-row",
         id: "notif-browser-row",
         title: "Show a desktop/Chrome notification when an agent needs you, a PR merges, or a budget is exceeded",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", id: "notif-browser-label", children: "Desktop / Chrome notifications" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "input",
               {
@@ -29355,12 +29355,12 @@ function Notifications(_) {
 function RuleRow({ rule }) {
   const [on, setOn] = reactExports.useState(rule.enabled !== false);
   const label = rule.label || rule.title || rule.event || "event";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "set-row set-switch-row notif-rule", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row set-switch-row notif-rule", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "notif-rule-text", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: label }),
       rule.body && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint notif-rule-desc", children: rule.body })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "input",
         {
@@ -29573,13 +29573,13 @@ function WindowRefresh() {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Keep usage windows warm" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "label",
+      "div",
       {
         className: "set-row set-switch-row",
         title: "Send a tiny, connection-free ping on a schedule so a provider's rolling usage window anchors when you want it to.",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Scheduled refresh" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "input",
               {
@@ -30981,14 +30981,14 @@ function Ide(_) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Editor CLI used to open workspaces — e.g. cursor, code, windsurf, zed." })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "label",
+      "div",
       {
         className: "set-row set-switch-row",
         id: "ide-auto-row",
         title: "Continuously adopt folders into MindFlock as you open them in your IDE",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", id: "ide-auto-label", children: "IDE auto-adopt" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "input",
               {

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -31322,13 +31322,28 @@ function Doctor(_) {
     ] })
   ] });
 }
+function shellShowItem() {
+  var _a2;
+  return (_a2 = window.mfshell) == null ? void 0 : _a2.showItem;
+}
 function SystemLogs({ onOpenSysLogsPane }) {
   const [sources, setSources] = reactExports.useState([]);
   const [selected, setSelected] = reactExports.useState("server");
   const [text, setText] = reactExports.useState("Loading…");
   const [meta, setMeta] = reactExports.useState("");
+  const [path, setPath] = reactExports.useState("");
   const [follow, setFollow] = reactExports.useState(false);
   const viewRef = reactExports.useRef(null);
+  const revealPath = reactExports.useCallback(async () => {
+    if (!path) return;
+    const show = shellShowItem();
+    if (show) {
+      const r = await show(path).catch(() => null);
+      if (r && r.ok !== false) return;
+    }
+    const ok = await copyText(path);
+    toast(ok ? "Log path copied to clipboard" : path);
+  }, [path]);
   const load2 = reactExports.useCallback(async () => {
     let d;
     try {
@@ -31344,7 +31359,8 @@ function SystemLogs({ onOpenSysLogsPane }) {
     if (atBottom && view) requestAnimationFrame(() => view.scrollTop = view.scrollHeight);
     const src = (d.sources || []).find((s) => s.name === d.selected);
     const kb = Math.round((d.size || 0) / 1024);
-    setMeta(((src == null ? void 0 : src.path) ? src.path + "  ·  " : "") + kb + " KB" + (d.truncated ? " (showing last 256 KB)" : ""));
+    setPath((src == null ? void 0 : src.path) || "");
+    setMeta(kb + " KB" + (d.truncated ? " (showing last 256 KB)" : ""));
   }, [selected]);
   reactExports.useEffect(() => {
     load2();
@@ -31358,7 +31374,11 @@ function SystemLogs({ onOpenSysLogsPane }) {
   }, [follow, load2]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "System logs" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "The server's own log — every request plus errors and background activity, newest last (up to 256 KB). Handy when something misbehaves; copy the tail when reporting an issue." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "set-hint", children: [
+      "The server's log plus the ingestion pipeline's, newest last (up to 256 KB each). Handy when something misbehaves — ",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "please paste the relevant tail into a GitHub issue when reporting a bug" }),
+      " (Ingestion pipeline is the one to grab for PR-review or ticket problems)."
+    ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "logs-toolbar", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "select",
@@ -31389,6 +31409,17 @@ function SystemLogs({ onOpenSysLogsPane }) {
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "logs-meta", className: "muted", children: meta })
     ] }),
+    path && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        id: "logs-path",
+        className: "logs-path",
+        title: shellShowItem() ? "Reveal this log file in Finder / your file manager" : "Copy this log file's full path",
+        onClick: revealPath,
+        children: path
+      }
+    ),
     /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { id: "logs-view", className: "logs-view", ref: viewRef, children: text })
   ] });
 }

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -31338,11 +31338,26 @@ function SystemLogs({ onOpenSysLogsPane }) {
     if (!path) return;
     const show = shellShowItem();
     if (show) {
-      const r = await show(path).catch(() => null);
-      if (r && r.ok !== false) return;
+      try {
+        const r = await show(path);
+        if (r && r.ok !== false) return;
+      } catch {
+      }
     }
-    const ok = await copyText(path);
-    toast(ok ? "Log path copied to clipboard" : path);
+    const el = document.getElementById("logs-path");
+    if (el) {
+      const sel = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      sel == null ? void 0 : sel.removeAllRanges();
+      sel == null ? void 0 : sel.addRange(range);
+    }
+    let ok = false;
+    try {
+      ok = await copyText(path);
+    } catch {
+    }
+    toast(ok ? "Log path copied — paste it anywhere" : "Path selected — press Ctrl+C to copy");
   }, [path]);
   const copyLog = reactExports.useCallback(async () => {
     if (!text) return;

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29665,6 +29665,58 @@ function WindowRefresh() {
     ] })
   ] });
 }
+function IngestionToggle() {
+  const [busy, setBusy] = reactExports.useState(false);
+  const [optimistic, setOptimistic] = reactExports.useState(null);
+  const { data: status, refetch } = useQuery({
+    queryKey: ["mindflock-status"],
+    queryFn: () => api("/api/mindflock/status"),
+    refetchInterval: 1e4,
+    retry: false
+  });
+  if (!status || !status.available) return null;
+  const running = !!status.running;
+  const desired = optimistic ?? (status.desired ?? running);
+  const toggle = async (start) => {
+    if (busy) return;
+    setBusy(true);
+    setOptimistic(start);
+    try {
+      await api(`/api/mindflock/${start ? "start" : "stop"}`, { method: "POST" });
+      toast(start ? "Ticket ingestion on" : "Ticket ingestion paused");
+    } catch (err) {
+      toast(`Ticket ingestion ${start ? "start" : "stop"} failed: ` + (err.message || ""));
+    } finally {
+      setBusy(false);
+      setOptimistic(null);
+      refetch();
+    }
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      className: "set-row set-switch-row",
+      id: "tk-ingestion-toggle-row",
+      title: "Run or stop ticket ingestion — polls your connected sources and auto-creates a coding session for each assigned ticket. Stays in this state across restarts.",
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Automated ingestion" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "checkbox",
+              id: "tk-ingestion-enabled",
+              checked: desired,
+              disabled: busy,
+              onChange: (e) => toggle(e.target.checked)
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
+        ] })
+      ]
+    }
+  );
+}
 function Ticketing(_) {
   const [catalog, setCatalog] = reactExports.useState([]);
   const [sources, setSources] = reactExports.useState(null);
@@ -29743,6 +29795,7 @@ function Ticketing(_) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Ticketing" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint set-block-hint", children: "Connect one or more ticketing platforms and MindFlock auto-creates a coding session for each ticket assigned to you. Add several sources — even two of the same provider (e.g. two Jira sites) — each with its own credentials. Stored in ~/.mindflock/settings.json (never committed)." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(IngestionToggle, {}),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "ticketing-sources", children: sources.map((src) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       SourceCard,
       {
@@ -30316,14 +30369,14 @@ function PrReview({ gotoScreen }) {
       " open pull requests on the repositories below and automatically spins up a coding session to address review comments. It runs while ingestion is active."
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "label",
+      "div",
       {
         className: "set-row set-switch-row",
         id: "gh-pr-toggle-row",
         title: "Turn automated PR review on or off — your repositories are kept either way",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Automated review" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "input",
               {
@@ -30627,14 +30680,14 @@ function GitIssues({ gotoScreen }) {
       " on the repositories below, grabs each issue and all its comments, and automatically spins up a coding session that starts work on a fresh branch for it. Separate from PR review — the repository lists are independent."
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "label",
+      "div",
       {
         className: "set-row set-switch-row",
         id: "gh-issues-toggle-row",
         title: "Turn automated issue handling on or off — your repositories are kept either way",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Automated handling" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ca-switch", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "input",
               {

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -23535,6 +23535,8 @@ function notifFromEvent(env) {
   switch (env.event) {
     case "session.created":
       return { text: "created", cls: "n-info" };
+    case "session.create_failed":
+      return { text: "couldn't start — " + (d.error || "failed"), cls: "n-warn" };
     case "session.deleted":
       return { text: "deleted", cls: "n-muted" };
     case "session.activity_changed":

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -7381,6 +7381,25 @@ button.linklike {
   word-break: break-all;
 }
 
+/* Full log-file path — click to reveal in Finder (desktop) or copy (browser). */
+.logs-path {
+  display: block;
+  width: 100%;
+  margin: 0 0 8px;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: left;
+  color: var(--accent);
+  font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  word-break: break-all;
+  cursor: pointer;
+}
+
+.logs-path:hover {
+  text-decoration: underline;
+}
+
 .logs-view {
   background: var(--bg);
   border: 1px solid var(--border);

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -1175,7 +1175,9 @@ p.set-hint {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  cursor: pointer;
+  /* No row-wide cursor: only the switch toggles now (the row is a <div>, not a
+     <label>), so the whole row must not look clickable. The .ca-slider keeps
+     its own pointer cursor. */
 }
 
 /* The row centers the label's line box on the switch, but the desktop app's

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -540,6 +540,10 @@
  * :root and .light have EQUAL specificity (0,1,0), so .light must stay after
  * :root for the light palette to win. */
 :root {
+  /* Tell the browser to render native control internals (time-picker clock
+     icon, number spinners, checkboxes, scrollbars) dark; .light flips it.
+     Without this the native clock glyph sat near-invisible on the dark bg. */
+  color-scheme: dark;
   --bg: #0f1117;
   --panel: #171a23;
   --panel-2: #1e222e;
@@ -596,6 +600,7 @@
    handful of hard-coded colors that don't survive the swap are patched in
    theme-light.css. The xterm terminal intentionally stays dark. */
 .light {
+  color-scheme: light;
   --bg: #f4f5f8;
   --panel: #ffffff;
   --panel-2: #eceef3;
@@ -1376,14 +1381,18 @@ p.set-hint {
   filter: brightness(1.08);
 }
 
-/* Narrow numeric input (e.g. refresh interval) — replaces an inline width. */
+/* Narrow numeric/time input (e.g. refresh interval, fresh-window time) —
+   replaces an inline width. accent-color tints the number spinner + the
+   time-picker clock glyph to match the rest of MindFlock. */
 .num-sm {
   width: 6em;
+  accent-color: var(--accent);
 }
 
 .set-row input[type="text"],
 .set-row input[type="password"],
-.set-row input[type="number"] {
+.set-row input[type="number"],
+.set-row input[type="time"] {
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--text);
@@ -3523,6 +3532,13 @@ p.set-hint {
   align-items: center;
   gap: 5px;
   font-size: 12.5px;
+  cursor: pointer;
+}
+
+/* Themed checkbox — the check fills with the MindFlock accent instead of the
+   browser-default blue. */
+.wr-prov input[type="checkbox"] {
+  accent-color: var(--accent);
   cursor: pointer;
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -133,10 +133,26 @@ which GitHub resolves only for an exact filename. They're set by
 `artifactName` in `electron/package.json` — renaming one silently breaks the
 front-page buttons, so change the README in the same commit.
 
-Desktop builds are **unsigned** (no Developer ID / Authenticode cert yet), so
-the desktop matrix sets `CSC_IDENTITY_AUTO_DISCOVERY=false` to build rather
-than fail, and `fail-fast: false` keeps one OS's failure from cancelling the
-others — a release missing one installer beats a release missing all three.
+Desktop builds have **no paid signing cert** (no Developer ID / Authenticode),
+so Gatekeeper and SmartScreen still warn on first launch. `fail-fast: false`
+keeps one OS's failure from cancelling the others — a release missing one
+installer beats a release missing all three.
+
+The macOS build *is* signed, but with a **free self-signed certificate**. That
+does nothing for Gatekeeper; its job is to give the app a stable code identity
+so macOS TCC remembers folder-access grants instead of re-prompting on every
+launch (an unsigned app has no identity to attach the grant to). Mint the cert
+once with [`scripts/make-mac-selfsigned-cert.sh`](../scripts/make-mac-selfsigned-cert.sh)
+and store its output as the `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD` repository
+secrets; `release.yml` passes them to electron-builder as `CSC_LINK` /
+`CSC_KEY_PASSWORD`. **Keep the same cert across releases** — regenerating it
+changes the identity and resets every user's remembered grant. When the secrets
+are absent (forks, or before they're set) the matrix falls back to
+`CSC_IDENTITY_AUTO_DISCOVERY=false` and builds unsigned rather than failing.
+
+A Gatekeeper-clean, notarized dmg still needs a paid Developer ID; that remains
+a TODO. Signing config lives in `electron/package.json` (`mac`) and
+`electron/build/entitlements.mac.plist`.
 
 ## Project layout
 

--- a/electron/README.md
+++ b/electron/README.md
@@ -18,10 +18,15 @@ server, reached by scanning the startup QR over your tailnet.)
 ## Deployment (the intended experience)
 
 1. **Once**: install the desktop app. Every tagged release attaches one
-   unsigned build per OS (the README's download buttons point at them), or
+   build per OS (the README's download buttons point at them), or
    `npm run dist` in this folder produces the one for the OS you run it on
    (NSIS `.exe` on Windows, universal `.dmg` on macOS, AppImage on Linux;
-   `dist:win` / `dist:mac` / `dist:linux` force a target).
+   `dist:win` / `dist:mac` / `dist:linux` force a target). None are notarized,
+   so first launch shows an "unverified developer" warning (the top-level
+   README walks through clearing it). The macOS build is self-signed only —
+   enough for macOS to remember folder-access grants, not enough for
+   Gatekeeper; see [Versioning & releases](../docs/development.md#versioning--releases)
+   for the cert setup.
 2. **Once**: install the server/CLI where the engine runs.
    - **Windows** — nothing to do: the NSIS installer runs the step below for
      you inside your default WSL distro (see

--- a/electron/build/entitlements.mac.plist
+++ b/electron/build/entitlements.mac.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    MindFlock is signed with a self-signed certificate (see
+    scripts/make-mac-selfsigned-cert.sh), NOT an Apple Developer ID. The point
+    of signing is a STABLE code identity so macOS TCC remembers folder-access
+    grants instead of re-prompting on every launch — it does nothing for
+    Gatekeeper. Hardened Runtime is off (package.json: hardenedRuntime=false)
+    because it is only meaningful for notarized apps, so these entitlements are
+    inert today. They are declared anyway so that turning Hardened Runtime on
+    later (if a Developer ID ever lands) does not stop Electron launching:
+    Electron needs a JIT and unsigned executable memory, and loads unsigned
+    helper binaries the engine spawns.
+  -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/electron/main.js
+++ b/electron/main.js
@@ -338,6 +338,19 @@ ipcMain.handle('diag:get', () => {
   return diag
 })
 
+// Reveal a file in Finder/Explorer (Settings → System logs "open in Finder").
+// showItemInFolder opens the containing folder with the file selected.
+ipcMain.handle('shell:show-item', (_e, p) => {
+  const target = String(p || '').trim()
+  if (!target) return { ok: false, error: 'no path' }
+  try {
+    shell.showItemInFolder(path.resolve(target))
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, error: String((e && e.message) || e) }
+  }
+})
+
 // One-click recovery for a wedged WSL: `wsl --shutdown` stops the utility VM
 // (the offline page warns that this closes anything else running in WSL),
 // then the normal launcher cold-boots the distro and the server again.

--- a/electron/package.json
+++ b/electron/package.json
@@ -32,7 +32,11 @@
     "mac": {
       "target": [{ "target": "dmg", "arch": ["universal"] }],
       "category": "public.app-category.developer-tools",
-      "artifactName": "MindFlock.dmg"
+      "artifactName": "MindFlock.dmg",
+      "hardenedRuntime": false,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist"
     },
     "linux": {
       "target": "AppImage",

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -16,6 +16,10 @@ contextBridge.exposeInMainWorld('mfshell', {
   // wording differs per OS (Windows routes to Add/Remove Programs), so surface
   // the platform. Undefined in a plain browser → the UI hides the control.
   platform: process.platform,
+  // Reveal a file in the OS file manager (Finder / Explorer), highlighted.
+  // Settings → System logs uses this to jump straight to a log file. Resolves
+  // { ok } so the UI can fall back to copying the path if it can't open.
+  showItem: (p) => ipcRenderer.invoke('shell:show-item', String(p == null ? '' : p)),
 })
 
 // App lifecycle from the UI: the in-app "Uninstall MindFlock" control

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -41,6 +41,12 @@ function notifFromEvent(env: EventEnvelope): { text: string; cls: string } | nul
   switch (env.event) {
     case "session.created":
       return { text: "created", cls: "n-info" };
+    case "session.create_failed":
+      // A forced PR review / ticket start that dies during background
+      // provisioning (clone, comment fetch) only emits this — without a case
+      // here it was dropped, so the user saw an optimistic "starting…" toast
+      // and then nothing. Surface the error so the failure is visible.
+      return { text: "couldn't start — " + (d.error || "failed"), cls: "n-warn" };
     case "session.deleted":
       return { text: "deleted", cls: "n-muted" };
     case "session.activity_changed":

--- a/frontend/src/components/grid/QueueTab.css
+++ b/frontend/src/components/grid/QueueTab.css
@@ -239,6 +239,13 @@
   cursor: pointer;
 }
 
+/* Themed checkbox — the check fills with the MindFlock accent instead of the
+   browser-default blue. */
+.wr-prov input[type="checkbox"] {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
 .queue-item {
   display: flex;
   align-items: flex-start;

--- a/frontend/src/components/settings/SettingsDialog.css
+++ b/frontend/src/components/settings/SettingsDialog.css
@@ -106,7 +106,9 @@ p.set-hint {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  cursor: pointer;
+  /* No row-wide cursor: only the switch toggles now (the row is a <div>, not a
+     <label>), so the whole row must not look clickable. The .ca-slider keeps
+     its own pointer cursor. */
 }
 
 /* The row centers the label's line box on the switch, but the desktop app's

--- a/frontend/src/components/settings/screens/CodingCli.tsx
+++ b/frontend/src/components/settings/screens/CodingCli.tsx
@@ -245,12 +245,13 @@ function WindowRefresh() {
   return (
     <>
       <h3 className="set-section-title">Keep usage windows warm</h3>
-      <label
+      <div
         className="set-row set-switch-row"
         title="Send a tiny, connection-free ping on a schedule so a provider's rolling usage window anchors when you want it to."
       >
         <span className="set-label">Scheduled refresh</span>
-        <span className="ca-switch">
+        {/* label wraps only the switch, so clicking the row text no longer flips it */}
+        <label className="ca-switch">
           <input
             type="checkbox"
             id="wr-enabled"
@@ -258,8 +259,8 @@ function WindowRefresh() {
             onChange={(e) => save({ enabled: e.target.checked })}
           />
           <span className="ca-slider" />
-        </span>
-      </label>
+        </label>
+      </div>
       <p className="set-hint">
         Sends a 1-token message (no MCPs/connections attached) to anchor the rolling usage
         window. Pick the time you want a totally fresh window to begin — usually the start of

--- a/frontend/src/components/settings/screens/General.tsx
+++ b/frontend/src/components/settings/screens/General.tsx
@@ -55,12 +55,13 @@ function GettingStarted() {
       <p className="set-hint">
         Tips and a guided tour to help you set up MindFlock's features.
       </p>
-      <label
+      <div
         className="set-row set-switch-row"
         title="Small inline 💡 tips that point out features around the app. Turn them back on any time to see the ones you dismissed again."
       >
         <span className="set-label">Show getting-started hints</span>
-        <span className="ca-switch">
+        {/* label wraps only the switch, so clicking the row text no longer flips it */}
+        <label className="ca-switch">
           <input
             type="checkbox"
             checked={enabled}
@@ -70,8 +71,8 @@ function GettingStarted() {
             }}
           />
           <span className="ca-slider" />
-        </span>
-      </label>
+        </label>
+      </div>
       <div className="set-row onboarding-action">
         <div className="onboarding-action-text">
           <span className="set-label">Welcome walkthrough</span>
@@ -101,7 +102,7 @@ function ReduceMotionRow() {
   const reduceMotion = useUi((s) => s.reduceMotion);
   const setReduceMotion = useUi((s) => s.setReduceMotion);
   return (
-    <label className="set-row set-switch-row">
+    <div className="set-row set-switch-row">
       <span className="notif-rule-text">
         <span className="set-label">Reduce motion</span>
         <span className="set-hint notif-rule-desc">
@@ -114,7 +115,8 @@ function ReduceMotionRow() {
           never covered. Off by default.
         </span>
       </span>
-      <span className="ca-switch">
+      {/* label wraps only the switch, so clicking the row text no longer flips it */}
+      <label className="ca-switch">
         <input
           type="checkbox"
           checked={reduceMotion}
@@ -124,8 +126,8 @@ function ReduceMotionRow() {
           }}
         />
         <span className="ca-slider" />
-      </span>
-    </label>
+      </label>
+    </div>
   );
 }
 

--- a/frontend/src/components/settings/screens/GitIssues.tsx
+++ b/frontend/src/components/settings/screens/GitIssues.tsx
@@ -129,13 +129,14 @@ export function GitIssues({ gotoScreen }: ScreenProps) {
         are independent.
       </p>
 
-      <label
+      <div
         className="set-row set-switch-row"
         id="gh-issues-toggle-row"
         title="Turn automated issue handling on or off — your repositories are kept either way"
       >
         <span className="set-label">Automated handling</span>
-        <span className="ca-switch">
+        {/* label wraps only the switch, so clicking the row text no longer flips it */}
+        <label className="ca-switch">
           <input
             type="checkbox"
             id="gh-issues-enabled"
@@ -148,8 +149,8 @@ export function GitIssues({ gotoScreen }: ScreenProps) {
             }
           />
           <span className="ca-slider" />
-        </span>
-      </label>
+        </label>
+      </div>
       <div
         id="gh-issues-status"
         className={"pr-status" + (n > 0 && enabled ? " on" : n > 0 ? " paused" : "")}

--- a/frontend/src/components/settings/screens/Ide.tsx
+++ b/frontend/src/components/settings/screens/Ide.tsx
@@ -95,13 +95,14 @@ export function Ide(_: ScreenProps) {
           Editor CLI used to open workspaces — e.g. cursor, code, windsurf, zed.
         </span>
       </label>
-      <label
+      <div
         className="set-row set-switch-row"
         id="ide-auto-row"
         title="Continuously adopt folders into MindFlock as you open them in your IDE"
       >
         <span className="set-label" id="ide-auto-label">IDE auto-adopt</span>
-        <span className="ca-switch">
+        {/* label wraps only the switch, so clicking the row text no longer flips it */}
+        <label className="ca-switch">
           <input
             type="checkbox"
             id="cursor-auto"
@@ -122,8 +123,8 @@ export function Ide(_: ScreenProps) {
             }}
           />
           <span className="ca-slider" />
-        </span>
-      </label>
+        </label>
+      </div>
     </>
   );
 }

--- a/frontend/src/components/settings/screens/Mobile.tsx
+++ b/frontend/src/components/settings/screens/Mobile.tsx
@@ -86,12 +86,13 @@ export function Mobile(_: ScreenProps) {
           <p className="set-hint">Loading…</p>
         ) : (
           <>
-            <label
+            <div
               className="set-row set-switch-row"
               title="Bind the server to all interfaces so phones on your tailnet can reach it"
             >
               <span className="set-label">Tailscale mode</span>
-              <span className="ca-switch">
+              {/* label wraps only the switch, so clicking the row text no longer flips it */}
+              <label className="ca-switch">
                 <input
                   type="checkbox"
                   checked={data.serve_mode === "tailscale"}
@@ -99,8 +100,8 @@ export function Mobile(_: ScreenProps) {
                   onChange={(e) => setMode(e.target.checked)}
                 />
                 <span className="ca-slider" />
-              </span>
-            </label>
+              </label>
+            </div>
             {pending && (
               <button type="button" className="test-btn" disabled={restarting} onClick={onRestart}>
                 {restarting ? "Restarting…" : "Restart server to apply"}

--- a/frontend/src/components/settings/screens/Notifications.tsx
+++ b/frontend/src/components/settings/screens/Notifications.tsx
@@ -85,13 +85,14 @@ export function Notifications(_: ScreenProps) {
   return (
     <>
       <h3 className="set-section-title">Browser notifications</h3>
-      <label
+      <div
         className="set-row set-switch-row"
         id="notif-browser-row"
         title="Show a desktop/Chrome notification when an agent needs you, a PR merges, or a budget is exceeded"
       >
         <span className="set-label" id="notif-browser-label">Desktop / Chrome notifications</span>
-        <span className="ca-switch">
+        {/* label wraps only the switch, so clicking the row text no longer flips it */}
+        <label className="ca-switch">
           <input
             type="checkbox"
             id="notif-browser-toggle"
@@ -109,8 +110,8 @@ export function Notifications(_: ScreenProps) {
             }}
           />
           <span className="ca-slider" />
-        </span>
-      </label>
+        </label>
+      </div>
       <p className="set-hint" id="notif-browser-status">{status}</p>
       <h3 className="set-section-title">What triggers a notification</h3>
       <p className="set-hint">Pick exactly which events notify you — turn off any you don't want.</p>
@@ -136,12 +137,13 @@ function RuleRow({ rule }: { rule: Rule }) {
   const [on, setOn] = useState(rule.enabled !== false);
   const label = rule.label || rule.title || rule.event || "event";
   return (
-    <label className="set-row set-switch-row notif-rule">
+    <div className="set-row set-switch-row notif-rule">
       <span className="notif-rule-text">
         <span className="set-label">{label}</span>
         {rule.body && <span className="set-hint notif-rule-desc">{rule.body}</span>}
       </span>
-      <span className="ca-switch">
+      {/* label wraps only the switch, so clicking the row text no longer flips it */}
+      <label className="ca-switch">
         <input
           type="checkbox"
           checked={on}
@@ -161,7 +163,7 @@ function RuleRow({ rule }: { rule: Rule }) {
           }}
         />
         <span className="ca-slider" />
-      </span>
-    </label>
+      </label>
+    </div>
   );
 }

--- a/frontend/src/components/settings/screens/PrReview.tsx
+++ b/frontend/src/components/settings/screens/PrReview.tsx
@@ -141,13 +141,14 @@ export function PrReview({ gotoScreen }: ScreenProps) {
         ingestion is active.
       </p>
 
-      <label
+      <div
         className="set-row set-switch-row"
         id="gh-pr-toggle-row"
         title="Turn automated PR review on or off — your repositories are kept either way"
       >
         <span className="set-label">Automated review</span>
-        <span className="ca-switch">
+        {/* label wraps only the switch, so clicking the row text no longer flips it */}
+        <label className="ca-switch">
           <input
             type="checkbox"
             id="gh-pr-enabled"
@@ -160,8 +161,8 @@ export function PrReview({ gotoScreen }: ScreenProps) {
             }
           />
           <span className="ca-slider" />
-        </span>
-      </label>
+        </label>
+      </div>
       <div
         id="gh-pr-status"
         className={"pr-status" + (n > 0 && enabled ? " on" : n > 0 ? " paused" : "")}

--- a/frontend/src/components/settings/screens/SystemLogs.tsx
+++ b/frontend/src/components/settings/screens/SystemLogs.tsx
@@ -36,14 +36,34 @@ export function SystemLogs({ onOpenSysLogsPane }: ScreenProps) {
     // Only the Electron shell bridge can open the file manager on the machine
     // the USER is at. A server-side open would run wherever the server lives
     // (e.g. WSL while the user is on Windows in a browser) — the wrong machine —
-    // so everywhere else we just copy the path, which is always useful.
+    // so everywhere else we copy the path, which is always useful.
     const show = shellShowItem();
     if (show) {
-      const r = await show(path).catch(() => null);
-      if (r && r.ok !== false) return;
+      try {
+        const r = await show(path);
+        if (r && r.ok !== false) return;
+      } catch {
+        /* fall through to copy */
+      }
     }
-    const ok = await copyText(path);
-    toast(ok ? "Log path copied to clipboard" : path);
+    // Select the visible path too: it's unmistakable feedback that the click
+    // registered, and lets the user Ctrl+C manually if the clipboard API is
+    // blocked in their context (some browsers over plain http).
+    const el = document.getElementById("logs-path");
+    if (el) {
+      const sel = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    }
+    let ok = false;
+    try {
+      ok = await copyText(path);
+    } catch {
+      /* clipboard blocked — the selection above is the fallback */
+    }
+    toast(ok ? "Log path copied — paste it anywhere" : "Path selected — press Ctrl+C to copy");
   }, [path]);
 
   const copyLog = useCallback(async () => {

--- a/frontend/src/components/settings/screens/SystemLogs.tsx
+++ b/frontend/src/components/settings/screens/SystemLogs.tsx
@@ -33,15 +33,24 @@ export function SystemLogs({ onOpenSysLogsPane }: ScreenProps) {
 
   const revealPath = useCallback(async () => {
     if (!path) return;
+    // Only the Electron shell bridge can open the file manager on the machine
+    // the USER is at. A server-side open would run wherever the server lives
+    // (e.g. WSL while the user is on Windows in a browser) — the wrong machine —
+    // so everywhere else we just copy the path, which is always useful.
     const show = shellShowItem();
     if (show) {
       const r = await show(path).catch(() => null);
       if (r && r.ok !== false) return;
-      // Couldn't open it (deleted, sandbox) — fall back to copying the path.
     }
     const ok = await copyText(path);
     toast(ok ? "Log path copied to clipboard" : path);
   }, [path]);
+
+  const copyLog = useCallback(async () => {
+    if (!text) return;
+    const ok = await copyText(text);
+    toast(ok ? "Log copied to clipboard" : "Copy failed");
+  }, [text]);
 
   const load = useCallback(async () => {
     let d: LogsPayload;
@@ -98,6 +107,15 @@ export function SystemLogs({ onOpenSysLogsPane }: ScreenProps) {
         </select>
         <button type="button" id="logs-refresh" className="test-btn" onClick={load}>
           Refresh
+        </button>
+        <button
+          type="button"
+          id="logs-copy"
+          className="test-btn"
+          title="Copy everything shown here (the last 256 KB) to the clipboard"
+          onClick={copyLog}
+        >
+          Copy log
         </button>
         <button
           type="button"

--- a/frontend/src/components/settings/screens/SystemLogs.tsx
+++ b/frontend/src/components/settings/screens/SystemLogs.tsx
@@ -3,7 +3,15 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../../../api/client";
+import { copyText } from "../../../lib/clipboard";
+import { toast } from "../../../lib/toast";
 import type { ScreenProps } from "../SettingsDialog";
+
+/** Reveal-in-file-manager bridge — present only inside the desktop shell. */
+function shellShowItem(): ((p: string) => Promise<{ ok?: boolean }>) | undefined {
+  return (window as unknown as { mfshell?: { showItem?: (p: string) => Promise<{ ok?: boolean }> } })
+    .mfshell?.showItem;
+}
 
 interface LogsPayload {
   sources?: Array<{ name: string; label: string; path?: string }>;
@@ -19,8 +27,21 @@ export function SystemLogs({ onOpenSysLogsPane }: ScreenProps) {
   const [selected, setSelected] = useState("server");
   const [text, setText] = useState("Loading…");
   const [meta, setMeta] = useState("");
+  const [path, setPath] = useState("");
   const [follow, setFollow] = useState(false);
   const viewRef = useRef<HTMLPreElement | null>(null);
+
+  const revealPath = useCallback(async () => {
+    if (!path) return;
+    const show = shellShowItem();
+    if (show) {
+      const r = await show(path).catch(() => null);
+      if (r && r.ok !== false) return;
+      // Couldn't open it (deleted, sandbox) — fall back to copying the path.
+    }
+    const ok = await copyText(path);
+    toast(ok ? "Log path copied to clipboard" : path);
+  }, [path]);
 
   const load = useCallback(async () => {
     let d: LogsPayload;
@@ -37,7 +58,8 @@ export function SystemLogs({ onOpenSysLogsPane }: ScreenProps) {
     if (atBottom && view) requestAnimationFrame(() => (view.scrollTop = view.scrollHeight));
     const src = (d.sources || []).find((s) => s.name === d.selected);
     const kb = Math.round((d.size || 0) / 1024);
-    setMeta((src?.path ? src.path + "  ·  " : "") + kb + " KB" + (d.truncated ? " (showing last 256 KB)" : ""));
+    setPath(src?.path || "");
+    setMeta(kb + " KB" + (d.truncated ? " (showing last 256 KB)" : ""));
   }, [selected]);
 
   useEffect(() => {
@@ -56,8 +78,10 @@ export function SystemLogs({ onOpenSysLogsPane }: ScreenProps) {
     <>
       <h3 className="set-section-title">System logs</h3>
       <p className="set-hint">
-        The server's own log — every request plus errors and background activity, newest last
-        (up to 256 KB). Handy when something misbehaves; copy the tail when reporting an issue.
+        The server's log plus the ingestion pipeline's, newest last (up to 256 KB each). Handy
+        when something misbehaves — <strong>please paste the relevant tail into a GitHub issue
+        when reporting a bug</strong> (Ingestion pipeline is the one to grab for PR-review or
+        ticket problems).
       </p>
       <div className="logs-toolbar">
         <select
@@ -90,6 +114,21 @@ export function SystemLogs({ onOpenSysLogsPane }: ScreenProps) {
         </label>
         <span id="logs-meta" className="muted">{meta}</span>
       </div>
+      {path && (
+        <button
+          type="button"
+          id="logs-path"
+          className="logs-path"
+          title={
+            shellShowItem()
+              ? "Reveal this log file in Finder / your file manager"
+              : "Copy this log file's full path"
+          }
+          onClick={revealPath}
+        >
+          {path}
+        </button>
+      )}
       <pre id="logs-view" className="logs-view" ref={viewRef}>
         {text}
       </pre>

--- a/frontend/src/components/settings/screens/Ticketing.tsx
+++ b/frontend/src/components/settings/screens/Ticketing.tsx
@@ -5,6 +5,7 @@
  * omitted so the server keeps stored values (matched by source id). */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../api/client";
 import { refreshConfig, usePanelQuery } from "../../../state/queries";
 import { toast } from "../../../lib/toast";
@@ -26,6 +27,65 @@ interface CatalogEntry {
 }
 
 type Source = Record<string, string> & { id: string; provider: string };
+
+/** Master ticket-ingestion switch — the settings-screen twin of the sidebar's
+ * AutomationBar. Same server contract (GET /api/mindflock/status for the
+ * desired state, POST /api/mindflock/{start,stop} to flip it) and the same
+ * ["mindflock-status"] query key, so the two switches stay in lock-step.
+ * Clicking the row text does nothing — only the switch itself flips it. */
+function IngestionToggle() {
+  const [busy, setBusy] = useState(false);
+  const [optimistic, setOptimistic] = useState<boolean | null>(null);
+  const { data: status, refetch } = useQuery({
+    queryKey: ["mindflock-status"],
+    queryFn: () =>
+      api<{ available: boolean; running: boolean; desired?: boolean }>("/api/mindflock/status"),
+    refetchInterval: 10_000,
+    retry: false,
+  });
+
+  // No engine installed / reachable — nothing to toggle (matches the sidebar).
+  if (!status || !status.available) return null;
+  const running = !!status.running;
+  const desired = optimistic ?? (status.desired ?? running);
+
+  const toggle = async (start: boolean) => {
+    if (busy) return;
+    setBusy(true);
+    setOptimistic(start);
+    try {
+      await api(`/api/mindflock/${start ? "start" : "stop"}`, { method: "POST" });
+      toast(start ? "Ticket ingestion on" : "Ticket ingestion paused");
+    } catch (err) {
+      toast(`Ticket ingestion ${start ? "start" : "stop"} failed: ` + ((err as Error).message || ""));
+    } finally {
+      setBusy(false);
+      setOptimistic(null);
+      refetch();
+    }
+  };
+
+  return (
+    <div
+      className="set-row set-switch-row"
+      id="tk-ingestion-toggle-row"
+      title="Run or stop ticket ingestion — polls your connected sources and auto-creates a coding session for each assigned ticket. Stays in this state across restarts."
+    >
+      <span className="set-label">Automated ingestion</span>
+      {/* label wraps only the switch, so clicking the row text no longer flips it */}
+      <label className="ca-switch">
+        <input
+          type="checkbox"
+          id="tk-ingestion-enabled"
+          checked={desired}
+          disabled={busy}
+          onChange={(e) => toggle(e.target.checked)}
+        />
+        <span className="ca-slider" />
+      </label>
+    </div>
+  );
+}
 
 export function Ticketing(_: ScreenProps) {
   const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
@@ -125,6 +185,7 @@ export function Ticketing(_: ScreenProps) {
         two Jira sites) — each with its own credentials. Stored in ~/.mindflock/settings.json
         (never committed).
       </p>
+      <IngestionToggle />
       <div id="ticketing-sources">
         {sources.map((src) => (
           <SourceCard

--- a/frontend/src/components/settings/screens/mobileLogs.css
+++ b/frontend/src/components/settings/screens/mobileLogs.css
@@ -65,6 +65,25 @@
   word-break: break-all;
 }
 
+/* Full log-file path — click to reveal in Finder (desktop) or copy (browser). */
+.logs-path {
+  display: block;
+  width: 100%;
+  margin: 0 0 8px;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: left;
+  color: var(--accent);
+  font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  word-break: break-all;
+  cursor: pointer;
+}
+
+.logs-path:hover {
+  text-decoration: underline;
+}
+
 .logs-view {
   background: var(--bg);
   border: 1px solid var(--border);

--- a/frontend/src/components/settings/screens/screens.css
+++ b/frontend/src/components/settings/screens/screens.css
@@ -107,14 +107,18 @@
   filter: brightness(1.08);
 }
 
-/* Narrow numeric input (e.g. refresh interval) — replaces an inline width. */
+/* Narrow numeric/time input (e.g. refresh interval, fresh-window time) —
+   replaces an inline width. accent-color tints the number spinner + the
+   time-picker clock glyph to match the rest of MindFlock. */
 .num-sm {
   width: 6em;
+  accent-color: var(--accent);
 }
 
 .set-row input[type="text"],
 .set-row input[type="password"],
-.set-row input[type="number"] {
+.set-row input[type="number"],
+.set-row input[type="time"] {
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--text);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -8,6 +8,10 @@
  * :root and .light have EQUAL specificity (0,1,0), so .light must stay after
  * :root for the light palette to win. */
 :root {
+  /* Tell the browser to render native control internals (time-picker clock
+     icon, number spinners, checkboxes, scrollbars) dark; .light flips it.
+     Without this the native clock glyph sat near-invisible on the dark bg. */
+  color-scheme: dark;
   --bg: #0f1117;
   --panel: #171a23;
   --panel-2: #1e222e;
@@ -64,6 +68,7 @@
    handful of hard-coded colors that don't survive the swap are patched in
    theme-light.css. The xterm terminal intentionally stays dark. */
 .light {
+  color-scheme: light;
   --bg: #f4f5f8;
   --panel: #ffffff;
   --panel-2: #eceef3;

--- a/scripts/make-mac-selfsigned-cert.sh
+++ b/scripts/make-mac-selfsigned-cert.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Mint a self-signed code-signing certificate for the macOS desktop build.
+#
+# WHY THIS EXISTS
+# ---------------
+# A $99/yr Apple Developer ID is the only thing that satisfies Gatekeeper (the
+# "Apple could not verify MindFlock is free of malware" prompt). We don't have
+# one, and this script does NOT change that — users still clear that prompt
+# once by hand (README explains how).
+#
+# What a self-signed cert DOES fix, for free: the app gets a STABLE code
+# identity. macOS TCC keys folder-access grants ("MindFlock would like to
+# access files in your Documents folder") to that identity. An unsigned app has
+# no stable identity, so the grant never sticks and the prompt returns on every
+# launch. Sign every build with the SAME cert and the grant is remembered.
+#
+# USAGE
+# -----
+#   scripts/make-mac-selfsigned-cert.sh [password]
+#
+# Produces (in the current directory):
+#   mindflock-selfsigned.p12          the cert + private key, for electron-builder
+#   mindflock-selfsigned.p12.base64   the same, base64'd for a GitHub secret
+#
+# Then store these as repository secrets so CI signs release builds with it:
+#   MAC_CSC_LINK          = contents of mindflock-selfsigned.p12.base64
+#   MAC_CSC_KEY_PASSWORD  = the password printed below
+# release.yml passes them to electron-builder as CSC_LINK / CSC_KEY_PASSWORD.
+#
+# KEEP THE SAME CERT. Regenerating it changes the code identity, which resets
+# every user's remembered folder grant (they get re-prompted once). The .p12 is
+# a signing key — do not commit it; the base64 lives only in the CI secret.
+#
+# Runs anywhere with openssl (no macOS required) — only the eventual build must
+# run on macOS.
+set -euo pipefail
+
+# Hex, not base64: the password travels through a GitHub secret and macOS
+# `security import`; a plain [0-9a-f] string can't pick up a stray +/=/newline
+# that would later read back as the wrong password.
+PASS="${1:-$(openssl rand -hex 24)}"
+OUT_P12="mindflock-selfsigned.p12"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Self-signed cert with the code-signing EKU so `codesign` / `security
+# find-identity -p codesigning` will accept it as a signing identity.
+openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+  -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
+  -subj "/CN=MindFlock Self-Signed/O=MindFlock/C=US" \
+  -addext "keyUsage=critical,digitalSignature" \
+  -addext "extendedKeyUsage=critical,codeSigning"
+
+# Bundle into a PKCS#12 that electron-builder can import. The friendly name is
+# the identity string electron-builder/codesign will match on.
+#
+# -legacy + -macalg sha1 are REQUIRED: OpenSSL 3.x defaults to a SHA-256 MAC
+# and AES-256 encryption that macOS's `security import` cannot read — it fails
+# with "MAC verification failed during PKCS12 import (wrong password?)", which
+# looks like a password bug but is really an algorithm mismatch. Legacy PBE
+# (3DES) + a SHA-1 MAC is what the macOS keychain importer expects.
+openssl pkcs12 -export -legacy -macalg sha1 \
+  -inkey "$TMP/key.pem" -in "$TMP/cert.pem" \
+  -name "MindFlock Self-Signed" \
+  -out "$OUT_P12" -passout pass:"$PASS"
+
+base64 < "$OUT_P12" > "$OUT_P12.base64"
+
+echo
+echo "Wrote $OUT_P12 and $OUT_P12.base64"
+echo
+echo "Set these repository secrets (Settings -> Secrets and variables -> Actions):"
+echo "  MAC_CSC_LINK          = contents of $OUT_P12.base64"
+echo "  MAC_CSC_KEY_PASSWORD  = $PASS"
+echo
+echo "Do NOT commit $OUT_P12 (it holds a private key). It is a signing key."

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -188,11 +188,20 @@ def test_ingestion_logs_surface_from_repo_root_not_cwd(tmp_path, monkeypatch):
     logs = tmp_path / "logs"
     logs.mkdir()
     (logs / "ticket-ingestion.log").write_text("hello ingestion\n")
-    (logs / "pipeline.log").write_text("structured line\n")
     monkeypatch.setenv("MINDFLOCK_REPO_ROOT", str(tmp_path))
 
-    names = {s["name"] for s in system_logs._log_sources()}
-    assert {"server", "ingestion", "pipeline"} <= names
+    srcs = {s["name"]: s["path"] for s in system_logs._log_sources()}
+    assert {"server", "ingestion"} <= set(srcs)
+    # One ingestion source — the raw capture the sidebar tails, not a confusing
+    # second "structured" duplicate of the same lines.
+    assert srcs["ingestion"].endswith("ticket-ingestion.log")
+    assert "pipeline" not in srcs
+
+
+def test_system_logs_has_copy_button():
+    """A Copy-log button copies the shown tail to the clipboard."""
+    js = client.get("/app.js").text
+    assert '"logs-copy"' in js
 
 
 def test_activity_log_records_requests_and_redacts_token(monkeypatch):

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -99,6 +99,17 @@ def test_system_logs_screen_present_and_wired():
     assert "Open as pane" in js  # wired into nav switch
 
 
+def test_system_logs_path_is_clickable_to_reveal_or_copy():
+    """The selected log's full path renders as a clickable control — reveal in
+    Finder inside the desktop shell (window.mfshell.showItem), copy otherwise —
+    so users can jump to or grab the file when filing a bug."""
+    js = client.get("/app.js").text
+    assert '"logs-path"' in js
+    assert "showItem" in js  # the desktop reveal bridge
+    css = client.get("/style.css").text
+    assert ".logs-path" in css
+
+
 def test_settings_nav_scrolls_so_all_items_reachable():
     """The settings nav column must scroll independently, else the bottom items
     (System logs, Advanced) get clipped on a short window."""

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -44,6 +44,16 @@ def test_switch_flips_only_on_the_switch_not_the_whole_row():
     ), "a set-switch-row is a <label> — clicking the row text flips the toggle"
 
 
+def test_forced_start_failure_is_surfaced_in_notifications():
+    """A forced PR review / ticket start that dies during background provisioning
+    (clone, comment fetch) only emits session.create_failed. The bell must map it
+    to a visible notification — without a case it was dropped, so the user saw an
+    optimistic 'starting…' toast and then nothing (the coworker's silent review)."""
+    js = client.get("/app.js").text
+    assert "session.create_failed" in js
+    assert "couldn't start" in js
+
+
 def test_settings_has_new_screens():
     html = client.get("/").text
     js = client.get("/app.js").text

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -166,6 +166,24 @@ def test_api_logs_returns_server_tail():
     assert client.get("/api/logs?name=bogus").json()["selected"] == "server"
 
 
+def test_ingestion_logs_surface_from_repo_root_not_cwd(tmp_path, monkeypatch):
+    """The pipeline runs as a subprocess from the repo root, so its logs live at
+    ``<repo root>/logs/`` — not the server's cwd. ``_log_sources`` must resolve
+    them via that root (the same anchor the ingestion addon launches from), or
+    the ingestion log goes missing and only 'server' shows in System logs."""
+    from backend.web.core import system_logs
+
+    (tmp_path / "config.toml").write_text("")
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "ticket-ingestion.log").write_text("hello ingestion\n")
+    (logs / "pipeline.log").write_text("structured line\n")
+    monkeypatch.setenv("MINDFLOCK_REPO_ROOT", str(tmp_path))
+
+    names = {s["name"] for s in system_logs._log_sources()}
+    assert {"server", "ingestion", "pipeline"} <= names
+
+
 def test_activity_log_records_requests_and_redacts_token(monkeypatch):
     """The HTTP activity-log middleware logs every request as
     ``METHOD path -> status ms client`` with the access token redacted."""

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -22,17 +22,26 @@ def test_every_settings_screen_leads_with_a_heading():
     assert js.count("set-section-title") >= 15, "screens are missing headings"
 
 
-def test_all_switch_rows_are_labels_not_divs():
-    """Cohesion + correctness: a .ca-switch only toggles on click when wrapped in
-    a <label>, so no switch row may be a <div>."""
-    html = client.get("/").text
+def test_switch_flips_only_on_the_switch_not_the_whole_row():
+    """Correctness: clicking a switch row's label text must NOT flip the toggle —
+    only the switch itself. So the row is a <div> and the .ca-switch is its own
+    <label> (which still gives the slider its click-to-toggle). The inverse of
+    the original layout, where the whole row was one <label>."""
     js = client.get("/app.js").text
     assert "set-switch-row" in js
-    # Every switch row renders as a <label> (a .ca-switch only toggles on
-    # click when an ancestor label wraps it) — no jsx("div", ...) may carry it.
+    # The switch keeps its click target: every .ca-switch renders as a <label>…
+    assert re.search(
+        r'jsxs?\("label",\s*\{\s*className:\s*"ca-switch"', js
+    ), "the .ca-switch is no longer a <label> — the slider won't toggle on click"
+    # …and none renders as a bare span/div (which wouldn't toggle at all).
     assert not re.search(
-        r'jsxs?\("div",\s*\{[^}]*set-switch-row', js
-    ), "a set-switch-row is a <div> — its toggle won't flip on click"
+        r'jsxs?\("(?:span|div)",\s*\{\s*className:\s*"ca-switch"', js
+    ), "a .ca-switch is a span/div — the slider won't toggle on click"
+    # No switch row is a <label> any more: a row-wide label flips the toggle
+    # from anywhere on the row, which is exactly the behaviour being removed.
+    assert not re.search(
+        r'jsxs?\("label",\s*\{[^}]*set-switch-row', js
+    ), "a set-switch-row is a <label> — clicking the row text flips the toggle"
 
 
 def test_settings_has_new_screens():


### PR DESCRIPTION
Two independent pieces of work from one session.

## 1. macOS self-signed code signing (`dc50497`)
Unsigned macOS builds have no stable code identity, so macOS **TCC** never remembers a folder-access grant and re-prompts on every launch. This signs the `.app` with a **free self-signed certificate** (not an Apple Developer ID), which gives it a stable identity so TCC remembers the grant.

- `scripts/make-mac-selfsigned-cert.sh` — mints the cert as a `.p12` (legacy PBE/SHA-1 MAC so macOS `security import` accepts it).
- CI (`release.yml`) imports it into a throwaway keychain, **trusts it for code signing** (so electron-builder's `find-identity -v` accepts it), and signs; falls back to unsigned when the `MAC_CSC_*` secrets are absent (forks).
- `electron/build/entitlements.mac.plist`, `mac.hardenedRuntime=false`, `gatekeeperAssess=false`.
- Docs: step-by-step "Open Anyway" instructions for users.

**Does NOT satisfy Gatekeeper** — users still clear the "unverified developer" prompt once (documented). Notarization (a paid Developer ID) remains a TODO. Proven end-to-end via a `workflow_dispatch` dry run: all three OS builds pass and the macOS `.app` is signed with `MindFlock Self-Signed`.

## 2. Settings UI (`d3a4089`, `b57d02b`)
- **Switch-only toggles:** every `set-switch-row` was a `<label>`, so clicking anywhere on the row flipped the switch. The row is now a `<div>` and only the `.ca-switch` is a `<label>`, so it flips on the control alone. Applied to all toggles (PR review, Git issues, General ×2, IDE, Coding CLI, Mobile, Notifications ×2).
- **Ticketing master switch:** the Ticketing screen gains an "Automated ingestion" switch mirroring the sidebar AutomationBar (same `/api/mindflock` status+start/stop contract and `["mindflock-status"]` query key, so the two stay in sync).
- **Themed native controls:** `color-scheme` per theme so the fresh-window time picker's clock glyph and number spinners render for dark/light; provider checkboxes and narrow inputs tinted with the MindFlock accent instead of browser-default blue.
- Updated `test_frontend_settings_revamp` to assert the new switch-row invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)