### PR TITLE
Sidebar: inline rename, readable ticket names, instant provisioning rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ MindFlock is a ground-up parallel-agent workspace. A few things set it apart:
   tracking apply to all of them.
 - 🖥️ **Desktop app** (Electron) — a draggable terminal grid with Agent /
   Terminal / Diff / Queue tabs per session, workflow-stage badges, and guided
-  next-step buttons.
+  next-step buttons, in a window that follows each OS's own chrome conventions
+  (native traffic lights on macOS, frameless with our own – □ ✕ elsewhere).
 - 📱 **Phone UI** — `mindflock serve tailscale` prints a QR code; the mobile
   UI at `/m` carries the same guided git action bar, so the full flow drives
   from a phone. Auth-token protected — never open to the LAN unauthenticated.

--- a/backend/config/config.py
+++ b/backend/config/config.py
@@ -268,9 +268,13 @@ def GetClaudeCommand() -> str:
 def DefaultConfig() -> Config:
     """Return the default configuration.
 
-    ``default_program`` is the result of :func:`GetClaudeCommand`, or the
-    literal ``"claude"`` on failure. ``branch_prefix`` is ``"{lower(user)}/"``,
-    or ``"session/"`` if the current user cannot be determined.
+    ``default_program`` is :func:`GetClaudeCommand`'s find folded back to the
+    provider name (it reports an absolute path — ``which`` output — and storing
+    that verbatim put a bare ``/opt/homebrew/bin/claude`` in the New Session
+    dialog's agent list on a first run), or the literal ``"claude"`` on failure.
+    A path no provider recognises is still stored as-is: for a custom agent the
+    exact string IS the launch command. ``branch_prefix`` is
+    ``"{lower(user)}/"``, or ``"session/"`` if the user cannot be determined.
     """
     try:
         program = GetClaudeCommand()
@@ -278,6 +282,12 @@ def DefaultConfig() -> Config:
         if log.ErrorLog is not None:
             log.ErrorLog.Printf("failed to get claude command: %v", err)
         program = DEFAULT_PROGRAM
+    try:
+        from backend import providers
+
+        program = providers.normalize_program(program) or program
+    except Exception:  # noqa: BLE001 — config must load without the registry
+        pass
 
     return Config(
         default_program=program,

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "TrustSpec",
     "register",
     "resolve",
+    "normalize_program",
     "get",
     "all_providers",
     "rebuild_registry",
@@ -113,6 +114,44 @@ def resolve(program_or_kind: Optional[str]) -> CodingProvider:
     if len(_RESOLVE_CACHE) < 256:  # program strings are user input — stay bounded
         _RESOLVE_CACHE[key] = result
     return result
+
+
+def normalize_program(program: Optional[str]) -> str:
+    """Canonical form of a program string: a provider NAME where one applies.
+
+    ``"/opt/homebrew/bin/claude"`` -> ``"claude"``. A resolved absolute path is
+    how :func:`backend.config.config.GetClaudeCommand` reports the CLI it found
+    (it shells out to ``which``), and storing that verbatim leaks an install
+    detail into every place a program is shown or matched — most visibly the New
+    Session dialog, which lists any program it doesn't recognise as an extra
+    dropdown entry, so a Homebrew Mac grew a mystery "/opt/homebrew/bin/claude"
+    item above the real agents.
+
+    Only a bare basename that a named provider claims is folded to that
+    provider's name. Anything else — a custom script, a program with arguments,
+    a path no provider recognises — is returned unchanged (stripped), because
+    for those the exact string IS the launch command.
+    """
+    key = (program or "").strip()
+    if not key or key in _REGISTRY:
+        return key
+    import os
+
+    # Arguments mean the string is a command line, not a binary to identify.
+    if len(key.split()) > 1:
+        return key
+    base = os.path.basename(key)
+    if base == key:  # already a bare name
+        return key
+    for name in _ORDER:
+        if name == "generic":
+            continue  # the catch-all claims everything; it identifies nothing
+        try:
+            if _REGISTRY[name].matches(base):
+                return name
+        except Exception:  # noqa: BLE001 — a matcher must never break this
+            continue
+    return key
 
 
 # --- built-in providers ----------------------------------------------------- #

--- a/backend/providers/claude_usage_api.py
+++ b/backend/providers/claude_usage_api.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
+import sys
 import threading
 import time
 import urllib.request
@@ -50,16 +52,67 @@ def _creds_diag(reason: str) -> None:
         _logger.debug("claude live usage unavailable: %s", reason)
 
 
+#: Keychain service name Claude Code stores its credentials under on macOS.
+_KEYCHAIN_SERVICE = "Claude Code-credentials"
+_KEYCHAIN_TIMEOUT = 5  # seconds; a denied/prompting lookup must not wedge /api/usage
+
+
+def _keychain_doc() -> Optional[dict]:
+    """The credentials document from the macOS login Keychain, or None.
+
+    On macOS Claude Code keeps its OAuth credentials in the Keychain rather than
+    in ``~/.claude/.credentials.json``, so the file read below finds nothing and
+    live plan usage was permanently dark on every Mac — the UI fell back to the
+    transcript estimate, which yields a reset countdown but no percentage unless
+    a window budget is configured. The stored blob is the same JSON as the file.
+
+    ``security`` may raise a one-time "MindFlock wants to use your Keychain"
+    prompt, since the item was created by a different binary; a denial (or a
+    headless session, where no prompt can be answered) just returns None and
+    behaviour is exactly as before. Timeout-bounded so an unanswered prompt
+    can't hold the usage request open.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        proc = subprocess.run(
+            ["security", "find-generic-password", "-s", _KEYCHAIN_SERVICE, "-w"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=_KEYCHAIN_TIMEOUT,
+        )
+    except Exception as e:  # noqa: BLE001 — no `security`, timeout, denial
+        _creds_diag("keychain lookup failed (%s)" % type(e).__name__)
+        return None
+    if proc.returncode != 0 or not proc.stdout:
+        _creds_diag("keychain has no %s item" % _KEYCHAIN_SERVICE)
+        return None
+    try:
+        doc = json.loads(proc.stdout.decode("utf-8", "replace"))
+    except ValueError:
+        _creds_diag("keychain item is not JSON")
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
 def _token() -> Optional[str]:
-    """The Claude Code OAuth access token, or None. Never logged."""
+    """The Claude Code OAuth access token, or None. Never logged.
+
+    Read from ``.credentials.json`` (Linux/WSL, and any install that keeps a
+    file) with the macOS Keychain as the fallback — see :func:`_keychain_doc`.
+    """
     root = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(
         os.path.expanduser("~"), ".claude"
     )
+    doc: Optional[dict] = None
     try:
         with open(os.path.join(root, ".credentials.json")) as f:
             doc = json.load(f)
-    except Exception as e:  # noqa: BLE001 — missing/corrupt creds: no live data
+    except Exception as e:  # noqa: BLE001 — missing/corrupt creds: try the keychain
         _creds_diag("cannot read .credentials.json (%s)" % type(e).__name__)
+    if not isinstance(doc, dict):
+        doc = _keychain_doc()
+    if not isinstance(doc, dict):
         return None
     tok = (doc.get("claudeAiOauth") or {}).get("accessToken") or None
     if not tok:

--- a/backend/web/addons/ticket_ingestion.py
+++ b/backend/web/addons/ticket_ingestion.py
@@ -26,6 +26,7 @@ from fastapi.responses import JSONResponse
 from backend import log
 from backend.session import provisioned as provisioning
 
+from backend.web.core import pending as _pending
 from backend.web.core.terminal import pump_pty, spawn_tail
 
 from .base import Addon, AppContext, FrontendDescriptor
@@ -399,6 +400,12 @@ class TicketIngestionController:
         act = self._activity() if running else {}
         if act and pid and act.get("pid") not in (None, pid):
             act = {}
+        # Work this server is bringing in itself (forced starts + sessions still
+        # provisioning) — independent of whether the pipeline runs at all.
+        try:
+            local = _pending.provisioning_kinds()
+        except Exception:  # noqa: BLE001 — status must never fail on this
+            local = set()
         return {
             "running": running,
             "pid": pid,
@@ -422,11 +429,14 @@ class TicketIngestionController:
             "pr_enabled": _pr_review_enabled(),
             # Whether issue handling is switched on (github.issues_enabled+repos).
             "issues_enabled": _issue_handling_enabled(),
-            # Live activity from the pipeline's beacon: True while a ticket /
-            # a PR batch / an issue is actually being handled (vs idle-waiting).
-            "tickets_active": bool(act.get("ticket_busy")),
-            "pr_active": bool(act.get("pr_busy")),
-            "issues_active": bool(act.get("issue_busy")),
+            # Live activity: True while a ticket / a PR batch / an issue is
+            # actually being brought in (vs idle-waiting). The pipeline's beacon
+            # only knows about the PIPELINE's queue, so a start forced from the
+            # UI (Settings → Ticketing / PR review / Git issues) used to leave
+            # the dot gold through its whole provisioning; `local` covers those.
+            "tickets_active": bool(act.get("ticket_busy")) or "tix" in local,
+            "pr_active": bool(act.get("pr_busy")) or "pr" in local,
+            "issues_active": bool(act.get("issue_busy")) or "iss" in local,
         }
 
 

--- a/backend/web/core/issue_start.py
+++ b/backend/web/core/issue_start.py
@@ -152,6 +152,19 @@ async def find_issue(repo: str, number: int):
     )
 
 
+def branch_for(issue) -> str:
+    """The branch a forced start will create for ``issue``.
+
+    Pure and network-free (it only needs the issue's number/title), unlike
+    :func:`prepare_start` — so the request path can hand it to the sidebar's
+    provisioning row before the comments fetch has happened.
+    """
+    from backend.ticket_ingestion.issue_monitor import issue_to_ticket
+    from backend.ticket_ingestion.provisioner import _branch_name_for
+
+    return _branch_name_for(issue_to_ticket(issue, []))
+
+
 async def prepare_start(issue) -> tuple:
     """Fetch the issue's comments and build its ticket + session prompt.
 

--- a/backend/web/core/pending.py
+++ b/backend/web/core/pending.py
@@ -1,0 +1,201 @@
+"""Force-starts that have been accepted but are not sessions yet.
+
+A forced PR review / issue / ticket answers 202 and then does the slow work
+(clone the head, run setup, launch the agent) before it can register an
+instance — tens of seconds during which the sidebar showed nothing at all and
+the start looked like it had failed. Every accepted start is recorded here the
+moment the request comes in, and :func:`rows` renders each as a provisioning
+row the UI already knows how to draw (status ``loading`` + stage
+``provisioning``, exactly like a session whose ``Start`` is still running).
+The entry is dropped as soon as the real instance exists, so the row is
+replaced rather than duplicated.
+
+Three consumers, which is why this is its own module rather than more of
+``server.py``:
+
+* ``GET /api/instances`` — appends :func:`rows` to the sessions snapshot.
+* The three force-start endpoints — the registry doubles as their
+  double-click guard, and the panels' ``has_session`` annotation reads it.
+* The ingestion addon's status — :func:`provisioning_kinds` is what turns the
+  sidebar bars' dots green while work is being brought in by THIS server
+  (the pipeline's own beacon only knows about the pipeline's own queue).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Optional, Set
+
+from backend import providers
+from backend.session.storage import Loading
+from backend.web.core.engine import get_engine
+
+# title -> {"kind": "pr"|"iss"|"tix", "since": epoch, **display meta}
+_PENDING: Dict[str, dict] = {}
+_LOCK = threading.Lock()
+
+
+def add(title: str, kind: str, **meta) -> None:
+    """Record (or enrich) an accepted force-start.
+
+    Called twice per start: once from the request path with only what the
+    payload knows, then again once the upstream lookup has filled in the
+    branch. ``since`` survives the second call so it stays the moment the user
+    actually asked for the work.
+    """
+    if not title:
+        return
+    with _LOCK:
+        prev = _PENDING.get(title) or {}
+        _PENDING[title] = {
+            "kind": kind,
+            "since": prev.get("since") or time.time(),
+            **{k: v for k, v in prev.items() if k not in ("kind", "since")},
+            **meta,
+        }
+
+
+def drop(title: str) -> None:
+    """Forget a start (it registered its session, or it failed). Tolerates ""
+    so callers can drop an unregistered provisional title unconditionally."""
+    if not title:
+        return
+    with _LOCK:
+        _PENDING.pop(title, None)
+
+
+def has(title: str) -> bool:
+    """Whether a start for ``title`` is in flight — the double-click guard."""
+    return bool(title) and title in _PENDING
+
+
+def snapshot() -> Dict[str, dict]:
+    with _LOCK:
+        return {t: dict(m) for t, m in _PENDING.items()}
+
+
+def session_kind(title: str, branch: str) -> str:
+    """``"pr"`` | ``"iss"`` | ``"tix"`` | ``""`` for a session title+branch.
+
+    The pipeline titles PR sessions ``pr-<slug>`` and issue sessions
+    ``issue-<slug>``; a ticket session is titled by its bare provider slug and
+    is recognised by the branch it owns. Mirrors the sidebar's own label logic
+    (``frontend/src/lib/sessionLabel.ts``) — keep the two in step.
+    """
+    if not title:
+        return ""
+    if title.startswith("pr-"):
+        return "pr"
+    if title.startswith("issue-"):
+        return "iss"
+    if branch.startswith(f"feature/{title}/"):
+        return "tix"
+    return ""
+
+
+def _is_provisioning(inst) -> bool:
+    """A session that exists but is still being provisioned (same test the
+    sidebar snapshot uses to report stage ``provisioning``)."""
+    try:
+        return not inst.Started() and inst.Status == Loading
+    except Exception:  # noqa: BLE001 — a half-built instance is not our problem
+        return False
+
+
+def provisioning_kinds(engine=None) -> Set[str]:
+    """Kinds of work being brought in by THIS server right now.
+
+    A kind is included while a force-start of it has no session yet, or while
+    the session it created is still provisioning. This is what makes the
+    sidebar bars' dots green for work started from the UI: the pipeline's
+    activity beacon only reports the pipeline's own queue, so without this a
+    forced ticket provisioned for two minutes with the light showing idle.
+    """
+    kinds = {(m.get("kind") or "") for m in snapshot().values()}
+    engine = engine if engine is not None else get_engine()
+    for inst in list(engine.instances.values()):
+        if not _is_provisioning(inst):
+            continue
+        kinds.add(session_kind(inst.Title or "", getattr(inst, "Branch", "") or ""))
+    return {k for k in kinds if k}
+
+
+def rows(engine=None) -> list:
+    """Sidebar entries for accepted starts with no instance yet.
+
+    Same key set as ``_instance_json`` plus ``pending``, which tells the UI the
+    row has no tmux session behind it yet (so it offers no actions on it).
+    """
+    engine = engine if engine is not None else get_engine()
+    program = engine.default_program()
+    provider = providers.resolve(program).name
+    out = []
+    for title, meta in snapshot().items():
+        # The instance exists now: the real snapshot entry is the truth.
+        if title in engine.instances:
+            continue
+        out.append(
+            {
+                "title": title,
+                "branch": meta.get("branch", ""),
+                "repo": meta.get("repo", ""),
+                "folder": "",
+                "folder_label": "",
+                "program": program,
+                "provider": provider,
+                "path": "",
+                "status": "loading",
+                "started": False,
+                "tmux_name": "",
+                "provisioned": True,
+                "workspace_strategy": meta.get("workspace_strategy", "clone"),
+                "in_place": False,
+                "diff_stat": None,
+                "workspace_missing": False,
+                "has_origin": False,
+                "stage": "provisioning",
+                "pr_url": None,
+                "failed_step": None,
+                "queue": None,
+                "tokens": 0,
+                "tokens_in": 0,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+                "tokens_ctx": 0,
+                "tokens_ctx_window": 0,
+                "tokens_cost": 0.0,
+                "tokens_model": "",
+                "budget": None,
+                "activity": "offline",
+                "activity_since": 0.0,
+                "last_turn": None,
+                "setup": None,
+                "check": None,
+                "ports": None,
+                "pending": True,
+            }
+        )
+    return out
+
+
+def cached_session_title(cache: dict, list_key: str, match) -> str:
+    """The session title a settings panel's cached list already computed for an
+    item, or ``""`` when nothing usable is cached.
+
+    The panels annotate every entry with ``session`` — the exact output of the
+    module-level ``session_title()`` the force-start will use — so a row
+    registered from it can't disagree with the session that turns up. Reading
+    it here is what lets the provisioning row go up BEFORE the upstream lookup
+    (a GitHub/provider round trip) that the title would otherwise wait on.
+    Slug derivation is deliberately NOT reimplemented: providers set their own
+    (Shortcut hardcodes ``sc-<id>``), so a second implementation would drift.
+    """
+    entry: Optional[tuple] = cache.get("v")
+    data = entry[1] if entry else None
+    if not isinstance(data, dict):
+        return ""
+    for item in data.get(list_key) or []:
+        if isinstance(item, dict) and match(item):
+            return str(item.get("session") or "")
+    return ""

--- a/backend/web/core/usage_api.py
+++ b/backend/web/core/usage_api.py
@@ -37,6 +37,17 @@ def _provider_label(name: str) -> str:
     return _PROVIDER_LABELS.get(name) or (name[:1].upper() + name[1:] if name else "")
 
 
+def _estimate_percent(win: Optional[dict]) -> Optional[float]:
+    """Percent of the configured window budget the transcript estimate has
+    spent, or None when there is no window or no budget to measure against."""
+    if not win or win.get("cost") is None:
+        return None
+    budget = _server()._window_budget_usd()
+    if budget <= 0:
+        return None
+    return min(100.0, round(100.0 * win["cost"] / budget, 1))
+
+
 def _usage_window_for(p) -> Optional[dict]:
     """The active usage window for provider ``p`` (or None) — the same
     computation the default provider has always used, factored out so it can run
@@ -79,6 +90,17 @@ def _usage_window_for(p) -> Optional[dict]:
             if live.get("end"):
                 win["end"] = live["end"]
             win["percent_used"] = live.get("percent_used")
+            # A live reading can carry a reset time but no utilization (an
+            # endpoint shape without it, or a window the provider reports only a
+            # deadline for). Taking it verbatim then blanked a percentage the
+            # transcript estimate could still supply — the UI showed a reset
+            # countdown with no "% used" row at all. Fall back to the estimate
+            # and say so, rather than showing nothing.
+            if win["percent_used"] is None and not live.get("groups"):
+                estimate_pct = _estimate_percent(win)
+                if estimate_pct is not None:
+                    win["percent_used"] = estimate_pct
+                    win["source"] = "estimate"
             win.setdefault("budget", 0.0)
             if live.get("weekly"):
                 win["weekly"] = live["weekly"]
@@ -91,13 +113,8 @@ def _usage_window_for(p) -> Optional[dict]:
             return win
         if win:
             win["source"] = "estimate"
-            budget = _server()._window_budget_usd()
-            win["budget"] = budget
-            win["percent_used"] = (
-                min(100.0, round(100.0 * win["cost"] / budget, 1))
-                if budget > 0
-                else None
-            )
+            win["budget"] = _server()._window_budget_usd()
+            win["percent_used"] = _estimate_percent(win)
             return win
         return None
     if kind == "daily":

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -103,6 +103,7 @@ from backend.web.core import issue_start as _issue_start
 from backend.web.core import pr_review as _pr_review
 from backend.web.core import ticket_start as _ticket_start
 from backend.web.core import remote as _remote
+from backend.web.core import pending as _pending
 from backend.web.core import prompt_queue as _prompt_queue
 from backend.web.core import window_refresh as _window_refresh
 from backend.web.core import worktree_setup as _wt_setup
@@ -1476,6 +1477,18 @@ def _session_snapshot_cheap(i, queues: dict, prev: Optional[dict] = None) -> dic
     return d
 
 
+# ---- Force-starts that have not registered a session yet ------------------- #
+# The registry lives in core.pending: the ingestion addon reads it too (its
+# provisioning_kinds() is what greens the sidebar bars for UI-started work), so
+# it can't live in this module without an import cycle. These aliases keep the
+# call sites below (and the tests) reading the same as before.
+_pending_add = _pending.add
+_pending_drop = _pending.drop
+_pending_rows = _pending.rows
+_pending_has = _pending.has
+_cached_session_title = _pending.cached_session_title
+
+
 def _build_instances_snapshot() -> list:
     """The full sessions snapshot — READ-ONLY (the tick's producer path).
 
@@ -1526,14 +1539,14 @@ def list_instances() -> JSONResponse:
     cached = _events.sessions_snapshot()
     if time.time() - _SNAPSHOT_AT <= _INSTANCES_TICK_INTERVAL * 2.5:
         if {d.get("title") for d in cached} == set(ENGINE.instances.keys()):
-            return JSONResponse(cached + _remote.merged_instances())
+            return JSONResponse(cached + _remote.merged_instances() + _pending_rows())
     queues = _prompt_queue.snapshot()
     by_title = {d.get("title"): d for d in cached}
     snap = [
         _session_snapshot_cheap(i, queues, by_title.get(i.Title))
         for i in list(ENGINE.instances.values())
     ]
-    return JSONResponse(snap + _remote.merged_instances())
+    return JSONResponse(snap + _remote.merged_instances() + _pending_rows())
 
 
 # ---- Tailnet multi-device control (backend.web.core.remote) -------------- #
@@ -3736,9 +3749,10 @@ async def instance_merge_pr(title: str) -> JSONResponse:
 # every open PR with the skip reason and force-start a review session for one,
 # bypassing those filters (see backend.web.core.pr_review).
 
-# PRs with a force-review currently provisioning: guards a double-click from
-# provisioning the same workspace twice before the session registers.
-_PR_REVIEWS_STARTING: set = set()
+# PRs/issues/tickets with a force-start currently provisioning live in
+# core.pending, which guards a double-click from provisioning the same
+# workspace twice, renders the sidebar's provisioning row, and greens the
+# sidebar bar's dot while the work is being brought in.
 
 
 _OPEN_PRS_CACHE: dict = {}  # "v" -> (fresh_until_mono, payload); "task" -> refresh
@@ -3838,9 +3852,8 @@ async def github_open_prs(fresh: bool = False) -> JSONResponse:
         return JSONResponse({"error": str(err)}, status_code=502)
     data = {**data, "stale": stale, "prs": [dict(p) for p in data.get("prs", [])]}
     for p in data.get("prs", []):
-        p["has_session"] = (
-            p.get("session") in ENGINE.instances
-            or p.get("session") in _PR_REVIEWS_STARTING
+        p["has_session"] = p.get("session") in ENGINE.instances or _pending_has(
+            p.get("session")
         )
     return JSONResponse(data)
 
@@ -3859,23 +3872,51 @@ async def github_force_review(payload: dict) -> JSONResponse:
     except (TypeError, ValueError):
         return JSONResponse({"error": "number must be an integer"}, status_code=400)
 
+    # The provisioning row goes up BEFORE the GitHub lookup below, which is the
+    # last thing standing between the click and the sidebar showing anything.
+    # The panel's cached list already carries the title this PR maps to, so no
+    # slug re-derivation is involved; a cold cache just falls back to the
+    # post-lookup registration further down.
+    early = _cached_session_title(
+        _OPEN_PRS_CACHE,
+        "prs",
+        lambda p: p.get("repo") == repo and p.get("number") == number,
+    )
+    if early:
+        if early in ENGINE.instances or _pending_has(early):
+            return JSONResponse(
+                {
+                    "error": "session %s already exists — close it to re-review"
+                    % early,
+                    "title": early,
+                },
+                status_code=409,
+            )
+        _pending_add(early, "pr", repo=repo)
+
     try:
         pr = await _pr_review.find_pr(repo, number)
     except LookupError as err:
+        _pending_drop(early)
         return JSONResponse({"error": str(err)}, status_code=404)
     except Exception as err:  # noqa: BLE001
+        _pending_drop(early)
         return JSONResponse({"error": str(err)}, status_code=502)
 
     title = _pr_review.session_title(pr)
-    if title in ENGINE.instances or title in _PR_REVIEWS_STARTING:
-        return JSONResponse(
-            {
-                "error": "session %s already exists — close it to re-review" % title,
-                "title": title,
-            },
-            status_code=409,
-        )
-    _PR_REVIEWS_STARTING.add(title)
+    if title != early:
+        _pending_drop(early)  # stale cache entry — keep only the real title
+        if title in ENGINE.instances or _pending_has(title):
+            return JSONResponse(
+                {
+                    "error": "session %s already exists — close it to re-review"
+                    % title,
+                    "title": title,
+                },
+                status_code=409,
+            )
+    # Re-registered with the branch now that it's known (add() keeps `since`).
+    _pending_add(title, "pr", branch=pr.head_ref, repo=repo)
 
     async def _bg_review() -> None:
         # Provision first (slow: clone/fetch of the PR head), then register the
@@ -3927,7 +3968,7 @@ async def github_force_review(payload: dict) -> JSONResponse:
                 "session.create_failed", session=title, data={"error": str(err)}
             )
         finally:
-            _PR_REVIEWS_STARTING.discard(title)
+            _pending_drop(title)
 
     _register_task(_bg_review())
     return JSONResponse({"started": True, "title": title}, status_code=202)
@@ -3938,11 +3979,6 @@ async def github_force_review(payload: dict) -> JSONResponse:
 # assigned to you on the configured sources with the reason auto ingestion has
 # or hasn't picked it up, and force-start a session for one, bypassing those
 # filters (see backend.web.core.ticket_start).
-
-# Tickets with a force-start currently provisioning: guards a double-click
-# from provisioning the same workspace twice before the session registers.
-_TICKET_STARTS: set = set()
-
 
 _ASSIGNED_TICKETS_CACHE: dict = {}  # "v" -> (fresh_until_mono, payload)
 
@@ -3966,8 +4002,8 @@ async def assigned_tickets(fresh: bool = False) -> JSONResponse:
         "tickets": [dict(t) for t in data.get("tickets", [])],
     }
     for t in data.get("tickets", []):
-        t["has_session"] = (
-            t.get("session") in ENGINE.instances or t.get("session") in _TICKET_STARTS
+        t["has_session"] = t.get("session") in ENGINE.instances or _pending_has(
+            t.get("session")
         )
     return JSONResponse(data)
 
@@ -3983,23 +4019,54 @@ async def ticket_force_start(payload: dict) -> JSONResponse:
     if not source or not ticket_id:
         return JSONResponse({"error": "source and id are required"}, status_code=400)
 
+    # Row first, provider fetch second (see the PR endpoint above). The panel's
+    # cached list is the title's source: ticket slugs are provider-defined
+    # (Shortcut hardcodes sc-<id>), so deriving one here would be a second
+    # implementation waiting to drift.
+    early = _cached_session_title(
+        _ASSIGNED_TICKETS_CACHE,
+        "tickets",
+        lambda t: t.get("source") == source and str(t.get("id")) == ticket_id,
+    )
+    if early:
+        if early in ENGINE.instances or _pending_has(early):
+            return JSONResponse(
+                {
+                    "error": "session %s already exists — close it to re-run" % early,
+                    "title": early,
+                },
+                status_code=409,
+            )
+        _pending_add(early, "tix")
+
     try:
         story = await _ticket_start.find_ticket(source, ticket_id)
     except LookupError as err:
+        _pending_drop(early)
         return JSONResponse({"error": str(err)}, status_code=404)
     except Exception as err:  # noqa: BLE001
+        _pending_drop(early)
         return JSONResponse({"error": str(err)}, status_code=502)
 
     title = _ticket_start.session_title(story)
-    if title in ENGINE.instances or title in _TICKET_STARTS:
-        return JSONResponse(
-            {
-                "error": "session %s already exists — close it to re-run" % title,
-                "title": title,
-            },
-            status_code=409,
-        )
-    _TICKET_STARTS.add(title)
+    if title != early:
+        _pending_drop(early)  # stale cache entry — keep only the real title
+        if title in ENGINE.instances or _pending_has(title):
+            return JSONResponse(
+                {
+                    "error": "session %s already exists — close it to re-run" % title,
+                    "title": title,
+                },
+                status_code=409,
+            )
+    # The branch is known now, so the row can read as the ticket it is rather
+    # than a bare slug (add() keeps the original `since`).
+    _pending_add(
+        title,
+        "tix",
+        branch=_ticket_start.branch_for(story),
+        workspace_strategy=_ticket_start.workspace_mode(),
+    )
 
     async def _bg_start() -> None:
         # Same shape as the pipeline's SessionRunner.run, but against THIS
@@ -4062,7 +4129,7 @@ async def ticket_force_start(payload: dict) -> JSONResponse:
                 "session.create_failed", session=title, data={"error": str(err)}
             )
         finally:
-            _TICKET_STARTS.discard(title)
+            _pending_drop(title)
 
     _register_task(_bg_start())
     return JSONResponse({"started": True, "title": title}, status_code=202)
@@ -4073,11 +4140,6 @@ async def ticket_force_start(payload: dict) -> JSONResponse:
 # on the issue-handling repos with the reason auto handling has or hasn't
 # picked it up, and force-start a session for one, bypassing those filters
 # (see backend.web.core.issue_start).
-
-# Issues with a force-start currently provisioning: guards a double-click from
-# provisioning the same workspace twice before the session registers.
-_ISSUE_STARTS: set = set()
-
 
 _OPEN_ISSUES_CACHE: dict = {}  # "v" -> (fresh_until_mono, payload)
 
@@ -4096,8 +4158,8 @@ async def github_open_issues(fresh: bool = False) -> JSONResponse:
         return JSONResponse({"error": str(err)}, status_code=502)
     data = {**data, "stale": stale, "issues": [dict(i) for i in data.get("issues", [])]}
     for i in data.get("issues", []):
-        i["has_session"] = (
-            i.get("session") in ENGINE.instances or i.get("session") in _ISSUE_STARTS
+        i["has_session"] = i.get("session") in ENGINE.instances or _pending_has(
+            i.get("session")
         )
     return JSONResponse(data)
 
@@ -4116,23 +4178,50 @@ async def github_issue_force_start(payload: dict) -> JSONResponse:
     except (TypeError, ValueError):
         return JSONResponse({"error": "number must be an integer"}, status_code=400)
 
+    # Row first, GitHub lookup second (see the PR endpoint above).
+    early = _cached_session_title(
+        _OPEN_ISSUES_CACHE,
+        "issues",
+        lambda i: i.get("repo") == repo and i.get("number") == number,
+    )
+    if early:
+        if early in ENGINE.instances or _pending_has(early):
+            return JSONResponse(
+                {
+                    "error": "session %s already exists — close it to re-run" % early,
+                    "title": early,
+                },
+                status_code=409,
+            )
+        _pending_add(early, "iss", repo=repo)
+
     try:
         issue = await _issue_start.find_issue(repo, number)
     except LookupError as err:
+        _pending_drop(early)
         return JSONResponse({"error": str(err)}, status_code=404)
     except Exception as err:  # noqa: BLE001
+        _pending_drop(early)
         return JSONResponse({"error": str(err)}, status_code=502)
 
     title = _issue_start.session_title(issue)
-    if title in ENGINE.instances or title in _ISSUE_STARTS:
-        return JSONResponse(
-            {
-                "error": "session %s already exists — close it to re-run" % title,
-                "title": title,
-            },
-            status_code=409,
-        )
-    _ISSUE_STARTS.add(title)
+    if title != early:
+        _pending_drop(early)  # stale cache entry — keep only the real title
+        if title in ENGINE.instances or _pending_has(title):
+            return JSONResponse(
+                {
+                    "error": "session %s already exists — close it to re-run" % title,
+                    "title": title,
+                },
+                status_code=409,
+            )
+    _pending_add(
+        title,
+        "iss",
+        branch=_issue_start.branch_for(issue),
+        repo=repo,
+        workspace_strategy=_issue_start.workspace_mode(),
+    )
 
     async def _bg_start() -> None:
         # Same shape as the pipeline's issue loop (issue → Ticket → engine
@@ -4182,7 +4271,7 @@ async def github_issue_force_start(payload: dict) -> JSONResponse:
                 "session.create_failed", session=title, data={"error": str(err)}
             )
         finally:
-            _ISSUE_STARTS.discard(title)
+            _pending_drop(title)
 
     _register_task(_bg_start())
     return JSONResponse({"started": True, "title": title}, status_code=202)

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1852,7 +1852,14 @@ def get_config() -> JSONResponse:
     capabilities, home dir, linked IDE name, first-run + auth-gate state."""
     return JSONResponse(
         {
-            "default_program": ENGINE.default_program(),
+            # Folded to the provider name when the stored value is a resolved
+            # path to a known CLI: an existing config.toml carrying
+            # "/opt/homebrew/bin/claude" (what a first run used to write) would
+            # otherwise seed the New Session dialog with a program it doesn't
+            # recognise, which it renders as an extra agent-dropdown entry.
+            # Launch paths keep using the stored value — this is what the UI
+            # shows and preselects.
+            "default_program": providers.normalize_program(ENGINE.default_program()),
             "provisioning_available": provisioning.provisioning_available(),
             # Optional-integration availability (git / tailscale / ticketing):
             # the UI hides absent features and shows "connect X" guidance on

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -24450,6 +24450,46 @@ function VoiceInput() {
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "mic-caption", className: caption == null ? "hidden" : "", children: caption || "" })
   ] });
 }
+const MAX_NAME = 20;
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function featureBranchName(branch, slug) {
+  const m = new RegExp(`^feature/${escapeRe(slug)}/(.+)$`).exec(branch);
+  return m ? m[1] : "";
+}
+function branchTail(branch) {
+  const parts = branch.split("/").filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : "";
+}
+function clip(name) {
+  return name.length > MAX_NAME ? name.slice(0, MAX_NAME - 1) + "…" : name;
+}
+function splitKind(title) {
+  if (title.startsWith("pr-")) return { kind: "pr", slug: title.slice(3) };
+  if (title.startsWith("issue-")) return { kind: "iss", slug: title.slice(6) };
+  return null;
+}
+function sessionLabel(title, branch) {
+  const plain = { text: title, full: title, kind: "", name: "", slug: title };
+  if (!title) return plain;
+  const split = splitKind(title);
+  const ticketName = split ? "" : featureBranchName(branch, title);
+  if (!split && !ticketName) return plain;
+  const kind = split ? split.kind : "tix";
+  const slug = split ? split.slug : title;
+  if (!slug) return plain;
+  const name = split ? featureBranchName(branch, title) || branchTail(branch) : ticketName;
+  const useName = name && name !== slug && name !== title ? name : "";
+  return {
+    text: useName ? `(${kind}) ${clip(useName)}/${slug}` : `(${kind}) ${slug}`,
+    full: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
+    kind,
+    name: useName,
+    slug
+  };
+}
+const DBLCLICK_MS = 300;
 function displayTitle(inst) {
   return inst.display_title || inst.title || "";
 }
@@ -24464,20 +24504,27 @@ const SidebarRow = reactExports.memo(function SidebarRow2({
 }) {
   var _a2, _b2;
   const [expanded, setExpanded] = reactExports.useState(false);
+  const [editing, setEditing] = reactExports.useState(false);
+  const cancelled = reactExports.useRef(false);
+  const renameTimer = reactExports.useRef(null);
+  const editEndedAt = reactExports.useRef(0);
   const { data: config } = useConfig();
   const focused = useUi((s) => s.focused);
   const hidden = useUi((s) => s.hidden.has(inst.title));
   const alias = useUi((s) => s.aliases[inst.title]);
   const openDialogFor = useUi((s) => s.openDialogFor);
+  const setAlias = useUi((s) => s.setAlias);
   const title = inst.title;
   const missing = !!inst.workspace_missing;
   const paused = inst.status === "paused";
+  const pending = !!inst.pending;
   const caps2 = (config == null ? void 0 : config.caps) ?? { git: true };
   const ideName2 = (config == null ? void 0 : config.ide_name) || "Cursor";
   const chip = chipState(inst);
   const check = checkChip(inst);
   const num = idx < 9 ? String(idx + 1) : "";
-  const shown = alias || displayTitle(inst);
+  const label = sessionLabel(displayTitle(inst), inst.branch || "");
+  const shown = alias || label.text;
   const folder = inst.folder || inst.path || "";
   const agentWs = reactExports.useSyncExternalStore(
     subscribeTermStates,
@@ -24491,13 +24538,41 @@ const SidebarRow = reactExports.memo(function SidebarRow2({
     e == null ? void 0 : e.stopPropagation();
     await fn();
   };
-  const rowCls = "inst" + (focused === title ? " active" : "") + (hidden ? " is-hidden" : "") + (missing ? " ws-missing" : "") + (dropCue ? ` drop-${dropCue}` : "");
+  const clearRenameTimer = () => {
+    if (renameTimer.current !== null) {
+      clearTimeout(renameTimer.current);
+      renameTimer.current = null;
+    }
+  };
+  reactExports.useEffect(() => clearRenameTimer, []);
+  const armRename = () => {
+    clearRenameTimer();
+    renameTimer.current = window.setTimeout(() => {
+      renameTimer.current = null;
+      cancelled.current = false;
+      setEditing(true);
+    }, DBLCLICK_MS);
+  };
+  const commitRename = (raw) => {
+    setEditing(false);
+    editEndedAt.current = Date.now();
+    if (cancelled.current) {
+      cancelled.current = false;
+      return;
+    }
+    const next = raw.trim();
+    const nextAlias = !next || next === label.text || next === displayTitle(inst) ? "" : next;
+    if (nextAlias === (alias || "")) return;
+    setAlias(title, nextAlias);
+    toast(nextAlias ? `Renamed to “${nextAlias}”` : "Reset to real title");
+  };
+  const rowCls = "inst" + (focused === title ? " active" : "") + (hidden ? " is-hidden" : "") + (missing ? " ws-missing" : "") + (pending ? " is-pending" : "") + (dropCue ? ` drop-${dropCue}` : "");
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "li",
     {
       className: rowCls,
       "data-title": title,
-      draggable: true,
+      draggable: !editing,
       onDragStart: (ev) => {
         ev.dataTransfer.setData("text/plain", title);
         ev.dataTransfer.effectAllowed = "move";
@@ -24533,15 +24608,23 @@ const SidebarRow = reactExports.memo(function SidebarRow2({
           "div",
           {
             className: "inst-row",
-            onClick: () => selectSession(title),
+            onClick: () => {
+              if (editing || Date.now() - editEndedAt.current < DBLCLICK_MS + 100) return;
+              if (focused !== title) {
+                selectSession(title);
+                return;
+              }
+              if (!pending) armRename();
+            },
             onDoubleClick: () => {
-              if (!missing) ideSession(title, true);
+              clearRenameTimer();
+              if (!missing && !pending) ideSession(title, true);
             },
             children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "grip", title: "Drag to reorder", children: "⠿" }),
               /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "idx", title: num ? `Ctrl+${num} / Alt+${num} to focus` : "", children: num }),
               /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "dot " + inst.status + (disconnected ? " disconnected" : "") }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
+              !pending && /* @__PURE__ */ jsxRuntimeExports.jsx(
                 "button",
                 {
                   className: "chevron" + (expanded ? " open" : ""),
@@ -24550,17 +24633,50 @@ const SidebarRow = reactExports.memo(function SidebarRow2({
                   children: "›"
                 }
               ),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "meta", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "meta", children: editing ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  className: "title title-edit",
+                  type: "text",
+                  defaultValue: shown,
+                  autoFocus: true,
+                  autoComplete: "off",
+                  spellCheck: false,
+                  onFocus: (e) => e.currentTarget.select(),
+                  onMouseDown: (e) => e.stopPropagation(),
+                  onClick: (e) => e.stopPropagation(),
+                  onDoubleClick: (e) => e.stopPropagation(),
+                  onBlur: (e) => commitRename(e.currentTarget.value),
+                  onKeyDown: (e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      commitRename(e.currentTarget.value);
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      cancelled.current = true;
+                      editEndedAt.current = Date.now();
+                      setEditing(false);
+                    }
+                  }
+                }
+              ) : /* @__PURE__ */ jsxRuntimeExports.jsx(
                 "span",
                 {
                   className: "title" + (alias ? " aliased" : ""),
-                  title: alias ? `${alias}  ·  ${displayTitle(inst)}` : displayTitle(inst),
+                  title: [
+                    alias ? `${alias}  ·  ${label.full}` : label.full,
+                    // The real title is the identity behind a reformatted label —
+                    // it's what every API path and `tmux attach` is keyed by.
+                    label.kind ? `session: ${displayTitle(inst)}` : "",
+                    inst.branch ? `branch: ${inst.branch}` : "",
+                    focused === title ? "Click again to rename" : ""
+                  ].filter(Boolean).join("\n"),
                   children: shown
                 }
               ) }),
               /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "stagechip " + chip.cls, title: chip.title, children: chip.label }),
               check && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "stagechip checkchip " + check.cls, title: check.title, children: check.label }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
+              !pending && /* @__PURE__ */ jsxRuntimeExports.jsx(
                 "button",
                 {
                   className: "kill" + (missing ? " cleanup" : ""),
@@ -24572,7 +24688,7 @@ const SidebarRow = reactExports.memo(function SidebarRow2({
             ]
           }
         ),
-        expanded && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "inst-actions", children: [
+        expanded && !pending && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "inst-actions", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "folder-row", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "folder-path", title: folder, children: inst.folder_label || folder || "—" }),
             /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -25269,7 +25385,10 @@ function AutomationBar() {
   const { data: status, refetch } = useQuery({
     queryKey: ["mindflock-status"],
     queryFn: () => api("/api/mindflock/status"),
-    refetchInterval: 1e4,
+    // Matches the sessions poll: the green window can be as short as one
+    // provisioning, and a 10s poll missed those often enough that the light
+    // looked like it never turned green at all.
+    refetchInterval: 4e3,
     retry: false
   });
   const online = reactExports.useSyncExternalStore(subscribeOnline, () => navigator.onLine);
@@ -25277,7 +25396,7 @@ function AutomationBar() {
   if (!status || !status.available) return null;
   const running = !!status.running;
   const desired = optimistic ?? (status.desired ?? running);
-  const active = running && !!status.tickets_active;
+  const active = !!status.tickets_active;
   const starting = desired && !running;
   const netIssue = !online || !!status.net_error;
   const toggle = async (start) => {
@@ -25305,8 +25424,13 @@ function AutomationBar() {
           "span",
           {
             id: "mindflock-dot",
-            className: "dc-dot " + (netIssue ? "error" : !desired ? "off" : active ? "on" : "idle"),
-            title: netIssue ? online ? "Connection issues in the ingestion log — see Settings → System logs" : "No network connection" : starting ? "Set to on but not running yet — starting, or the pipeline exited (flip the switch off and on to restart it)" : active ? "A ticket is being handled right now" : desired ? "Waiting for an assigned ticket — turns green while one is being handled" : void 0
+            className: (
+              // `active` outranks the switch: a ticket forced from Settings is
+              // genuinely being brought in even with auto ingestion switched off,
+              // and "off" would be a lie about the work in flight.
+              "dc-dot " + (netIssue ? "error" : active ? "on" : !desired ? "off" : "idle")
+            ),
+            title: active ? "A ticket is being brought in right now (auto ingestion or a forced start)" : netIssue ? online ? "Connection issues in the ingestion log — see Settings → System logs" : "No network connection" : starting ? "Set to on but not running yet — starting, or the pipeline exited (flip the switch off and on to restart it)" : desired ? "Waiting for an assigned ticket — turns green while one is being brought in" : void 0
           }
         ),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "dc-label", children: "Ticket Ingestion" }),
@@ -25359,7 +25483,7 @@ function useGithubToggleBar(opts) {
   const { data: ingestion } = useQuery({
     queryKey: ["mindflock-status"],
     queryFn: () => api("/api/mindflock/status"),
-    refetchInterval: 1e4,
+    refetchInterval: 4e3,
     retry: false
   });
   reactExports.useEffect(() => {
@@ -25411,8 +25535,8 @@ function GitIssueBar() {
           "span",
           {
             id: "git-issue-dot",
-            className: "dc-dot " + (!on ? "off" : active ? "on" : "idle"),
-            title: on ? starting ? "Switched on — the pipeline is starting" : active ? "An issue is being worked on right now" : "Waiting for a newly opened issue — turns green while one is being handled" : void 0
+            className: "dc-dot " + (active ? "on" : !on ? "off" : "idle"),
+            title: active ? "An issue is being brought in right now (automated or a forced start)" : on ? starting ? "Switched on — the pipeline is starting" : "Waiting for a newly opened issue — turns green while one is being handled" : void 0
           }
         ),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "dc-label", children: "Issue Handling" }),
@@ -25472,8 +25596,8 @@ function PrReviewBar() {
           "span",
           {
             id: "pr-review-dot",
-            className: "dc-dot " + (!on ? "off" : active ? "on" : "idle"),
-            title: on ? starting ? "Switched on — the review pipeline is starting" : active ? "A pull request is being reviewed right now" : "Waiting for an open PR with actionable review comments — turns green while one is being handled" : void 0
+            className: "dc-dot " + (active ? "on" : !on ? "off" : "idle"),
+            title: active ? "A pull request is being brought in for review right now (automated or a forced start)" : on ? starting ? "Switched on — the review pipeline is starting" : "Waiting for an open PR with actionable review comments — turns green while one is being handled" : void 0
           }
         ),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "dc-label", children: "PR Review" }),
@@ -30086,10 +30210,9 @@ function AssignedTicketRow({ t, onStarted }) {
                 const r = await api("/api/tickets/start", {
                   json: { source: t.source, id: t.id }
                 });
-                toast(
-                  "Session " + ((r == null ? void 0 : r.title) || t.slug) + " starting — it will appear in the sidebar shortly"
-                );
+                toast("Session " + ((r == null ? void 0 : r.title) || t.slug) + " — provisioning, see the sidebar");
                 setState("started");
+                refreshInstances();
                 setTimeout(onStarted, 5e3);
               } catch (err) {
                 toast("Begin work failed: " + (err.message || "error"));
@@ -30592,10 +30715,9 @@ function OpenPrRow({ p, onStarted }) {
                 const r = await api("/api/github/prs/review", {
                   json: { repo: p.repo, number: p.number }
                 });
-                toast(
-                  "Review session " + ((r == null ? void 0 : r.title) || "") + " starting — it will appear in the sidebar shortly"
-                );
+                toast("Review session " + ((r == null ? void 0 : r.title) || "") + " — provisioning, see the sidebar");
                 setState("started");
+                refreshInstances();
                 setTimeout(onStarted, 5e3);
               } catch (err) {
                 toast("Begin review failed: " + (err.message || "error"));
@@ -30897,10 +31019,9 @@ function OpenIssueRow({ i, onStarted }) {
                 const r = await api("/api/github/issues/start", {
                   json: { repo: i.repo, number: i.number }
                 });
-                toast(
-                  "Issue session " + ((r == null ? void 0 : r.title) || "") + " starting — it will appear in the sidebar shortly"
-                );
+                toast("Issue session " + ((r == null ? void 0 : r.title) || "") + " — provisioning, see the sidebar");
                 setState("started");
+                refreshInstances();
                 setTimeout(onStarted, 5e3);
               } catch (err) {
                 toast("Start work failed: " + (err.message || "error"));

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -23959,6 +23959,32 @@ function EventToasts() {
   }, []);
   return null;
 }
+function winctl() {
+  if (typeof window === "undefined") return void 0;
+  return window.winctl;
+}
+async function isFullScreen() {
+  var _a2, _b2;
+  try {
+    return await ((_b2 = (_a2 = winctl()) == null ? void 0 : _a2.isFullScreen) == null ? void 0 : _b2.call(_a2)) === true;
+  } catch {
+    return false;
+  }
+}
+function bridge() {
+  if (typeof window === "undefined") return void 0;
+  return window.mfshell;
+}
+function hasNativeWindowControls() {
+  var _a2;
+  return ((_a2 = bridge()) == null ? void 0 : _a2.nativeTitleBar) === true;
+}
+function onFullScreenChanged(cb) {
+  var _a2, _b2;
+  const off = (_b2 = (_a2 = winctl()) == null ? void 0 : _a2.onFullScreenChanged) == null ? void 0 : _b2.call(_a2, cb);
+  return typeof off === "function" ? off : () => {
+  };
+}
 function applyTheme(light) {
   document.documentElement.classList.toggle("light", light);
 }
@@ -23970,6 +23996,20 @@ function TopBar() {
   const [recentOpen, setRecentOpen] = reactExports.useState(false);
   const [version, setVersion] = reactExports.useState(engineVersion);
   const dropRef = reactExports.useRef(null);
+  const [mac] = reactExports.useState(hasNativeWindowControls);
+  const [fullScreen, setFullScreen] = reactExports.useState(false);
+  reactExports.useEffect(() => {
+    if (!mac) return;
+    let live = true;
+    void isFullScreen().then((f) => {
+      if (live) setFullScreen(f);
+    });
+    const off = onFullScreenChanged(setFullScreen);
+    return () => {
+      live = false;
+      off();
+    };
+  }, [mac]);
   reactExports.useEffect(() => {
     if (engineVersion) return;
     let live = true;
@@ -24011,10 +24051,31 @@ function TopBar() {
     rethemeAll();
     redrawFavicon();
   };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "topbar", children: [
+  const logo = /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "brand-logo", "aria-hidden": "true" });
+  const themeToggle = /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "button",
+    {
+      id: "theme-btn",
+      type: "button",
+      title: light ? "Switch to dark mode" : "Switch to light mode",
+      "aria-label": "Toggle light / dark mode",
+      onClick: toggleTheme,
+      children: /* @__PURE__ */ jsxRuntimeExports.jsx("svg", { viewBox: "0 0 24 24", width: "15", height: "15", "aria-hidden": "true", children: light ? /* @__PURE__ */ jsxRuntimeExports.jsxs("g", { fill: "none", stroke: "currentColor", strokeWidth: "2", strokeLinecap: "round", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("circle", { cx: "12", cy: "12", r: "4.2" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: "M12 2.5v2.4M12 19.1v2.4M2.5 12h2.4M19.1 12h2.4M5.3 5.3l1.7 1.7M17 17l1.7 1.7M18.7 5.3L17 7M7 17l-1.7 1.7" })
+      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "path",
+        {
+          fill: "currentColor",
+          d: "M20.2 14.6A8.6 8.6 0 0 1 9.4 3.8a8.6 8.6 0 1 0 10.8 10.8z"
+        }
+      ) })
+    }
+  );
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "topbar", "data-mac": mac ? "" : void 0, "data-mac-lights": mac && !fullScreen ? "" : void 0, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "tb-start", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "tb-left", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "brand-logo", "aria-hidden": "true" }),
+        !mac && logo,
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "button",
           {
@@ -24041,27 +24102,8 @@ function TopBar() {
             )
           }
         ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            id: "theme-btn",
-            type: "button",
-            title: light ? "Switch to dark mode" : "Switch to light mode",
-            "aria-label": "Toggle light / dark mode",
-            onClick: toggleTheme,
-            children: /* @__PURE__ */ jsxRuntimeExports.jsx("svg", { viewBox: "0 0 24 24", width: "15", height: "15", "aria-hidden": "true", children: light ? /* @__PURE__ */ jsxRuntimeExports.jsxs("g", { fill: "none", stroke: "currentColor", strokeWidth: "2", strokeLinecap: "round", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("circle", { cx: "12", cy: "12", r: "4.2" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: "M12 2.5v2.4M12 19.1v2.4M2.5 12h2.4M19.1 12h2.4M5.3 5.3l1.7 1.7M17 17l1.7 1.7M18.7 5.3L17 7M7 17l-1.7 1.7" })
-            ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "path",
-              {
-                fill: "currentColor",
-                d: "M20.2 14.6A8.6 8.6 0 0 1 9.4 3.8a8.6 8.6 0 1 0 10.8 10.8z"
-              }
-            ) })
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(NotificationsBell, {})
+        !mac && themeToggle,
+        !mac && /* @__PURE__ */ jsxRuntimeExports.jsx(NotificationsBell, {})
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("nav", { className: "tb-menu", "aria-label": "Main actions", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -24167,7 +24209,12 @@ function TopBar() {
         version
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "tb-drag" })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "tb-drag" }),
+    mac && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "tb-end", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(NotificationsBell, {}),
+      themeToggle,
+      logo
+    ] })
   ] });
 }
 function ConnBanner() {

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -712,6 +712,34 @@ body #mf-winctl {
   gap: 6px;
 }
 
+/* --- macOS layout ---------------------------------------------------------- */
+/* The desktop shell keeps the NATIVE traffic lights top-left there
+   (electron/main.js `titleBarStyle: 'hidden'`), because a Mac user reads
+   red/yellow/green in that corner as "the window controls" — ours on the right
+   was the Windows arrangement on the wrong OS. Two consequences here:
+
+     1. leave room for them, so the menu doesn't start underneath;
+     2. mirror our own cluster (logo / theme / bell) to the right, which on a Mac
+        is otherwise empty — the shell draws no – □ ✕ there.
+
+   The gap is keyed on `data-mac-lights`, not `data-mac`: macOS hides the lights
+   in fullscreen, and the shell tells the UI so (electron `fullscreen-changed`)
+   rather than leaving a hole no window button occupies. Browser tabs on macOS
+   get NEITHER attribute — they have their own chrome and no lights to dodge. */
+#topbar[data-mac-lights] {
+  /* 13px light origin + 3 x 12px buttons + 2 x 8px gaps + breathing room. */
+  padding-left: 78px;
+}
+
+#topbar[data-mac] .tb-end {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  /* Sits after the drag handle, so it hugs the right edge; the handle keeps all
+     the flexible width and the brand stays centred between the two zones. */
+  flex: 0 0 auto;
+}
+
 /* Wordmark in normal flow between two equal flex:1 zones (the left cluster+menu
    on one side, the drag region on the other). Equal zones => the brand sits at
    true window center whenever there's room. When the left zone's content is

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -2937,6 +2937,30 @@ p.set-hint {
   text-overflow: ellipsis;
 }
 
+/* A force-start the server accepted but hasn't turned into a session yet: it
+   carries the provisioning chip like any loading row, dimmed a touch because
+   there is nothing to act on until the clone finishes. */
+.inst.is-pending .title {
+  color: var(--muted);
+}
+
+/* Inline rename (click the selected row): sits exactly where the title text was
+   so the row height never shifts. */
+.inst input.title-edit {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 0 2px;
+  margin: -1px 0;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  outline: none;
+}
+
 .inst .branch {
   font-size: 11px;
   color: var(--muted);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,7 +217,13 @@ See [cli.md](cli.md).
 
 An Electron shell that auto-starts the server (through WSL on Windows) and
 loads the web UI in a native window, with an offline/diagnostics page while the
-server boots. See `electron/README.md`.
+server boots. Window chrome is platform-conditional — frameless with injected
+– □ ✕ on Windows/Linux, `titleBarStyle: 'hidden'` with the OS traffic lights on
+macOS — and the UI adapts to it through **capability flags on the preload
+bridge** (`mfshell.nativeTitleBar`, read via `frontend/src/lib/shell.ts`) rather
+than platform sniffing: the shell and the engine that serves the UI ship on
+independent cadences, so each side has to tolerate the other being older. See
+`electron/README.md`.
 
 ## Data flow: one story, end to end
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,6 +35,33 @@ It is a no-op in the packaged prod build. Full per-OS instructions, the
 fully-isolated (separate-server) variant, and how to pin the dev icon to the
 Windows taskbar are in [`electron/README.md`](../electron/README.md).
 
+### Shell ↔ engine skew
+
+The packaged app freezes only four files — `main.js`, `preload.js`, `logger.js`,
+`offline.html` — and loads everything else (the whole frontend) from whatever
+`mindflock serve` is installed. So the shell and the UI are **separately
+versioned at runtime**, in both directions, and anything new on the preload
+bridge has to be optional on both sides:
+
+- **New frontend, old shell** — the flag is simply absent. Gate on the
+  capability (`mfshell.nativeTitleBar`), never on `platform`/`navigator`, and the
+  old shell keeps the layout it was built for.
+- **New shell, old frontend** — the common case, since the app updates on its
+  own cadence. This one has a **known rough edge**: a new macOS shell hands its
+  native traffic lights to an older top bar that reserves no room for them, so
+  they paint over that bar's logo / sidebar toggle / theme button until the
+  engine is updated (re-running `install.sh` upgrades it in place). No mitigation
+  is in the shell today; the fix, if it becomes a real complaint, is a defensive
+  `insertCSS` of `#topbar { padding-left: 78px }` on darwin.
+
+### Rebuild the bundle in the same commit
+
+`backend/web/static/app.js` and `style.css` are **committed build output**. Any
+change under `frontend/src` — including CSS-only tweaks, which are the easiest to
+forget — needs `npm run build` in `frontend/` so the regenerated pair lands in
+the same commit as the source. The backend tests assert on literals inside those
+files, so a stale bundle shows up as a confusing Python test failure.
+
 ## Pre-commit hooks
 
 Shared, deterministic hooks live in `.pre-commit-config.yaml` (black,
@@ -214,7 +241,7 @@ refresher re-runs suites automatically.
 | PR flow | `test_pr_pipeline` |
 | Property (hypothesis) | backfill ordering, prompt construction, validation-with-context, assignee filter, timestamp persistence |
 | Integration | `test_claude_runner` (async ClaudeCodeRunner) |
-| Frontend (vitest) | `frontend/src/__tests__/*.test.ts` — the pure logic modules (layout, diff, keymap, ordering, stage, format, barDefs, usageModel) |
+| Frontend (vitest) | `frontend/src/__tests__/*.test.ts` — the pure logic modules (layout, diff, keymap, ordering, stage, format, barDefs, usageModel, sessionLabel, shell) |
 
 The launch-parity golden files pin the workspace launcher byte-for-byte
 (backend rolling, markers, resume loop) — update them deliberately when changing
@@ -226,7 +253,7 @@ The frontend tests are **not** part of `uv run pytest`. `vitest` is a
 production build is untouched by test settings). Nothing in CI runs them today:
 
 ```bash
-cd frontend && npm test           # 8 files, 118 tests
+cd frontend && npm test           # 10 files, 137 tests
 ```
 
 ## Conventions

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -26,6 +26,37 @@ provider's aliases). Registration order:
 poll tick), so results are memoized per program string in a small bounded
 cache, invalidated whenever the registry changes (register / rebuild).
 
+### `normalize_program(program)`
+
+Canonicalizes a *stored or displayed* program string to a provider **name** where
+one applies — `/opt/homebrew/bin/claude` → `claude`. Detection reports an
+absolute path (it shells out to `which`), and storing that verbatim leaks an
+install detail into everything that shows or matches a program, most visibly the
+New Session dialog, which renders any program it doesn't recognize as an extra
+agent-dropdown entry. The rules:
+
+- empty, or already a registry key → returned unchanged (whitespace stripped)
+- more than one whitespace-separated token → unchanged; it's a command line, not
+  a binary to identify
+- already a bare basename → unchanged
+- otherwise the basename is matched against each provider's aliases in
+  registration order, **skipping `generic`** (the catch-all claims everything, so
+  it identifies nothing), and the first match's name is returned
+- a path no provider claims → unchanged, because for a custom agent the exact
+  string *is* the launch command
+
+Unlike `resolve()` it is **not memoized** and it **is registry-state dependent**:
+a user TOML provider whose aliases claim a basename starts folding paths that
+previously passed through, and results can change after `rebuild_registry()`.
+Matcher exceptions are swallowed (one broken provider can't break normalization),
+so a `matches()` implementation must stay cheap and side-effect free.
+
+Two call sites: `config.DefaultConfig()` at write time (so a first run stores
+`claude`, not the `which` output) and `GET /api/config` at read time (so an older
+`config.toml` holding an absolute path is *displayed* as the provider name). The
+read-time pass does not rewrite the file, so the stored launch value and the
+displayed/preselected one can differ — see [web-api.md](web-api.md).
+
 ## The default: `claude`
 
 The Claude provider launches plain `claude` (Claude Code). It:
@@ -149,8 +180,10 @@ Settings → **Agent providers** surfaces a **connection** view for every
 registered provider (built-in and custom): whether its binary is installed
 (with the resolved path) and, when it's missing, a copy-paste install command
 (see [web-ui.md](web-ui.md)). MindFlock does **not** drive sign-in — each CLI
-prompts you to authenticate on its own the first time a session launches it, so
-MindFlock never touches your credentials. Install detection is the same
+prompts you to authenticate on its own the first time a session launches it —
+MindFlock never drives sign-in and never stores credentials. It does read Claude
+Code's *existing* OAuth token read-only, solely to display live plan usage (see
+**Live usage & limit state** below). Install detection is the same
 `shutil.which` / explicit-path check the backend uses to gate the default
 provider (below).
 
@@ -231,3 +264,27 @@ Two provider methods drive the usage-limit hold on the prompt queue (see
   (`{limited, reset_at}`). The hold logic consults the live meter even when this
   reports no banner, so a rebooted session with a fresh idle prompt is still
   held when its meter shows a window genuinely spent.
+
+### Credential sources for `usage_live()`
+
+Claude's live reading needs the OAuth access token the Claude CLI already holds.
+MindFlock reads it — read-only, never written, never logged — from, in order:
+
+1. `$CLAUDE_CONFIG_DIR/.credentials.json`, else `~/.claude/.credentials.json`
+   (Linux/WSL, and any install that keeps a file).
+2. **macOS only:** the login Keychain item `Claude Code-credentials`, via
+   `security find-generic-password -s "Claude Code-credentials" -w`. macOS Claude
+   Code keeps its credentials here instead of in a file, so before this fallback
+   live plan usage was permanently dark on every Mac (the UI fell back to the
+   transcript estimate). This adds a macOS-only runtime dependency on the
+   `security` binary.
+
+Because the Keychain item was created by the Claude CLI and not by MindFlock, the
+lookup can raise a one-time *"MindFlock wants to use your Keychain"* prompt from
+the MindFlock (Python/Electron) binary. The call is bounded at **5 s** so an
+unanswered prompt can't wedge `GET /api/usage`, and a denial — like a headless
+session, a missing `security`, or a non-JSON item — simply yields no live reading,
+which is exactly the pre-existing behavior. The result is **not cached**, so a
+denial can re-prompt on later usage fetches. Failures are reported only as a
+reason string on the `_creds_diag` debug channel; the token itself is never
+logged.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -11,6 +11,34 @@ and the contracts to preserve.
 
 ## Layout
 
+**Top bar** — on the left: the brand logo, the sidebar toggle (`Ctrl+B` / `⌘B`),
+the theme toggle 🌙 and the notifications 🔔 bell. Then the menu — **New**,
+**Recent ▾** (Recently closed… / Workspaces on disk…), **Prompts**, **Command**,
+**Settings**. The **MindFlock** wordmark (carrying the *running engine's*
+version, plus a red `-DEV` badge under a dev shell) sits centered, and the empty
+strip beside it is the drag region that moves the desktop shell's window.
+
+In the desktop shell **on macOS** the bar mirrors. The window keeps the OS
+traffic lights top-left (`titleBarStyle: 'hidden'` — the shell draws no – □ ✕
+there), so the bar reserves ~78px in that corner and moves the logo / theme /
+bell cluster to the right, where a Mac has nothing else; the sidebar toggle and
+the menu stay where they are. It is the same elements with the same behaviour,
+mirrored — the one difference is DOM order: the mirrored cluster sits after the
+drag region, so `Tab` reaches the theme toggle and bell last there instead of
+first. The reserved gap collapses in fullscreen, because macOS hides the lights then:
+the shell pushes transitions over a `fullscreen-changed` IPC event, and the bar
+also *pulls* the current state (`win:is-fullscreen`) when it mounts — a window
+that is already fullscreen when the UI loads or reloads never sees a transition,
+so without the pull it would hold the gap open until you toggled fullscreen.
+
+The **same** UI in Safari or Chrome on macOS keeps the standard left-hand
+layout: the decision reads the preload bridge's `nativeTitleBar` capability flag
+(`frontend/src/lib/shell.ts`), never the user agent, so the layout only shifts
+where something really draws native controls. Two DOM hooks come with it, for
+theme and addon authors styling against the bar: `#topbar[data-mac]` (native
+title bar) and `#topbar[data-mac-lights]` (…and the lights are visible right
+now).
+
 **Sidebar** — session list with drag-to-reorder, status dots, stage chips, and a
 kill ✕ per row (ends the session, keeps the worktree). Long titles ellipsize
 (full name on hover); a session cut from a different repo than the one the
@@ -27,12 +55,11 @@ bar (pipeline on/off switch, state dot, Logs pane), the **PR Review** and
 **Issue Handling** bars, and one auto-rendered bar per generic addon — e.g.
 **Notifications** with its On/Off toggle (disabled with an explanatory tooltip
 on plain-http origins, "Blocked" when the browser denies permission).
-Below: view-mode buttons (Auto/1/2/4/9), **Recent…** (reopen closed sessions),
-**Disk…** (workspace manager), session count, a **Command** button (opens the
-command palette), a **⚙ Customize** button (sidebar bars — see below), settings
-⚙, and the theme toggle 🌙. The workspace manager
-lists each managed workspace with its size and a per-row delete, plus a **Clear**
-button that bulk-removes every unprotected, idle workspace in one sweep
+Below: view-mode buttons (Auto/1/2/4/9), the session count, a **⚙ Customize**
+button (sidebar bars — see below) and **⌨ Shortcuts**. (Recently closed, the
+workspace manager, the command palette and settings live in the top bar's menu,
+not down here.) The workspace manager lists each managed workspace with its size
+and a per-row delete, plus a **Clear** button that bulk-removes every unprotected, idle workspace in one sweep
 (`POST /api/workspaces/clear`) — protected base clones / cache refreshers and any
 dir a live session is using are left alone.
 
@@ -46,8 +73,8 @@ or below, but which never itself moves). Order and the hidden set persist per
 browser (`localStorage`). Turning a feature's bar on is how you reveal PR
 review, ticket ingestion, and issue handling once you've connected them.
 
-**Command palette** — `Ctrl+P` or `Ctrl+Shift+P` (`Cmd` on Mac, or the footer
-Command button) opens a fuzzy-filtered palette over everything: jump to
+**Command palette** — `Ctrl+P` or `Ctrl+Shift+P` (`Cmd` on Mac, or the top bar's
+**Command** button) opens a fuzzy-filtered palette over everything: jump to
 ("Focus:") any session, New session, Commit / Push / Create PR / Open in IDE on
 the focused session, Open Settings / Doctor / Setup checklist, Toggle sidebar,
 and New from Recently closed. Type to filter (subsequence match), `↑`/`↓` to

--- a/electron/README.md
+++ b/electron/README.md
@@ -1,8 +1,12 @@
 # MindFlock — the desktop app (Electron)
 
 **This is the MindFlock client** — the one supported way to use MindFlock on a
-desktop, on every platform. A single frameless window renders the UI served by
-the local FastAPI server, auto-starting that server when it isn't running:
+desktop, on every platform. A single window renders the UI served by the local
+FastAPI server, auto-starting that server when it isn't running. The chrome is
+platform-conditional: **frameless** (`frame: false`) on Windows/Linux with our
+own injected – □ ✕, and on **macOS** `titleBarStyle: 'hidden'` with
+`trafficLightPosition: { x: 13, y: 13 }`, keeping the OS traffic lights
+top-left (see [Window chrome](#window-chrome-and-the-preload-bridge)).
 
 - **Linux / macOS** — the server runs natively; the app spawns the installed
   `mindflock serve` directly (login PATH, falling back to
@@ -111,9 +115,47 @@ Substitute `<Distro>`, `<user>`, and `path\to\MindFlock`. If `npm install`
 misbehaves over the UNC path, copy this `electron/` folder to a Windows-local
 dir (e.g. `C:\mindflock-desktop`) and run it there instead.
 
-The window opens frameless with our title bar; **drag** the bar to move,
-**drag any edge** to resize (native), and the **□ / ❐** button toggles maximize.
-If the server isn't up yet you'll see a "waiting…" page that auto-reconnects.
+The window opens with our own title bar in place of the OS one; **drag** the bar
+to move, **drag any edge** to resize (native), and the **□ / ❐** button toggles
+maximize. On **macOS** there is no injected – □ ✕ at all: minimize / zoom / close
+are the native red-yellow-green buttons top-left, so the glyph swap is a
+Windows/Linux detail; drag and edge-resize behave the same. If the server isn't
+up yet you'll see a "waiting…" page that auto-reconnects.
+
+## Window chrome and the preload bridge
+
+`main.js` branches on `process.platform` when it creates the window:
+
+| | Windows / Linux | macOS |
+|---|---|---|
+| Frame | `frame: false` | `titleBarStyle: 'hidden'`, `trafficLightPosition: {x:13,y:13}` |
+| Controls | injected `#mf-winctl` – □ ✕ (top-right) | the OS traffic lights (top-left) |
+| `TITLEBAR_JS` | injects the buttons | returns early — two sets of controls otherwise |
+
+The UI has to know, because it draws its own top bar in that same strip: on
+macOS it reserves ~78px top-left and mirrors its logo/theme/bell cluster to the
+right (`docs/web-ui.md` → Layout → Top bar). It learns this from the bridge, not
+from the platform — `preload.js` exposes:
+
+| Member | Meaning | Undefined in a browser (or an older shell) |
+|---|---|---|
+| `mfshell.platform` | `process.platform` | UI hides platform-specific controls |
+| `mfshell.nativeTitleBar` | **capability**: the OS draws this window's controls, top-left | falsy → the UI keeps the injected-controls layout |
+| `mfshell.dev` | dev build (red `-DEV` wordmark) | no badge |
+| `mfshell.showItem(p)` | reveal a path in Finder/Explorer → `{ ok }` | UI falls back to copying the path |
+| `winctl.minimize/maximize/close` | window commands for the injected bar | no-op; the browser has its own chrome |
+| `winctl.onMaximizedChanged(cb)` | `maximized-changed` pushes; returns nothing | never fires |
+| `winctl.onFullScreenChanged(cb)` | `fullscreen-changed` on enter/leave-full-screen; **returns an unsubscribe** | returns a no-op unsubscribe |
+| `winctl.isFullScreen()` | current state via `win:is-fullscreen` — the event above only carries transitions, so a window already fullscreen at load needs this | resolves false |
+| `mfdiag.*` | offline-page diagnostics | offline page isn't reachable |
+
+`nativeTitleBar` is deliberately a *capability* flag and not `platform ===
+'darwin'`: the shell and the engine-served frontend ship on independent
+cadences, so a Mac shell built before this change still injects its own controls
+top-right, and a platform-keyed layout would stack the frontend's cluster on top
+of them. The flag is absent there, so that build keeps the layout it was built
+for. New bridge members must stay optional the same way — see
+[shell ↔ engine skew](../docs/development.md#shell--engine-skew).
 
 ## Dev loop (no rebuilds)
 
@@ -244,13 +286,21 @@ no console to watch when something breaks. Two logs capture everything:
 
 ## Files
 
-- `main.js` — single frameless `BrowserWindow` loading the UI + injected chrome
+- `main.js` — the single `BrowserWindow` loading the UI + injected chrome
   (scrollbar/title-strip CSS, `#mf-winctl` buttons), window-control IPC,
-  auto-start of the hidden WSL server, offline/retry, log wiring.
+  auto-start of the hidden WSL server, offline/retry, log wiring. Window chrome
+  is platform-branched (`frame: false` vs. darwin's `titleBarStyle: 'hidden'` +
+  `trafficLightPosition`), `TITLEBAR_JS` returns early on darwin so the OS keeps
+  the only set of controls, `enter-full-screen` / `leave-full-screen` push a
+  `fullscreen-changed` event to the renderer (guarded like `sendMax`), and
+  `win:is-fullscreen` answers the state query the top bar makes on mount.
 - `logger.js` — file logging for the main process (rotation + crash/renderer
   capture); `init(app)` / `attachWindow(win)` / `paths()`.
-- `preload.js` — `contextBridge` exposing `window.winctl` to the injected bar
-  and `window.mfdiag` to the offline page.
+- `preload.js` — `contextBridge` exposing `window.mfshell` (`dev`, `platform`,
+  `nativeTitleBar`, `showItem`, …) to the UI, `window.winctl` to the injected bar
+  (plus `onFullScreenChanged`, which unlike `onMaximizedChanged` returns an
+  unsubscribe), and `window.mfdiag` to the offline page. See
+  [the bridge contract](#window-chrome-and-the-preload-bridge).
 - `offline.html` — shown until the server answers. Polls `diag:get` (a hidden
   `wsl.exe` probe on Windows) to say *why* nothing is answering: server
   booting, MindFlock not installed, or WSL down — with a one-click

--- a/electron/main.js
+++ b/electron/main.js
@@ -768,6 +768,9 @@ const TITLEBAR_CSS = `
 
 const TITLEBAR_JS = `
 (function () {
+  // macOS draws the real traffic lights (titleBarStyle:'hidden' above), so
+  // adding ours would give the window two sets of controls.
+  if (${process.platform === 'darwin'}) return;
   if (document.getElementById('mf-winctl')) return;
   var bar = document.createElement('div');
   bar.id = 'mf-winctl';
@@ -1239,7 +1242,16 @@ function createWindow() {
     height: 820,
     minWidth: 900,
     minHeight: 600,
-    frame: false,             // custom title strip; native drag/resize still work
+    // Custom title strip on every platform; native drag/resize still work.
+    // macOS is the exception: `frame:false` there ALSO removes the traffic
+    // lights, so the shell drew its own – □ ✕ on the right — the Windows
+    // position, which is exactly backwards for a Mac user. `titleBarStyle:
+    // 'hidden'` keeps the frame hidden but leaves the REAL red/yellow/green
+    // buttons top-left, where they belong; TITLEBAR_JS then skips ours, and the
+    // top bar reserves room for them (see TopBar.css `#topbar[data-mac]`).
+    ...(process.platform === 'darwin'
+      ? { titleBarStyle: 'hidden', trafficLightPosition: { x: 13, y: 13 } }
+      : { frame: false }),
     backgroundColor: '#0f1117',
     title: DEV ? 'MindFlock (dev)' : 'MindFlock',
     icon: DEV_ICON || path.join(__dirname, 'icon.ico'),
@@ -1422,6 +1434,18 @@ function createWindow() {
   }
   win.on('maximize', sendMax)
   win.on('unmaximize', sendMax)
+
+  // macOS hides the traffic lights in fullscreen, so the top bar has to give
+  // back the room it reserves for them (see TopBar's `data-mac-lights`) or the
+  // menu sits behind a 78px hole.
+  const sendFullScreen = () => {
+    if (win && !win.webContents.isDestroyed()) {
+      win.webContents.send('fullscreen-changed', win.isFullScreen())
+    }
+  }
+  win.on('enter-full-screen', sendFullScreen)
+  win.on('leave-full-screen', sendFullScreen)
+
   win.on('closed', () => { win = null })
 
   // The page sets document.title (with unread-badge counts), which otherwise
@@ -1443,6 +1467,13 @@ ipcMain.on('win:toggle-maximize', () => {
   win.isMaximized() ? win.unmaximize() : win.maximize()
 })
 ipcMain.on('win:close', () => { if (win) win.close() })
+// Current fullscreen state, pulled once when the top bar mounts. The
+// 'fullscreen-changed' push above only carries TRANSITIONS, and a window that is
+// already fullscreen when the page loads (or reloads — the offline-recovery path
+// reloads on its own) never sees one, so it would hold the traffic-light gap
+// open until the user toggled fullscreen. A pull can't race the renderer's
+// listener registration the way a push at did-finish-load would.
+ipcMain.handle('win:is-fullscreen', () => !!(win && win.isFullScreen()))
 
 app.whenReady().then(() => {
   // Drop Electron's default application menu: it carries devtools

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -16,6 +16,16 @@ contextBridge.exposeInMainWorld('mfshell', {
   // wording differs per OS (Windows routes to Add/Remove Programs), so surface
   // the platform. Undefined in a plain browser → the UI hides the control.
   platform: process.platform,
+  // True when the OS draws this window's controls itself and they sit TOP-LEFT
+  // (macOS traffic lights, via titleBarStyle:'hidden' in main.js) — so the top
+  // bar must leave room for them and mirror its own cluster to the right.
+  //
+  // A capability flag rather than a platform check on purpose: the frontend
+  // ships in the engine, the shell ships as the desktop app, and they update
+  // independently. An older shell still injects its own – □ ✕ top-RIGHT, where
+  // a platform-keyed UI would have moved the logo/theme/bell on top of them.
+  // Undefined there, so that build keeps the layout it was built for.
+  nativeTitleBar: process.platform === 'darwin',
   // Reveal a file in the OS file manager (Finder / Explorer), highlighted.
   // Settings → System logs uses this to jump straight to a log file. Resolves
   // { ok } so the UI can fall back to copying the path if it can't open.
@@ -36,6 +46,18 @@ contextBridge.exposeInMainWorld('winctl', {
   close: () => ipcRenderer.send('win:close'),
   onMaximizedChanged: (cb) =>
     ipcRenderer.on('maximized-changed', (_e, isMax) => cb(isMax)),
+  // Current fullscreen state, for the initial paint — the event below only
+  // carries transitions, and a window launched/reloaded already fullscreen sees
+  // none of them.
+  isFullScreen: () => ipcRenderer.invoke('win:is-fullscreen'),
+  // macOS only in practice: the traffic lights disappear in fullscreen, so the
+  // top bar stops reserving space for them. Returns an unsubscribe so a React
+  // effect can clean up.
+  onFullScreenChanged: (cb) => {
+    const h = (_e, isFull) => cb(isFull)
+    ipcRenderer.on('fullscreen-changed', h)
+    return () => ipcRenderer.removeListener('fullscreen-changed', h)
+  },
 })
 
 // Offline-page diagnostics: lets offline.html explain WHY the UI can't load

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,7 +28,16 @@ changes.
   live OUTSIDE React and are adopted into panes via refs, so re-renders never
   remount a PTY; all the tmux mouse/copy/wheel workarounds live here),
   `keymap.ts` (bindings + Ctrl+K chords + rebind store), `sessionActions.ts`,
-  `stage.ts`, `diff.ts`, `presets.ts`, `clipboard.ts`, `toast.ts`, `format.ts`.
+  `stage.ts`, `diff.ts`, `presets.ts`, `clipboard.ts`, `toast.ts`, `format.ts`,
+  `shell.ts` (what the surrounding desktop shell is: `inShell`, `isMacShell`,
+  `hasNativeWindowControls`, `onFullScreenChanged`).
+- **`lib/shell.ts` is the only place allowed to touch `window.mfshell` /
+  `window.winctl`.** Two rules go with it: never branch on
+  `navigator.userAgent`/`platform` for shell behavior (a Mac user in Safari has
+  no traffic lights to dodge, and must keep the standard layout), and when a
+  capability flag exists, gate on the flag rather than on `isMacShell()` — the
+  shell and the engine-served frontend update independently, so an older shell
+  has to be able to keep the layout it was built for.
 - `src/components/` — the UI: `sidebar/`, `grid/` (panes, diff/queue tabs,
   special panes), `settings/` (one file per screen), `dialogs/`, `palette/`,
   plus TopBar / NotificationsBell / EventToasts / ConnBanner / VoiceInput.

--- a/frontend/src/__tests__/sessionLabel.test.ts
+++ b/frontend/src/__tests__/sessionLabel.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { sessionLabel } from "../lib/sessionLabel";
+
+describe("sessionLabel", () => {
+  it("pulls a ticket's feature name out of its branch", () => {
+    const l = sessionLabel("sc-12345", "feature/sc-12345/add-dark-mode");
+    expect(l.text).toBe("(tix) add-dark-mode/sc-12345");
+    expect(l.kind).toBe("tix");
+    expect(l.name).toBe("add-dark-mode");
+    expect(l.slug).toBe("sc-12345");
+  });
+
+  it("labels a PR review session from its head ref", () => {
+    expect(sessionLabel("pr-app-42", "fix/login-crash").text).toBe("(pr) login-crash/app-42");
+  });
+
+  it("labels an issue session from its feature branch", () => {
+    expect(sessionLabel("issue-app-77", "feature/issue-app-77/cant-open").text).toBe(
+      "(iss) cant-open/app-77"
+    );
+  });
+
+  it("leaves a hand-made session title alone", () => {
+    const l = sessionLabel("my-refactor", "feature/my-refactor");
+    expect(l.text).toBe("my-refactor");
+    expect(l.kind).toBe("");
+  });
+
+  it("keeps the tag when there is no branch to name the work", () => {
+    // A pending PR row before its head ref is known.
+    expect(sessionLabel("pr-app-42", "").text).toBe("(pr) app-42");
+  });
+
+  it("drops a branch that only restates the slug", () => {
+    expect(sessionLabel("pr-app-42", "pr-app-42").text).toBe("(pr) app-42");
+  });
+
+  it("clips a long feature name in the row but not in the tooltip", () => {
+    const long = "rework-the-entire-billing-pipeline";
+    const l = sessionLabel("sc-9", `feature/sc-9/${long}`);
+    expect(l.text).toBe("(tix) rework-the-entire-b…/sc-9");
+    expect(l.full).toBe(`(tix) ${long}/sc-9`);
+  });
+
+  it("survives regex-special characters in a title", () => {
+    // Provider ids are sanitized upstream, but a title reaching the regex path
+    // must never throw.
+    expect(() => sessionLabel("sc+1(a)", "feature/sc+1(a)/name")).not.toThrow();
+    expect(sessionLabel("sc+1(a)", "feature/sc+1(a)/name").text).toBe("(tix) name/sc+1(a)");
+  });
+
+  it("handles an empty title", () => {
+    expect(sessionLabel("", "").text).toBe("");
+  });
+});

--- a/frontend/src/__tests__/shell.test.ts
+++ b/frontend/src/__tests__/shell.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  hasNativeWindowControls,
+  inShell,
+  isFullScreen,
+  isMacShell,
+  onFullScreenChanged,
+} from "../lib/shell";
+
+const g = globalThis as Record<string, unknown>;
+
+function setWindow(w: unknown) {
+  if (w === undefined) delete g.window;
+  else g.window = w;
+}
+
+// Restore, don't just delete: the node environment has no `window`, but the
+// setup file (and any future test in this worker) may add DOM globals of its
+// own — clobbering one would make failures depend on file order.
+const hadWindow = "window" in g;
+const originalWindow = g.window;
+
+afterEach(() => setWindow(hadWindow ? originalWindow : undefined));
+
+describe("isMacShell", () => {
+  it("is true in the desktop shell on macOS", () => {
+    setWindow({ mfshell: { platform: "darwin" } });
+    expect(isMacShell()).toBe(true);
+  });
+
+  it("is false for a browser tab ON a Mac", () => {
+    // The decisive case: Safari/Chrome on macOS has its own chrome and no
+    // traffic lights to leave room for, so the layout must NOT shift. Only the
+    // preload bridge proves we're in the shell — never the user agent.
+    setWindow({});
+    expect(isMacShell()).toBe(false);
+    expect(inShell()).toBe(false);
+  });
+
+  it("is false in the shell on other platforms", () => {
+    setWindow({ mfshell: { platform: "win32" } });
+    expect(isMacShell()).toBe(false);
+    expect(inShell()).toBe(true);
+    setWindow({ mfshell: { platform: "linux" } });
+    expect(isMacShell()).toBe(false);
+  });
+
+  it("survives a missing window entirely", () => {
+    setWindow(undefined);
+    expect(isMacShell()).toBe(false);
+    expect(inShell()).toBe(false);
+  });
+
+  it("counts a bridge with no platform as the shell, but not as a Mac", () => {
+    // inShell() asks "is the preload bridge here", isMacShell() asks a strictly
+    // narrower question — an unexpected/absent platform must not answer yes.
+    setWindow({ mfshell: {} });
+    expect(inShell()).toBe(true);
+    expect(isMacShell()).toBe(false);
+  });
+});
+
+describe("hasNativeWindowControls", () => {
+  it("is true only when the shell says it uses a native title bar", () => {
+    setWindow({ mfshell: { platform: "darwin", nativeTitleBar: true } });
+    expect(hasNativeWindowControls()).toBe(true);
+  });
+
+  it("is false on a mac shell built BEFORE the traffic-light move", () => {
+    // The version-skew case that matters: the engine (this frontend) updates
+    // independently of the desktop app. An older shell still injects its own
+    // – □ ✕ top-right, so mirroring the cluster there would stack them.
+    setWindow({ mfshell: { platform: "darwin" } });
+    expect(isMacShell()).toBe(true); // it IS a mac shell...
+    expect(hasNativeWindowControls()).toBe(false); // ...but keeps its own layout
+  });
+
+  it("is false on Windows/Linux shells and in a browser", () => {
+    setWindow({ mfshell: { platform: "win32", nativeTitleBar: false } });
+    expect(hasNativeWindowControls()).toBe(false);
+    setWindow({});
+    expect(hasNativeWindowControls()).toBe(false);
+    setWindow(undefined);
+    expect(hasNativeWindowControls()).toBe(false);
+  });
+
+  it("demands a real boolean — a truthy string or 1 doesn't move the layout", () => {
+    // The check is `=== true` on purpose. This flag decides where the window
+    // controls are; a sloppy future bridge value must fail closed, keeping the
+    // layout the shell actually draws rather than guessing from truthiness.
+    for (const value of ["true", 1, {}, "darwin"]) {
+      setWindow({ mfshell: { platform: "darwin", nativeTitleBar: value } });
+      expect(hasNativeWindowControls()).toBe(false);
+    }
+  });
+});
+
+describe("onFullScreenChanged", () => {
+  it("subscribes through the shell bridge and returns its unsubscribe", () => {
+    const off = vi.fn();
+    const sub = vi.fn(() => off);
+    setWindow({ mfshell: { platform: "darwin" }, winctl: { onFullScreenChanged: sub } });
+    const unsub = onFullScreenChanged(() => {});
+    expect(sub).toHaveBeenCalledOnce();
+    unsub();
+    expect(off).toHaveBeenCalledOnce();
+  });
+
+  it("forwards the fullscreen payload verbatim", () => {
+    // The top bar keys `data-mac-lights` off this value, so true/false have to
+    // arrive unchanged and in order — not coerced, not swallowed.
+    let fire!: (isFull: boolean) => void;
+    setWindow({
+      winctl: {
+        onFullScreenChanged: (cb: (isFull: boolean) => void) => {
+          fire = cb;
+          return () => {};
+        },
+      },
+    });
+    const seen: boolean[] = [];
+    onFullScreenChanged((isFull) => seen.push(isFull));
+    fire(true);
+    fire(false);
+    expect(seen).toEqual([true, false]);
+  });
+
+  it("returns a callable no-op when the bridge predates the method", () => {
+    // An older shell build has no onFullScreenChanged; the effect cleanup still
+    // has to be safe to call.
+    setWindow({ mfshell: { platform: "darwin" }, winctl: {} });
+    expect(() => onFullScreenChanged(() => {})()).not.toThrow();
+    setWindow({});
+    expect(() => onFullScreenChanged(() => {})()).not.toThrow();
+  });
+
+  it("tolerates a bridge that returns nothing from subscribe", () => {
+    setWindow({ winctl: { onFullScreenChanged: () => undefined } });
+    expect(() => onFullScreenChanged(() => {})()).not.toThrow();
+  });
+
+  it("tolerates a bridge that returns a non-function from subscribe", () => {
+    // React calls whatever the effect returns; a bridge handing back a number
+    // or an object must not turn unmount into a TypeError.
+    for (const value of [42, {}, null, "off"]) {
+      setWindow({ winctl: { onFullScreenChanged: () => value } });
+      expect(() => onFullScreenChanged(() => {})()).not.toThrow();
+    }
+  });
+
+  it("returns a callable no-op with no window at all", () => {
+    setWindow(undefined);
+    expect(() => onFullScreenChanged(() => {})()).not.toThrow();
+  });
+});
+
+describe("isFullScreen", () => {
+  it("reports the shell's current state", async () => {
+    setWindow({ winctl: { isFullScreen: () => Promise.resolve(true) } });
+    expect(await isFullScreen()).toBe(true);
+  });
+
+  it("is false in a browser, on an older shell, and when the IPC rejects", async () => {
+    // The initial-paint query must never be what breaks the top bar: without a
+    // bridge, without the method, or on a rejected invoke, assume windowed.
+    setWindow({});
+    expect(await isFullScreen()).toBe(false);
+    setWindow({ winctl: {} });
+    expect(await isFullScreen()).toBe(false);
+    setWindow({ winctl: { isFullScreen: () => Promise.reject(new Error("no window")) } });
+    expect(await isFullScreen()).toBe(false);
+    setWindow(undefined);
+    expect(await isFullScreen()).toBe(false);
+  });
+
+  it("demands a real true — a truthy resolve doesn't count", async () => {
+    setWindow({ winctl: { isFullScreen: () => Promise.resolve("yes" as unknown as boolean) } });
+    expect(await isFullScreen()).toBe(false);
+  });
+});

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -83,6 +83,10 @@ export interface Instance {
   /** Present on rows proxied from another tailnet device (title is
    * "<device>::<title>"). */
   device?: string;
+  /** True for a force-started PR/issue/ticket the server has accepted but
+   * whose session does not exist yet (it is still cloning). The row shows as
+   * provisioning; there is nothing to act on until it becomes real. */
+  pending?: boolean;
 }
 
 export interface Caps {

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -53,6 +53,34 @@ body #mf-winctl {
   gap: 6px;
 }
 
+/* --- macOS layout ---------------------------------------------------------- */
+/* The desktop shell keeps the NATIVE traffic lights top-left there
+   (electron/main.js `titleBarStyle: 'hidden'`), because a Mac user reads
+   red/yellow/green in that corner as "the window controls" — ours on the right
+   was the Windows arrangement on the wrong OS. Two consequences here:
+
+     1. leave room for them, so the menu doesn't start underneath;
+     2. mirror our own cluster (logo / theme / bell) to the right, which on a Mac
+        is otherwise empty — the shell draws no – □ ✕ there.
+
+   The gap is keyed on `data-mac-lights`, not `data-mac`: macOS hides the lights
+   in fullscreen, and the shell tells the UI so (electron `fullscreen-changed`)
+   rather than leaving a hole no window button occupies. Browser tabs on macOS
+   get NEITHER attribute — they have their own chrome and no lights to dodge. */
+#topbar[data-mac-lights] {
+  /* 13px light origin + 3 x 12px buttons + 2 x 8px gaps + breathing room. */
+  padding-left: 78px;
+}
+
+#topbar[data-mac] .tb-end {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  /* Sits after the drag handle, so it hugs the right edge; the handle keeps all
+     the flexible width and the brand stays centred between the two zones. */
+  flex: 0 0 auto;
+}
+
 /* Wordmark in normal flow between two equal flex:1 zones (the left cluster+menu
    on one side, the drag region on the other). Equal zones => the brand sits at
    true window center whenever there's room. When the left zone's content is

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,7 +1,13 @@
 /** Top bar (port of the 030 partial + section 17's chrome wiring):
  * sidebar/theme cluster, notifications bell, the main menu (New / Recent
  * dropdown / Prompts / Command / Settings), centered wordmark, and the
- * Electron drag region. */
+ * Electron drag region.
+ *
+ * On macOS the whole thing mirrors: the window shows the native traffic lights
+ * top-left (electron/main.js `titleBarStyle: 'hidden'`), so the bar leaves room
+ * for them and moves the logo / theme / bell cluster to the right — where a Mac
+ * has nothing else, since our own – □ ✕ aren't drawn there. Same elements, same
+ * behaviour, mirrored placement. */
 
 import { useEffect, useRef, useState } from "react";
 import { useUi } from "../state/store";
@@ -9,6 +15,7 @@ import { rethemeAll } from "../lib/terminals";
 import { NotificationsBell } from "./NotificationsBell";
 import { redrawFavicon } from "./EventToasts";
 import { api } from "../api/client";
+import { hasNativeWindowControls, isFullScreen, onFullScreenChanged } from "../lib/shell";
 
 function applyTheme(light: boolean) {
   document.documentElement.classList.toggle("light", light);
@@ -29,6 +36,25 @@ export function TopBar() {
   const [recentOpen, setRecentOpen] = useState(false);
   const [version, setVersion] = useState(engineVersion);
   const dropRef = useRef<HTMLDivElement | null>(null);
+  // Evaluated once: the shell can't grow or lose its title bar mid-run.
+  const [mac] = useState(hasNativeWindowControls);
+  // macOS hides the traffic lights in fullscreen — stop reserving their room.
+  const [fullScreen, setFullScreen] = useState(false);
+
+  useEffect(() => {
+    if (!mac) return;
+    // Ask for the current state (a window already fullscreen at load never gets
+    // a transition), then follow changes.
+    let live = true;
+    void isFullScreen().then((f) => {
+      if (live) setFullScreen(f);
+    });
+    const off = onFullScreenChanged(setFullScreen);
+    return () => {
+      live = false;
+      off();
+    };
+  }, [mac]);
 
   useEffect(() => {
     if (engineVersion) return; // already known this page load
@@ -78,11 +104,42 @@ export function TopBar() {
     redrawFavicon(); // the tab favicon inverts with the theme
   };
 
+  // The cluster that swaps sides on macOS. Defined once and rendered in exactly
+  // one place, so the two layouts can't drift apart.
+  const logo = <span id="brand-logo" aria-hidden="true" />;
+  const themeToggle = (
+    <button
+      id="theme-btn"
+      type="button"
+      title={light ? "Switch to dark mode" : "Switch to light mode"}
+      aria-label="Toggle light / dark mode"
+      onClick={toggleTheme}
+    >
+      {/* Monochrome, not ☀️/🌙: an emoji glyph paints its own colors, and a
+          yellow moon on a yellow top bar (Goldfinch, Toucan) vanishes.
+          currentColor follows --text, which regions.css rebinds per region,
+          so these stay legible on a bar of any hue. */}
+      <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">
+        {light ? (
+          <g fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <circle cx="12" cy="12" r="4.2" />
+            <path d="M12 2.5v2.4M12 19.1v2.4M2.5 12h2.4M19.1 12h2.4M5.3 5.3l1.7 1.7M17 17l1.7 1.7M18.7 5.3L17 7M7 17l-1.7 1.7" />
+          </g>
+        ) : (
+          <path
+            fill="currentColor"
+            d="M20.2 14.6A8.6 8.6 0 0 1 9.4 3.8a8.6 8.6 0 1 0 10.8 10.8z"
+          />
+        )}
+      </svg>
+    </button>
+  );
+
   return (
-    <div id="topbar">
+    <div id="topbar" data-mac={mac ? "" : undefined} data-mac-lights={mac && !fullScreen ? "" : undefined}>
       <div className="tb-start">
         <div className="tb-left">
-          <span id="brand-logo" aria-hidden="true" />
+          {!mac && logo}
           <button
             id="sidebar-toggle"
             type="button"
@@ -103,32 +160,8 @@ export function TopBar() {
               <line x1="9" y1="4" x2="9" y2="20" />
             </svg>
           </button>
-          <button
-            id="theme-btn"
-            type="button"
-            title={light ? "Switch to dark mode" : "Switch to light mode"}
-            aria-label="Toggle light / dark mode"
-            onClick={toggleTheme}
-          >
-            {/* Monochrome, not ☀️/🌙: an emoji glyph paints its own colors, and a
-                yellow moon on a yellow top bar (Goldfinch, Toucan) vanishes.
-                currentColor follows --text, which regions.css rebinds per region,
-                so these stay legible on a bar of any hue. */}
-            <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">
-              {light ? (
-                <g fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <circle cx="12" cy="12" r="4.2" />
-                  <path d="M12 2.5v2.4M12 19.1v2.4M2.5 12h2.4M19.1 12h2.4M5.3 5.3l1.7 1.7M17 17l1.7 1.7M18.7 5.3L17 7M7 17l-1.7 1.7" />
-                </g>
-              ) : (
-                <path
-                  fill="currentColor"
-                  d="M20.2 14.6A8.6 8.6 0 0 1 9.4 3.8a8.6 8.6 0 1 0 10.8 10.8z"
-                />
-              )}
-            </svg>
-          </button>
-          <NotificationsBell />
+          {!mac && themeToggle}
+          {!mac && <NotificationsBell />}
         </div>
         <nav className="tb-menu" aria-label="Main actions">
           <button
@@ -223,6 +256,15 @@ export function TopBar() {
         {version && <span className="tb-version">v{version}</span>}
       </span>
       <div className="tb-drag" />
+      {/* macOS: the mirror of .tb-left. Ordered so the logo anchors the far
+          corner, the way it does on the left everywhere else. */}
+      {mac && (
+        <div className="tb-end">
+          <NotificationsBell />
+          {themeToggle}
+          {logo}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/settings/screens/GitIssues.tsx
+++ b/frontend/src/components/settings/screens/GitIssues.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../../api/client";
 import { toast } from "../../../lib/toast";
-import { usePanelQuery } from "../../../state/queries";
+import { refreshInstances, usePanelQuery } from "../../../state/queries";
 import { SettingField, useSettings } from "../useSettings";
 import type { ScreenProps } from "../SettingsDialog";
 
@@ -377,10 +377,11 @@ function OpenIssueRow({ i, onStarted }: { i: OpenIssue; onStarted(): void }) {
               const r = await api<{ title?: string }>("/api/github/issues/start", {
                 json: { repo: i.repo, number: i.number },
               });
-              toast(
-                "Issue session " + (r?.title || "") + " starting — it will appear in the sidebar shortly"
-              );
+              toast("Issue session " + (r?.title || "") + " — provisioning, see the sidebar");
               setState("started");
+              // The server already has a provisioning row for it: pull it now
+              // instead of leaving the sidebar blank until the next poll.
+              refreshInstances();
               setTimeout(onStarted, 5000);
             } catch (err) {
               toast("Start work failed: " + ((err as Error).message || "error"));

--- a/frontend/src/components/settings/screens/PrReview.tsx
+++ b/frontend/src/components/settings/screens/PrReview.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../../api/client";
 import { toast } from "../../../lib/toast";
-import { usePanelQuery } from "../../../state/queries";
+import { refreshInstances, usePanelQuery } from "../../../state/queries";
 import { SettingField, useSettings } from "../useSettings";
 import type { ScreenProps } from "../SettingsDialog";
 
@@ -399,10 +399,11 @@ function OpenPrRow({ p, onStarted }: { p: OpenPr; onStarted(): void }) {
               const r = await api<{ title?: string }>("/api/github/prs/review", {
                 json: { repo: p.repo, number: p.number },
               });
-              toast(
-                "Review session " + (r?.title || "") + " starting — it will appear in the sidebar shortly"
-              );
+              toast("Review session " + (r?.title || "") + " — provisioning, see the sidebar");
               setState("started");
+              // The server already has a provisioning row for it: pull it now
+              // instead of leaving the sidebar blank through the PR clone.
+              refreshInstances();
               setTimeout(onStarted, 5000);
             } catch (err) {
               toast("Begin review failed: " + ((err as Error).message || "error"));

--- a/frontend/src/components/settings/screens/Ticketing.tsx
+++ b/frontend/src/components/settings/screens/Ticketing.tsx
@@ -7,7 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../api/client";
-import { refreshConfig, usePanelQuery } from "../../../state/queries";
+import { refreshConfig, refreshInstances, usePanelQuery } from "../../../state/queries";
 import { toast } from "../../../lib/toast";
 import type { ScreenProps } from "../SettingsDialog";
 
@@ -600,11 +600,11 @@ function AssignedTicketRow({ t, onStarted }: { t: AssignedTicket; onStarted(): v
               const r = await api<{ title?: string }>("/api/tickets/start", {
                 json: { source: t.source, id: t.id },
               });
-              toast(
-                "Session " + (r?.title || t.slug) +
-                  " starting — it will appear in the sidebar shortly"
-              );
+              toast("Session " + (r?.title || t.slug) + " — provisioning, see the sidebar");
               setState("started");
+              // The server already has a provisioning row for it: pull it now
+              // instead of leaving the sidebar blank until the next poll.
+              refreshInstances();
               setTimeout(onStarted, 5000);
             } catch (err) {
               toast("Begin work failed: " + ((err as Error).message || "error"));

--- a/frontend/src/components/sidebar/AutomationBar.tsx
+++ b/frontend/src/components/sidebar/AutomationBar.tsx
@@ -40,7 +40,10 @@ export function AutomationBar() {
   const { data: status, refetch } = useQuery({
     queryKey: ["mindflock-status"],
     queryFn: () => api<MfStatus>("/api/mindflock/status"),
-    refetchInterval: 10_000,
+    // Matches the sessions poll: the green window can be as short as one
+    // provisioning, and a 10s poll missed those often enough that the light
+    // looked like it never turned green at all.
+    refetchInterval: 4_000,
     retry: false,
   });
 
@@ -51,9 +54,11 @@ export function AutomationBar() {
   const running = !!status.running;
   // Old servers don't send `desired` — fall back to the live state.
   const desired = optimistic ?? (status.desired ?? running);
-  // Green only while a ticket is actually being handled; a running-but-idle
-  // pipeline "waits" (gold) for the next ticket to come in.
-  const active = running && !!status.tickets_active;
+  // Green while a ticket is actually being brought in — by the pipeline OR by a
+  // start forced from Settings → Ticketing (the server folds both into
+  // tickets_active). NOT gated on `running`: a forced ticket provisions with
+  // the pipeline stopped, and gold would be a lie about it.
+  const active = !!status.tickets_active;
   const starting = desired && !running;
   const netIssue = !online || !!status.net_error;
 
@@ -81,20 +86,23 @@ export function AutomationBar() {
       <span
         id="mindflock-dot"
         className={
+          // `active` outranks the switch: a ticket forced from Settings is
+          // genuinely being brought in even with auto ingestion switched off,
+          // and "off" would be a lie about the work in flight.
           "dc-dot " +
-          (netIssue ? "error" : !desired ? "off" : active ? "on" : "idle")
+          (netIssue ? "error" : active ? "on" : !desired ? "off" : "idle")
         }
         title={
-          netIssue
-            ? online
-              ? "Connection issues in the ingestion log — see Settings → System logs"
-              : "No network connection"
-            : starting
-              ? "Set to on but not running yet — starting, or the pipeline exited (flip the switch off and on to restart it)"
-              : active
-                ? "A ticket is being handled right now"
+          active
+            ? "A ticket is being brought in right now (auto ingestion or a forced start)"
+            : netIssue
+              ? online
+                ? "Connection issues in the ingestion log — see Settings → System logs"
+                : "No network connection"
+              : starting
+                ? "Set to on but not running yet — starting, or the pipeline exited (flip the switch off and on to restart it)"
                 : desired
-                  ? "Waiting for an assigned ticket — turns green while one is being handled"
+                  ? "Waiting for an assigned ticket — turns green while one is being brought in"
                   : undefined
         }
       />

--- a/frontend/src/components/sidebar/GitIssueBar.tsx
+++ b/frontend/src/components/sidebar/GitIssueBar.tsx
@@ -36,15 +36,17 @@ export function GitIssueBar() {
     >
       <span
         id="git-issue-dot"
-        className={"dc-dot " + (!on ? "off" : active ? "on" : "idle")}
+        // `active` outranks the switch: an issue forced from Settings is
+        // genuinely in flight even with automated handling switched off.
+        className={"dc-dot " + (active ? "on" : !on ? "off" : "idle")}
         title={
-          on
-            ? starting
-              ? "Switched on — the pipeline is starting"
-              : active
-                ? "An issue is being worked on right now"
+          active
+            ? "An issue is being brought in right now (automated or a forced start)"
+            : on
+              ? starting
+                ? "Switched on — the pipeline is starting"
                 : "Waiting for a newly opened issue — turns green while one is being handled"
-            : undefined
+              : undefined
         }
       />
       <span className="dc-label">Issue Handling</span>

--- a/frontend/src/components/sidebar/PrReviewBar.tsx
+++ b/frontend/src/components/sidebar/PrReviewBar.tsx
@@ -34,15 +34,17 @@ export function PrReviewBar() {
     >
       <span
         id="pr-review-dot"
-        className={"dc-dot " + (!on ? "off" : active ? "on" : "idle")}
+        // `active` outranks the switch: a review forced from Settings is
+        // genuinely in flight even with automated review switched off.
+        className={"dc-dot " + (active ? "on" : !on ? "off" : "idle")}
         title={
-          on
-            ? starting
-              ? "Switched on — the review pipeline is starting"
-              : active
-                ? "A pull request is being reviewed right now"
+          active
+            ? "A pull request is being brought in for review right now (automated or a forced start)"
+            : on
+              ? starting
+                ? "Switched on — the review pipeline is starting"
                 : "Waiting for an open PR with actionable review comments — turns green while one is being handled"
-            : undefined
+              : undefined
         }
       />
       <span className="dc-label">PR Review</span>

--- a/frontend/src/components/sidebar/SidebarRow.css
+++ b/frontend/src/components/sidebar/SidebarRow.css
@@ -148,6 +148,30 @@
   text-overflow: ellipsis;
 }
 
+/* A force-start the server accepted but hasn't turned into a session yet: it
+   carries the provisioning chip like any loading row, dimmed a touch because
+   there is nothing to act on until the clone finishes. */
+.inst.is-pending .title {
+  color: var(--muted);
+}
+
+/* Inline rename (click the selected row): sits exactly where the title text was
+   so the row height never shifts. */
+.inst input.title-edit {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 0 2px;
+  margin: -1px 0;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  outline: none;
+}
+
 .inst .branch {
   font-size: 11px;
   color: var(--muted);

--- a/frontend/src/components/sidebar/SidebarRow.tsx
+++ b/frontend/src/components/sidebar/SidebarRow.tsx
@@ -4,6 +4,8 @@
 import {
   memo,
   useCallback,
+  useEffect,
+  useRef,
   useState,
   useSyncExternalStore,
   type DragEvent,
@@ -16,6 +18,7 @@ import { useUi } from "../../state/store";
 import { copyText } from "../../lib/clipboard";
 import { errMsg } from "../../lib/format";
 import { chipState, checkChip } from "../../lib/stage";
+import { sessionLabel } from "../../lib/sessionLabel";
 import {
   cleanupMissing,
   commitSession,
@@ -31,6 +34,11 @@ import {
 } from "../../lib/sessionActions";
 import { toast } from "../../lib/toast";
 import { peekTerm, subscribeTermStates } from "../../lib/terminals";
+
+/** How long a click on the selected row waits for a second click before it
+ * turns into an inline rename. Under the browser's ~500ms dblclick ceiling,
+ * but long enough that an unhurried double-click still opens the IDE. */
+const DBLCLICK_MS = 300;
 
 function displayTitle(inst: Instance): string {
   return (inst as unknown as { display_title?: string }).display_title || inst.title || "";
@@ -56,21 +64,36 @@ export const SidebarRow = memo(function SidebarRow({
   onDropRow,
 }: Props) {
   const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  // Escape must abandon the edit; unmounting the focused input can still run
+  // the blur handler, so the cancel is flagged rather than inferred.
+  const cancelled = useRef(false);
+  const renameTimer = useRef<number | null>(null);
+  // When a click ends an edit, that same click also reaches the row — without
+  // this the dismiss would immediately re-arm the rename.
+  const editEndedAt = useRef(0);
   const { data: config } = useConfig();
   const focused = useUi((s) => s.focused);
   const hidden = useUi((s) => s.hidden.has(inst.title));
   const alias = useUi((s) => s.aliases[inst.title]);
   const openDialogFor = useUi((s) => s.openDialogFor);
+  const setAlias = useUi((s) => s.setAlias);
 
   const title = inst.title;
   const missing = !!inst.workspace_missing;
   const paused = inst.status === "paused";
+  // A force-start the server has accepted but not yet turned into a session:
+  // it exists only as this row, so nothing on it is actionable yet.
+  const pending = !!inst.pending;
   const caps = config?.caps ?? { git: true, tailscale: true, ticketing: true };
   const ideName = config?.ide_name || "Cursor";
   const chip = chipState(inst);
   const check = checkChip(inst);
   const num = idx < 9 ? String(idx + 1) : "";
-  const shown = alias || displayTitle(inst);
+  // Ticket/PR/issue sessions read as "(tix) add-dark-mode/sc-12345" instead of
+  // the bare slug; a hand-made session's title is passed through unchanged.
+  const label = sessionLabel(displayTitle(inst), inst.branch || "");
+  const shown = alias || label.text;
   const folder = inst.folder || inst.path || "";
   // Subscribed (not a render-time snapshot): the row must clear its red dot
   // the moment the agent socket connects, not on the next instances poll.
@@ -85,18 +108,57 @@ export const SidebarRow = memo(function SidebarRow({
     await fn();
   };
 
+  const clearRenameTimer = () => {
+    if (renameTimer.current !== null) {
+      clearTimeout(renameTimer.current);
+      renameTimer.current = null;
+    }
+  };
+  useEffect(() => clearRenameTimer, []);
+
+  /** Click on the row that's ALREADY selected → edit the name in place. The
+   * second click of a double-click also lands here, so the edit is held for
+   * the double-click window and cancelled by onDoubleClick (open in IDE). */
+  const armRename = () => {
+    clearRenameTimer();
+    renameTimer.current = window.setTimeout(() => {
+      renameTimer.current = null;
+      cancelled.current = false;
+      setEditing(true);
+    }, DBLCLICK_MS);
+  };
+
+  const commitRename = (raw: string) => {
+    setEditing(false);
+    editEndedAt.current = Date.now();
+    if (cancelled.current) {
+      cancelled.current = false;
+      return;
+    }
+    const next = raw.trim();
+    // Blank, or typed back to what the row shows by itself, means "drop the
+    // alias" — that's the default label as well as the raw title.
+    const nextAlias =
+      !next || next === label.text || next === displayTitle(inst) ? "" : next;
+    if (nextAlias === (alias || "")) return;
+    setAlias(title, nextAlias);
+    toast(nextAlias ? `Renamed to “${nextAlias}”` : "Reset to real title");
+  };
+
   const rowCls =
     "inst" +
     (focused === title ? " active" : "") +
     (hidden ? " is-hidden" : "") +
     (missing ? " ws-missing" : "") +
+    (pending ? " is-pending" : "") +
     (dropCue ? ` drop-${dropCue}` : "");
 
   return (
     <li
       className={rowCls}
       data-title={title}
-      draggable
+      // Row drag would hijack text selection inside the rename input.
+      draggable={!editing}
       onDragStart={(ev: DragEvent) => {
         ev.dataTransfer.setData("text/plain", title);
         ev.dataTransfer.effectAllowed = "move";
@@ -133,28 +195,74 @@ export const SidebarRow = memo(function SidebarRow({
     >
       <div
         className="inst-row"
-        onClick={() => selectSession(title)}
+        onClick={() => {
+          if (editing || Date.now() - editEndedAt.current < DBLCLICK_MS + 100) return;
+          if (focused !== title) {
+            selectSession(title);
+            return;
+          }
+          if (!pending) armRename();
+        }}
         onDoubleClick={() => {
-          if (!missing) ideSession(title, true);
+          clearRenameTimer();
+          if (!missing && !pending) ideSession(title, true);
         }}
       >
         <span className="grip" title="Drag to reorder">⠿</span>
         <span className="idx" title={num ? `Ctrl+${num} / Alt+${num} to focus` : ""}>{num}</span>
         <span className={"dot " + inst.status + (disconnected ? " disconnected" : "")} />
-        <button
-          className={"chevron" + (expanded ? " open" : "")}
-          title="Actions"
-          onClick={(e) => act(() => setExpanded((v) => !v), e)}
-        >
-          ›
-        </button>
-        <span className="meta">
-          <span
-            className={"title" + (alias ? " aliased" : "")}
-            title={alias ? `${alias}  ·  ${displayTitle(inst)}` : displayTitle(inst)}
+        {!pending && (
+          <button
+            className={"chevron" + (expanded ? " open" : "")}
+            title="Actions"
+            onClick={(e) => act(() => setExpanded((v) => !v), e)}
           >
-            {shown}
-          </span>
+            ›
+          </button>
+        )}
+        <span className="meta">
+          {editing ? (
+            <input
+              className="title title-edit"
+              type="text"
+              defaultValue={shown}
+              autoFocus
+              autoComplete="off"
+              spellCheck={false}
+              onFocus={(e) => e.currentTarget.select()}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+              onBlur={(e) => commitRename(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commitRename(e.currentTarget.value);
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  cancelled.current = true;
+                  editEndedAt.current = Date.now();
+                  setEditing(false);
+                }
+              }}
+            />
+          ) : (
+            <span
+              className={"title" + (alias ? " aliased" : "")}
+              title={[
+                alias ? `${alias}  ·  ${label.full}` : label.full,
+                // The real title is the identity behind a reformatted label —
+                // it's what every API path and `tmux attach` is keyed by.
+                label.kind ? `session: ${displayTitle(inst)}` : "",
+                inst.branch ? `branch: ${inst.branch}` : "",
+                focused === title ? "Click again to rename" : "",
+              ]
+                .filter(Boolean)
+                .join("\n")}
+            >
+              {shown}
+            </span>
+          )}
         </span>
         <span className={"stagechip " + chip.cls} title={chip.title}>{chip.label}</span>
         {check && (
@@ -162,19 +270,21 @@ export const SidebarRow = memo(function SidebarRow({
             {check.label}
           </span>
         )}
-        <button
-          className={"kill" + (missing ? " cleanup" : "")}
-          title={
-            missing
-              ? "Clean up — workspace is gone; remove this session"
-              : "End session — keeps worktree (Ctrl+W / Del; undo with Ctrl+Shift+T)"
-          }
-          onClick={(e) => act(() => (missing ? cleanupMissing(title) : killSession(title)), e)}
-        >
-          {missing ? "Clean up" : "✕"}
-        </button>
+        {!pending && (
+          <button
+            className={"kill" + (missing ? " cleanup" : "")}
+            title={
+              missing
+                ? "Clean up — workspace is gone; remove this session"
+                : "End session — keeps worktree (Ctrl+W / Del; undo with Ctrl+Shift+T)"
+            }
+            onClick={(e) => act(() => (missing ? cleanupMissing(title) : killSession(title)), e)}
+          >
+            {missing ? "Clean up" : "✕"}
+          </button>
+        )}
       </div>
-      {expanded && (
+      {expanded && !pending && (
         <div className="inst-actions">
           <div className="folder-row">
             <span className="folder-path" title={folder}>{inst.folder_label || folder || "—"}</span>

--- a/frontend/src/components/sidebar/useGithubToggleBar.ts
+++ b/frontend/src/components/sidebar/useGithubToggleBar.ts
@@ -65,11 +65,12 @@ export function useGithubToggleBar(opts: {
     refetchInterval: 30_000,
     retry: false,
   });
-  // Same key as AutomationBar's poll — TanStack dedupes it into one request.
+  // Same key AND interval as AutomationBar's poll — TanStack dedupes it into
+  // one request, and a mismatched interval would make which one wins matter.
   const { data: ingestion } = useQuery({
     queryKey: ["mindflock-status"],
     queryFn: () => api<MfStatus>("/api/mindflock/status"),
-    refetchInterval: 10_000,
+    refetchInterval: 4_000,
     retry: false,
   });
 

--- a/frontend/src/lib/sessionLabel.ts
+++ b/frontend/src/lib/sessionLabel.ts
@@ -1,0 +1,100 @@
+/** Human-readable sidebar labels for sessions that a ticket / PR / issue
+ * created.
+ *
+ * Those sessions are titled by their machine slug — `sc-12345`, `pr-app-42`,
+ * `issue-app-77` — which says nothing about what the work IS. The feature name
+ * is already sitting in the branch (`feature/<slug>/<name>`, or the PR's head
+ * ref), so the label pulls it forward:
+ *
+ *     sc-12345      feature/sc-12345/add-dark-mode   ->  (tix) add-dark-mode/sc-12345
+ *     pr-app-42     fix/login-crash                  ->  (pr) login-crash/app-42
+ *     issue-app-77  feature/issue-app-77/cant-open   ->  (iss) cant-open/app-77
+ *
+ * Titles that no pipeline created are returned untouched — a hand-made
+ * "my-refactor" session has nothing to reformat.
+ *
+ * This is display only. `inst.title` remains the identity every API path,
+ * tmux name and workspace dir is keyed by, so the real title always rides
+ * along in the row's tooltip.
+ */
+
+/** How much of the feature name survives in the row text. The name is the
+ * flexible part and the slug is the identifying part, so a long name is
+ * clipped here rather than being allowed to push the slug into the row's
+ * ellipsis. The tooltip always carries the full thing. */
+const MAX_NAME = 20;
+
+export interface SessionLabel {
+  /** "(tix) add-dark-mode/sc-12345", or the plain title when not a pipeline session. */
+  text: string;
+  /** Same as {@link text} but with the feature name never clipped — for tooltips. */
+  full: string;
+  /** Kind tag without parens ("tix" | "pr" | "iss"), or "" for plain sessions. */
+  kind: string;
+  /** Feature name, un-clipped ("add-dark-mode"), or "" when none was derivable. */
+  name: string;
+  /** Identifying slug ("sc-12345", "app-42"). */
+  slug: string;
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** The `<name>` of a `feature/<slug>/<name>` branch, else "". */
+function featureBranchName(branch: string, slug: string): string {
+  const m = new RegExp(`^feature/${escapeRe(slug)}/(.+)$`).exec(branch);
+  return m ? m[1] : "";
+}
+
+/** Last path segment of a branch ref — a PR's `fix/login-crash` reads as
+ * "login-crash". */
+function branchTail(branch: string): string {
+  const parts = branch.split("/").filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : "";
+}
+
+function clip(name: string): string {
+  return name.length > MAX_NAME ? name.slice(0, MAX_NAME - 1) + "…" : name;
+}
+
+/** Split a session title into its kind tag and identifying slug. */
+function splitKind(title: string): { kind: string; slug: string } | null {
+  if (title.startsWith("pr-")) return { kind: "pr", slug: title.slice(3) };
+  if (title.startsWith("issue-")) return { kind: "iss", slug: title.slice(6) };
+  return null;
+}
+
+/**
+ * @param title  The session's own title (already device-stripped — pass
+ *               `display_title` for a proxied row, not "<device>::<title>").
+ * @param branch The session's branch, which is where the feature name lives.
+ */
+export function sessionLabel(title: string, branch: string): SessionLabel {
+  const plain: SessionLabel = { text: title, full: title, kind: "", name: "", slug: title };
+  if (!title) return plain;
+
+  const split = splitKind(title);
+  // A ticket session is titled by its provider slug with no kind prefix of its
+  // own; the branch it owns (feature/<title>/…) is what identifies it as one.
+  const ticketName = split ? "" : featureBranchName(branch, title);
+  if (!split && !ticketName) return plain;
+
+  const kind = split ? split.kind : "tix";
+  const slug = split ? split.slug : title;
+  if (!slug) return plain;
+
+  // PR/issue sessions: the feature name comes from the branch under their own
+  // slug when the pipeline made one, else from the PR's head ref.
+  const name = split ? featureBranchName(branch, title) || branchTail(branch) : ticketName;
+  // A branch that just restates the slug adds nothing worth the row width.
+  const useName = name && name !== slug && name !== title ? name : "";
+
+  return {
+    text: useName ? `(${kind}) ${clip(useName)}/${slug}` : `(${kind}) ${slug}`,
+    full: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
+    kind,
+    name: useName,
+    slug,
+  };
+}

--- a/frontend/src/lib/shell.ts
+++ b/frontend/src/lib/shell.ts
@@ -1,0 +1,77 @@
+/** What the surrounding desktop shell is, for the few places the UI has to
+ * match a platform convention rather than pick its own.
+ *
+ * Only the Electron shell counts. A Mac user viewing the web UI in Safari has a
+ * browser chrome of its own and no traffic lights to make room for, so the
+ * layout must not shift for them — hence every check here goes through the
+ * preload bridge, never a Mac-looking user agent.
+ */
+
+interface ShellBridge {
+  dev?: boolean;
+  platform?: string;
+  /** The OS draws this window's controls, top-left (macOS traffic lights). */
+  nativeTitleBar?: boolean;
+}
+
+interface WinCtl {
+  isFullScreen?: () => Promise<boolean>;
+  onFullScreenChanged?: (cb: (isFull: boolean) => void) => (() => void) | void;
+}
+
+function winctl(): WinCtl | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { winctl?: WinCtl }).winctl;
+}
+
+/** Whether the shell window is fullscreen right now; false in a browser or on a
+ * shell build without the query. The transition event only fires on a CHANGE, so
+ * a window that is already fullscreen when the UI loads needs this. */
+export async function isFullScreen(): Promise<boolean> {
+  try {
+    return (await winctl()?.isFullScreen?.()) === true;
+  } catch {
+    return false; // an IPC that rejects means "assume windowed", never a crash
+  }
+}
+
+/** The preload bridge, or undefined — including when there is no `window` at
+ * all, so these are safe to call from any context. */
+function bridge(): ShellBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { mfshell?: ShellBridge }).mfshell;
+}
+
+/** True inside the desktop shell (any OS); false in a plain browser. */
+export function inShell(): boolean {
+  return !!bridge();
+}
+
+/** True inside the desktop shell on macOS. Prefer
+ * {@link hasNativeWindowControls} for layout decisions — see its note. */
+export function isMacShell(): boolean {
+  return bridge()?.platform === "darwin";
+}
+
+/**
+ * True when the window's controls are drawn by the OS in the TOP-LEFT corner,
+ * so the top bar must leave room for them and mirror its own cluster right.
+ *
+ * Deliberately the shell's own capability flag rather than
+ * `platform === "darwin"`: the frontend ships inside the engine and the shell
+ * ships as the desktop app, on separate release cadences. A shell built before
+ * this change still injects its own controls top-right on a Mac, and a
+ * platform-keyed layout would stack the logo/theme/bell on top of them. The
+ * flag is absent there, so that build keeps the layout it was built for.
+ */
+export function hasNativeWindowControls(): boolean {
+  return bridge()?.nativeTitleBar === true;
+}
+
+/** Subscribe to shell fullscreen changes; returns an unsubscribe (no-op in a
+ * browser, or on a shell build without the bridge method). macOS hides the
+ * traffic lights in fullscreen, so the reserved gap has to collapse. */
+export function onFullScreenChanged(cb: (isFull: boolean) => void): () => void {
+  const off = winctl()?.onFullScreenChanged?.(cb);
+  return typeof off === "function" ? off : () => {};
+}

--- a/tests/unit/test_claude_usage_api.py
+++ b/tests/unit/test_claude_usage_api.py
@@ -283,3 +283,76 @@ def test_live_usage_fetch_runs_without_holding_lock(monkeypatch):
 
     monkeypatch.setattr(api, "_fetch", _f)
     assert api.live_usage() == {"percent_used": 1.0}
+
+
+# --- macOS credentials (Keychain) ------------------------------------------- #
+# Claude Code stores its OAuth credentials in the login Keychain on macOS, not
+# in ~/.claude/.credentials.json. Without the fallback below, live plan usage
+# was permanently dark on every Mac: no token -> no live reading -> the UI fell
+# back to the transcript estimate, which shows a reset countdown but no
+# percentage unless a window budget happens to be configured.
+
+
+def _no_creds_file(monkeypatch, tmp_path):
+    """Point the file path at an empty dir so only the keychain can answer."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+
+def test_token_falls_back_to_the_macos_keychain(monkeypatch, tmp_path):
+    _no_creds_file(monkeypatch, tmp_path)
+    monkeypatch.setattr(api.sys, "platform", "darwin")
+    blob = json.dumps({"claudeAiOauth": {"accessToken": "kc-tok"}}).encode()
+
+    def _run(argv, **kw):
+        assert argv[:2] == ["security", "find-generic-password"]
+        assert api._KEYCHAIN_SERVICE in argv
+        assert kw.get("timeout") == api._KEYCHAIN_TIMEOUT  # can't hang on a prompt
+        return api.subprocess.CompletedProcess(argv, 0, stdout=blob)
+
+    monkeypatch.setattr(api.subprocess, "run", _run)
+    assert api._token() == "kc-tok"
+
+
+def test_keychain_is_not_consulted_off_macos(monkeypatch, tmp_path):
+    _no_creds_file(monkeypatch, tmp_path)
+    monkeypatch.setattr(api.sys, "platform", "linux")
+
+    def _boom(*a, **k):
+        raise AssertionError("must not shell out to `security` off macOS")
+
+    monkeypatch.setattr(api.subprocess, "run", _boom)
+    assert api._token() is None
+
+
+def test_keychain_denial_is_not_an_error(monkeypatch, tmp_path):
+    """A denied prompt / missing item / no `security` binary means "no live
+    data", exactly as before — never a raise."""
+    _no_creds_file(monkeypatch, tmp_path)
+    monkeypatch.setattr(api.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        api.subprocess,
+        "run",
+        lambda argv, **kw: api.subprocess.CompletedProcess(argv, 1, stdout=b""),
+    )
+    assert api._token() is None
+
+    def _timeout(*a, **k):
+        raise api.subprocess.TimeoutExpired("security", 5)
+
+    monkeypatch.setattr(api.subprocess, "run", _timeout)
+    assert api._token() is None
+
+
+def test_credentials_file_wins_when_present(monkeypatch, tmp_path):
+    """The file is authoritative where it exists — no keychain prompt at all."""
+    (tmp_path / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": "file-tok"}})
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(api.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        api.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("keychain consulted")),
+    )
+    assert api._token() == "file-tok"

--- a/tests/unit/test_config_wire.py
+++ b/tests/unit/test_config_wire.py
@@ -133,10 +133,20 @@ class TestDefaultConfig:
         assert cfg.auto_yes is False
         assert cfg.daemon_poll_interval == 1000
 
-    def test_uses_resolved_claude_command(self, monkeypatch):
-        monkeypatch.setattr(C, "GetClaudeCommand", lambda: "/usr/local/bin/claude")
-        cfg = C.DefaultConfig()
-        assert cfg.default_program == "/usr/local/bin/claude"
+    def test_resolved_claude_path_is_stored_as_the_provider_name(self, monkeypatch):
+        """GetClaudeCommand reports `which` output (an absolute path). Storing
+        that verbatim leaked the install location into the New Session dialog,
+        which lists any program it doesn't recognise as an extra agent entry —
+        a Homebrew Mac grew a "/opt/homebrew/bin/claude" item above the real
+        agents on its first run."""
+        monkeypatch.setattr(C, "GetClaudeCommand", lambda: "/opt/homebrew/bin/claude")
+        assert C.DefaultConfig().default_program == "claude"
+
+    def test_a_path_no_provider_claims_is_kept_verbatim(self, monkeypatch):
+        """For a custom agent the exact string IS the launch command, so it must
+        survive untouched."""
+        monkeypatch.setattr(C, "GetClaudeCommand", lambda: "/opt/bin/my-own-agent")
+        assert C.DefaultConfig().default_program == "/opt/bin/my-own-agent"
 
 
 class TestDefaultBranchPrefix:

--- a/tests/unit/test_mac_titlebar.py
+++ b/tests/unit/test_mac_titlebar.py
@@ -1,0 +1,308 @@
+"""macOS window chrome: native traffic lights + the mirrored top-bar cluster.
+
+The window chrome became platform-conditional here for the first time. Three
+surfaces have to agree, and they ship on *separate* release cadences (the shell
+is the desktop app, the frontend rides the engine), so each side is pinned:
+
+- ``electron/main.js`` — ``titleBarStyle: 'hidden'`` + ``trafficLightPosition``
+  on darwin instead of ``frame: false``, TITLEBAR_JS skipping its own – □ ✕
+  there, and the new ``fullscreen-changed`` push.
+- ``electron/preload.js`` — the ``mfshell.nativeTitleBar`` capability flag and
+  ``winctl.onFullScreenChanged``, which (unlike ``onMaximizedChanged``) returns
+  an unsubscribe the React effect depends on.
+- the built bundle in ``backend/web/static/`` — same structural style as
+  test_frontend_*.py, which is also what proves ``npm run build`` was re-run
+  after the TSX/CSS edit.
+
+The live layout is verified with screenshots; these pin the wiring and the
+literal strings the three sides share so they can't silently drift apart.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.web import server
+
+client = TestClient(server.app)
+
+_REPO = Path(__file__).resolve().parents[2]
+_MAIN_JS = _REPO / "electron" / "main.js"
+_PRELOAD_JS = _REPO / "electron" / "preload.js"
+_TOPBAR_TSX = _REPO / "frontend" / "src" / "components" / "TopBar.tsx"
+_TOPBAR_CSS = _REPO / "frontend" / "src" / "components" / "TopBar.css"
+_SHELL_TS = _REPO / "frontend" / "src" / "lib" / "shell.ts"
+
+# The channel the shell pushes fullscreen state on. Asserted from BOTH sides
+# below: a literal-string mismatch between main.js and preload.js fails
+# silently at runtime (the listener simply never fires).
+_FULLSCREEN_CHANNEL = "fullscreen-changed"
+
+
+def _src(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _decommented(path: Path) -> str:
+    """Source with ``//`` line comments dropped.
+
+    Several of these files *explain* the rejected alternative in prose right
+    above the code (main.js talks about ``frame:false`` on macOS in the comment
+    that justifies not using it), so "appears only in the else branch" style
+    assertions have to look at code alone.
+    """
+    return "\n".join(
+        re.sub(r"(^|\s)//.*$", "", line) for line in _src(path).splitlines()
+    )
+
+
+def _css_block(css: str, selector: str) -> str:
+    """The declarations inside ``selector { … }``, or "" when absent."""
+    i = css.find(selector + " {")
+    if i < 0:
+        return ""
+    return css[i + len(selector) + 2 :].split("}")[0]
+
+
+# --------------------------------------------------------------------------- #
+# electron/main.js — BrowserWindow chrome is platform-conditional.
+# --------------------------------------------------------------------------- #
+
+
+def test_main_js_uses_native_traffic_lights_on_darwin_only():
+    """darwin keeps the REAL red/yellow/green top-left; every other platform
+    keeps the frameless window the injected – □ ✕ cluster is drawn into."""
+    code = _decommented(_MAIN_JS)
+    # One spread ternary carries both arms, so the two can't drift.
+    assert "process.platform === 'darwin'" in code
+    m = re.search(
+        r"\.\.\.\(process\.platform === 'darwin'\s*\?\s*(\{[^}]*\{[^}]*\}[^}]*\})"
+        r"\s*:\s*(\{[^}]*\})\)",
+        code,
+    )
+    assert m, "BrowserWindow options no longer branch on platform for the chrome"
+    darwin, other = m.group(1), m.group(2)
+    assert "titleBarStyle: 'hidden'" in darwin
+    assert "trafficLightPosition" in darwin
+    assert re.search(r"x:\s*13", darwin) and re.search(r"y:\s*13", darwin)
+    # `frame: false` on macOS would remove the traffic lights too — the whole
+    # point of the branch. It belongs to the non-darwin arm and nowhere else.
+    assert "frame: false" in other
+    assert "frame:" not in darwin
+    assert code.count("frame: false") == 1
+
+
+def test_titlebar_js_skips_its_own_controls_on_darwin():
+    """The injected cluster must bail BEFORE creating #mf-winctl, else a Mac
+    window carries two sets of window controls."""
+    js = _src(_MAIN_JS)
+    body = js.split("const TITLEBAR_JS = `")[1].split("`\n")[0]
+    # Interpolated at build time from the shell's own platform (the string is
+    # evaluated in the renderer, which can't see process.platform).
+    guard = "if (${process.platform === 'darwin'}) return;"
+    assert guard in body
+    assert body.index(guard) < body.index(
+        "'mf-winctl'"
+    ), "the darwin early return must precede any #mf-winctl creation"
+
+
+def test_main_js_pushes_fullscreen_state_on_both_transitions():
+    """macOS hides the traffic lights in fullscreen, so the bar has to give the
+    reserved 78px back — both directions, guarded like sendMax."""
+    code = _decommented(_MAIN_JS)
+    m = re.search(r"const sendFullScreen = \(\) => \{(.*?)\n  \}", code, re.S)
+    assert m, "sendFullScreen sender is gone"
+    sender = m.group(1)
+    # Same destroyed-webContents guard as the older sendMax: the events can
+    # arrive while the window is tearing down.
+    assert "win && !win.webContents.isDestroyed()" in sender
+    assert f"win.webContents.send('{_FULLSCREEN_CHANNEL}'" in sender
+    assert "win.isFullScreen()" in sender
+    for event in ("enter-full-screen", "leave-full-screen"):
+        assert f"win.on('{event}', sendFullScreen)" in code, event
+
+
+def test_fullscreen_channel_name_matches_on_both_sides_of_the_bridge():
+    """A typo here fails silently — the renderer just never hears about it."""
+    assert f"send('{_FULLSCREEN_CHANNEL}'" in _src(_MAIN_JS)
+    preload = _src(_PRELOAD_JS)
+    assert f"ipcRenderer.on('{_FULLSCREEN_CHANNEL}'" in preload
+    assert f"removeListener('{_FULLSCREEN_CHANNEL}'" in preload
+
+
+# --------------------------------------------------------------------------- #
+# electron/preload.js — the capability flag + an unsubscribing listener.
+# --------------------------------------------------------------------------- #
+
+
+def test_preload_exposes_native_title_bar_capability_flag():
+    """A capability flag, not a platform check, is what the frontend gates on:
+    an OLDER mac shell still draws its own – □ ✕ top-right, and must keep the
+    layout it was built for (see frontend/src/lib/shell.ts)."""
+    code = _decommented(_PRELOAD_JS)
+    mfshell = code.split("exposeInMainWorld('mfshell'")[1].split("exposeInMainWorld")[0]
+    assert "nativeTitleBar: process.platform === 'darwin'" in mfshell
+    # platform stays exposed too — shell.ts's isMacShell() reads it.
+    assert "platform: process.platform" in mfshell
+
+
+def test_preload_fullscreen_listener_lives_on_winctl_and_unsubscribes():
+    """frontend/src/lib/shell.ts looks the method up on ``window.winctl`` and
+    uses its return value as the React effect's cleanup, so both the placement
+    and the returned closure are contract."""
+    code = _decommented(_PRELOAD_JS)
+    winctl = code.split("exposeInMainWorld('winctl'")[1]
+    assert "onFullScreenChanged:" in winctl
+    # Not on mfshell — that's the capability/info bridge.
+    mfshell = code.split("exposeInMainWorld('mfshell'")[1].split("exposeInMainWorld")[0]
+    assert "onFullScreenChanged" not in mfshell
+
+    m = re.search(r"onFullScreenChanged: \(cb\) => \{(.*?)\n  \}", winctl, re.S)
+    assert m, "onFullScreenChanged is no longer a block-bodied subscriber"
+    body = m.group(1)
+    # The handler is hoisted to a named const and the SAME reference is removed,
+    # so repeated mount/unmount cycles can't leak IPC listeners. A
+    # removeAllListeners would also tear down any other subscriber.
+    assert re.search(r"const (\w+) = \(_e, isFull\) => cb\(isFull\)", body)
+    handler = re.search(r"const (\w+) = \(_e, isFull\) => cb\(isFull\)", body).group(1)
+    assert f"ipcRenderer.on('{_FULLSCREEN_CHANNEL}', {handler})" in body
+    assert (
+        f"return () => ipcRenderer.removeListener('{_FULLSCREEN_CHANNEL}', {handler})"
+        in body
+    )
+    assert "removeAllListeners" not in body
+
+
+# --------------------------------------------------------------------------- #
+# frontend/src/lib/shell.ts — bridge-gated, never user-agent-gated.
+# --------------------------------------------------------------------------- #
+
+
+def test_shell_ts_gates_on_the_bridge_not_the_user_agent():
+    """A Mac user in Safari has browser chrome of its own and no traffic lights
+    to dodge, so the layout must not shift for them."""
+    ts = _src(_SHELL_TS)
+    # Every check reads the preload bridge off `window` (typed through a cast,
+    # hence no bare `window.mfshell` literal).
+    assert "mfshell?: ShellBridge }).mfshell" in ts
+    assert "winctl?: WinCtl }).winctl" in ts
+    for forbidden in ("navigator", "userAgent", "Macintosh", "MacIntel"):
+        assert forbidden not in ts, forbidden
+    # Strict === true: a sloppy future bridge value ("true", 1) must not move
+    # the layout.
+    assert "nativeTitleBar === true" in ts
+    # The subscribe result is only trusted when it really is callable.
+    assert 'typeof off === "function" ? off : () => {}' in ts
+
+
+# --------------------------------------------------------------------------- #
+# TopBar.tsx — one cluster definition, two placements.
+# --------------------------------------------------------------------------- #
+
+
+def test_topbar_marks_the_mac_layout_with_two_separate_attributes():
+    """``data-mac`` (mirrored layout) and ``data-mac-lights`` (reserve room for
+    the lights) are deliberately distinct: fullscreen drops the second only."""
+    tsx = _src(_TOPBAR_TSX)
+    assert 'data-mac={mac ? "" : undefined}' in tsx
+    assert 'data-mac-lights={mac && !fullScreen ? "" : undefined}' in tsx
+    # The capability flag decides, evaluated once — a window can't grow or lose
+    # its title bar mid-run.
+    assert "useState(hasNativeWindowControls)" in tsx
+
+
+def test_topbar_tracks_fullscreen_only_in_a_native_title_bar_shell():
+    """The fullscreen effect is gated on the capability flag (a non-mac renderer
+    registers no IPC listener at all), and it takes BOTH readings: the initial
+    state has to be pulled, because the push only carries transitions and a
+    window already fullscreen at load never sees one."""
+    tsx = _src(_TOPBAR_TSX)
+    effect = tsx.split("useEffect(() => {\n    if (!mac) return;", 1)
+    assert len(effect) == 2, "the fullscreen effect must bail out when !mac"
+    body = effect[1].split("}, [mac]);", 1)[0]
+    assert "isFullScreen()" in body  # initial state, pulled
+    assert "onFullScreenChanged(setFullScreen)" in body  # transitions, pushed
+    assert "off()" in body  # and unsubscribed on unmount
+
+
+def test_topbar_defines_the_swapping_cluster_exactly_once():
+    """The point of hoisting logo / theme / bell into consts: the two layouts
+    render the same elements and can't drift apart."""
+    tsx = _src(_TOPBAR_TSX)
+    assert tsx.count('id="brand-logo"') == 1
+    assert tsx.count('id="theme-btn"') == 1
+    assert tsx.count("onClick={toggleTheme}") == 1
+    assert tsx.count("<NotificationsBell />") == 2  # one per placement, gated
+    # Left-hand placement (Windows/Linux/browser) is gated off on mac...
+    for gated in (
+        "{!mac && logo}",
+        "{!mac && themeToggle}",
+        "{!mac && <NotificationsBell />}",
+    ):
+        assert gated in tsx, gated
+    # ...and the mirrored .tb-end exists only there.
+    assert '{mac && (\n        <div className="tb-end">' in tsx
+
+
+def test_topbar_mac_cluster_sits_after_the_drag_region():
+    """.tb-end has to follow .tb-drag so the flexible handle keeps the width and
+    the cluster hugs the right edge."""
+    tsx = _src(_TOPBAR_TSX)
+    assert tsx.index('className="tb-drag"') < tsx.index('className="tb-end"')
+
+
+# --------------------------------------------------------------------------- #
+# TopBar.css / the shipped stylesheet — and that they are the SAME rules.
+# --------------------------------------------------------------------------- #
+
+
+def test_style_css_ships_the_mac_topbar_rules():
+    css = client.get("/style.css").text
+    assert "#topbar[data-mac-lights]" in css
+    assert "#topbar[data-mac] .tb-end" in css
+    # The gap is keyed on data-mac-lights, NOT data-mac — otherwise fullscreen
+    # (where macOS hides the lights) leaves a hole no button occupies.
+    assert "padding-left" in _css_block(css, "#topbar[data-mac-lights]")
+    assert "padding-left" not in _css_block(css, "#topbar[data-mac]")
+
+
+def test_shipped_light_gap_matches_the_topbar_css_source():
+    """Catches a TopBar.css edit committed without ``npm run build``."""
+    served = _css_block(client.get("/style.css").text, "#topbar[data-mac-lights]")
+    source = _css_block(_src(_TOPBAR_CSS), "#topbar[data-mac-lights]")
+    assert source, "the data-mac-lights rule vanished from TopBar.css"
+    pad = re.compile(r"padding-left:\s*([\w.]+)")
+    assert pad.search(served) and pad.search(source)
+    assert pad.search(served).group(1) == pad.search(source).group(1)
+    # 13px origin + 3 x 12px buttons + 2 x 8px gaps + breathing room.
+    assert pad.search(source).group(1) == "78px"
+
+
+# --------------------------------------------------------------------------- #
+# The built bundle carries the change (i.e. it was actually rebuilt).
+# --------------------------------------------------------------------------- #
+
+
+def test_app_js_bundle_was_rebuilt_with_the_mac_title_bar_sources():
+    js = client.get("/app.js").text
+    # From TopBar.tsx…
+    assert '"data-mac-lights"' in js
+    assert '"data-mac"' in js
+    assert '"tb-end"' in js
+    # …and from lib/shell.ts, strict-equality intact through the build.
+    assert "nativeTitleBar" in js
+    assert re.search(r"nativeTitleBar\)? === true", js)
+    assert "onFullScreenChanged" in js
+
+
+def test_app_js_bundle_builds_the_swapping_cluster_once():
+    """Guards against a future edit that duplicates the cluster in the built
+    output instead of reusing the hoisted element."""
+    js = client.get("/app.js").text
+    assert js.count('id: "theme-btn"') == 1
+    assert js.count('id: "brand-logo"') == 1
+    # Still positioned after the drag handle in the emitted tree.
+    assert js.index('"tb-drag"') < js.index('"tb-end"')

--- a/tests/unit/test_provider_base.py
+++ b/tests/unit/test_provider_base.py
@@ -183,3 +183,46 @@ def test_seed_prompt_expr_unwritable_dir_returns_blank(tmp_path, monkeypatch):
     blocker.write_text("file, not a dir")
     monkeypatch.setenv("MINDFLOCK_SEED_PROMPT_DIR", str(blocker / "seed"))
     assert seed_prompt_expr("mindflock_s", "do a thing") == ""
+
+
+# --------------------------------------------------------------------------- #
+# normalize_program — a resolved binary path folds back to the provider name
+# --------------------------------------------------------------------------- #
+# GetClaudeCommand reports `which` output, so a first run stored an absolute
+# path as the default program. Every consumer that shows or matches a program
+# then had to cope with an install detail; the New Session dialog didn't, and
+# rendered it as a spurious extra agent entry.
+def test_normalize_program_folds_a_known_binary_path():
+    from backend import providers
+
+    assert providers.normalize_program("/opt/homebrew/bin/claude") == "claude"
+    assert providers.normalize_program("/usr/local/bin/codex") == "codex"
+
+
+def test_normalize_program_passes_through_bare_names_and_customs():
+    from backend import providers
+
+    assert providers.normalize_program("claude") == "claude"
+    assert providers.normalize_program("codex") == "codex"
+    # No provider claims it -> it IS the launch command, keep it exactly.
+    assert providers.normalize_program("/opt/bin/my-agent") == "/opt/bin/my-agent"
+    # Arguments mean a command line, not a binary to identify.
+    assert providers.normalize_program("/opt/homebrew/bin/claude --foo") == (
+        "/opt/homebrew/bin/claude --foo"
+    )
+
+
+def test_normalize_program_handles_empty_and_none():
+    from backend import providers
+
+    assert providers.normalize_program("") == ""
+    assert providers.normalize_program(None) == ""
+    assert providers.normalize_program("   ") == ""
+
+
+def test_normalize_program_never_returns_the_catch_all():
+    """The generic fallback claims every program, so it must not be allowed to
+    rename an unrecognised path to "generic"."""
+    from backend import providers
+
+    assert providers.normalize_program("/opt/bin/whatever") == "/opt/bin/whatever"

--- a/tests/unit/test_server_routes.py
+++ b/tests/unit/test_server_routes.py
@@ -1213,6 +1213,28 @@ def test_assigned_tickets_annotates_has_session(monkeypatch):
         server._pending_drop("sc-99")
 
 
+def test_config_reports_the_default_program_as_a_provider_name(monkeypatch):
+    """A config.toml written by an older first run stores `which claude` output.
+    Served verbatim, the New Session dialog didn't recognise it and listed it as
+    an extra agent-dropdown entry — a mystery "/opt/homebrew/bin/claude" above
+    the real agents on a Homebrew Mac. Normalized on the way out, so an existing
+    install is fixed without editing any file."""
+    monkeypatch.setattr(
+        server.ENGINE, "default_program", lambda: "/opt/homebrew/bin/claude"
+    )
+    assert client.get("/api/config").json()["default_program"] == "claude"
+
+
+def test_config_keeps_a_custom_program_verbatim(monkeypatch):
+    """A program no provider claims is the launch command itself — untouched."""
+    monkeypatch.setattr(
+        server.ENGINE, "default_program", lambda: "/opt/bin/my-own-agent"
+    )
+    assert (
+        client.get("/api/config").json()["default_program"] == "/opt/bin/my-own-agent"
+    )
+
+
 def test_pending_start_shows_as_a_provisioning_row():
     """An accepted force-start is visible in the sidebar before its session
     exists — the whole point of core.pending (a PR clone runs far longer than

--- a/tests/unit/test_server_routes.py
+++ b/tests/unit/test_server_routes.py
@@ -1197,7 +1197,7 @@ def test_github_open_prs_502_on_error(monkeypatch):
 
 def test_assigned_tickets_annotates_has_session(monkeypatch):
     server._ASSIGNED_TICKETS_CACHE.pop("v", None)
-    server._TICKET_STARTS.add("sc-99")  # a start already in flight
+    server._pending_add("sc-99", "tix")  # a start already in flight
     monkeypatch.setattr(
         server._ticket_start,
         "list_assigned_tickets",
@@ -1206,11 +1206,139 @@ def test_assigned_tickets_annotates_has_session(monkeypatch):
     try:
         r = client.get("/api/tickets")
         assert r.status_code == 200
-        # a ticket whose start is in-flight (in _TICKET_STARTS) reads as claimed
+        # a ticket whose start is in-flight (in core.pending) reads as claimed
         assert r.json()["tickets"][0]["has_session"] is True
     finally:
         server._ASSIGNED_TICKETS_CACHE.pop("v", None)
-        server._TICKET_STARTS.discard("sc-99")
+        server._pending_drop("sc-99")
+
+
+def test_pending_start_shows_as_a_provisioning_row():
+    """An accepted force-start is visible in the sidebar before its session
+    exists — the whole point of core.pending (a PR clone runs far longer than
+    the instances poll, and an empty sidebar reads as a failed start)."""
+    server._pending_add("pr-app-42", "pr", branch="fix/login-crash", repo="o/app")
+    try:
+        rows = client.get("/api/instances").json()
+        row = next(r for r in rows if r["title"] == "pr-app-42")
+        assert row["pending"] is True
+        assert row["status"] == "loading"
+        assert row["stage"] == "provisioning"
+        # The branch rides along so the row can name the work, not just the slug.
+        assert row["branch"] == "fix/login-crash"
+    finally:
+        server._pending_drop("pr-app-42")
+    assert not [
+        r for r in client.get("/api/instances").json() if r["title"] == "pr-app-42"
+    ]
+
+
+def test_pending_row_yields_to_the_real_session(monkeypatch):
+    """Once the instance registers, the real entry is the only one — a stale
+    pending marker must not double the row."""
+    monkeypatch.setitem(server.ENGINE.instances, "sc-77", _FakeInst("sc-77"))
+    server._pending_add("sc-77", "tix", branch="feature/sc-77/x")
+    try:
+        titles = [r["title"] for r in client.get("/api/instances").json()]
+        assert titles.count("sc-77") == 1
+    finally:
+        server._pending_drop("sc-77")
+
+
+def test_force_review_row_appears_before_the_github_lookup(monkeypatch):
+    """The provisioning row must not wait on find_pr: the panel's cached list
+    already carries the session title, so the row goes up first and the lookup
+    (a GitHub round trip — the last click-to-row delay) happens after."""
+    server._OPEN_PRS_CACHE["v"] = (
+        time.monotonic() + 60,
+        {"prs": [{"repo": "o/app", "number": 42, "session": "pr-app-42"}]},
+    )
+    seen: list = []
+
+    async def _slow_find(repo, number):
+        # Whatever the row state is at lookup time is what the user sees while
+        # waiting on GitHub.
+        seen.append(
+            [
+                r["title"]
+                for r in client.get("/api/instances").json()
+                if r.get("pending")
+            ]
+        )
+        raise LookupError("no such PR")
+
+    monkeypatch.setattr(server._pr_review, "find_pr", _slow_find)
+    monkeypatch.setattr(server, "git_available", lambda: True)
+    try:
+        r = client.post("/api/github/prs/review", json={"repo": "o/app", "number": 42})
+        assert r.status_code == 404  # the lookup failed, as staged
+        assert seen == [["pr-app-42"]]  # ...but the row was already up
+        # A failed lookup takes its row back down again.
+        assert not [x for x in client.get("/api/instances").json() if x.get("pending")]
+    finally:
+        server._OPEN_PRS_CACHE.pop("v", None)
+        server._pending_drop("pr-app-42")
+
+
+def test_force_review_409s_from_the_cached_title(monkeypatch):
+    """The double-click guard works off the early title too — otherwise the
+    second click would sail past it and provision the same workspace twice."""
+    server._OPEN_PRS_CACHE["v"] = (
+        time.monotonic() + 60,
+        {"prs": [{"repo": "o/app", "number": 7, "session": "pr-app-7"}]},
+    )
+    server._pending_add("pr-app-7", "pr")
+    monkeypatch.setattr(server, "git_available", lambda: True)
+    try:
+        r = client.post("/api/github/prs/review", json={"repo": "o/app", "number": 7})
+        assert r.status_code == 409
+        assert r.json()["title"] == "pr-app-7"
+    finally:
+        server._OPEN_PRS_CACHE.pop("v", None)
+        server._pending_drop("pr-app-7")
+
+
+def test_ingestion_status_greens_for_a_locally_forced_start():
+    """The pipeline's beacon only knows the pipeline's own queue, so a ticket
+    forced from the UI has to green the dot through core.pending — otherwise the
+    light reads idle for the whole provisioning (what it did before)."""
+    r = client.get("/api/mindflock/status")
+    assert r.status_code == 200
+    assert r.json()["tickets_active"] is False
+    server._pending_add("sc-5", "tix")
+    try:
+        assert client.get("/api/mindflock/status").json()["tickets_active"] is True
+        # The other two dots are unaffected by a ticket start.
+        assert client.get("/api/mindflock/status").json()["pr_active"] is False
+    finally:
+        server._pending_drop("sc-5")
+    assert client.get("/api/mindflock/status").json()["tickets_active"] is False
+
+
+def test_provisioning_kinds_classifies_a_loading_session(monkeypatch):
+    """A session that exists but is still cloning counts as active work too —
+    the pending marker is dropped the moment the instance registers, so without
+    this the light would flick back to gold mid-provisioning."""
+    from backend.web.core import pending
+
+    inst = _FakeInst("sc-9", started=False, status=Loading)
+    inst.Branch = "feature/sc-9/add-thing"
+    monkeypatch.setitem(server.ENGINE.instances, "sc-9", inst)
+    assert "tix" in pending.provisioning_kinds()
+    # A running session is not "being brought in" — that's the idle state.
+    inst._started = True
+    assert "tix" not in pending.provisioning_kinds()
+
+
+def test_session_kind_matches_the_sidebar_label():
+    """Backend kind classification and the frontend's sessionLabel must agree
+    on what a PR / issue / ticket session looks like."""
+    from backend.web.core import pending
+
+    assert pending.session_kind("pr-app-42", "fix/x") == "pr"
+    assert pending.session_kind("issue-app-77", "feature/issue-app-77/x") == "iss"
+    assert pending.session_kind("sc-12345", "feature/sc-12345/add-dark-mode") == "tix"
+    assert pending.session_kind("my-refactor", "feature/my-refactor") == ""
 
 
 def test_github_open_issues_502_on_error(monkeypatch):

--- a/tests/unit/test_usage_api.py
+++ b/tests/unit/test_usage_api.py
@@ -304,3 +304,71 @@ def test_provider_usage_entry_swallows_usage_errors(monkeypatch):
     assert entry["window"] is None
     assert entry["window_note"] == ""
     assert entry["periods"] is None
+
+
+# --------------------------------------------------------------------------- #
+# _usage_window_for: a live reading with a reset time but NO utilization
+# --------------------------------------------------------------------------- #
+# Reported from a Mac: the plan window showed its reset countdown but no
+# "% used" row at all. Taking live's percent verbatim discarded a percentage the
+# transcript estimate could still supply, so an end-only live reading blanked it.
+class _ClaudeLive(_Claude):
+    def __init__(self, live):
+        self._live = live
+
+    def usage_live(self):
+        return self._live
+
+
+def test_live_end_without_percent_falls_back_to_the_estimate(monkeypatch):
+    _patch_estimate(
+        monkeypatch,
+        {"anchor": 0.0, "end": 5.0, "cost": 3.0, "tokens": 100},
+        budget=10.0,
+    )
+    win = usage_api._usage_window_for(_ClaudeLive({"end": 4242.0}))
+    assert win["end"] == 4242.0  # the live reset time is still the accurate one
+    assert win["percent_used"] == 30.0  # 100 * 3 / 10, from the estimate
+    # Marked as an estimate so the UI keeps its "(est.)" qualifier honest.
+    assert win["source"] == "estimate"
+
+
+def test_live_end_without_percent_stays_blank_with_no_budget(monkeypatch):
+    """No budget means there is genuinely no percentage to compute — the window
+    still reports its reset time, as before."""
+    _patch_estimate(
+        monkeypatch,
+        {"anchor": 0.0, "end": 5.0, "cost": 3.0, "tokens": 100},
+        budget=0.0,
+    )
+    win = usage_api._usage_window_for(_ClaudeLive({"end": 4242.0}))
+    assert win["end"] == 4242.0
+    assert win["percent_used"] is None
+    assert win["source"] == "live"
+
+
+def test_live_percent_is_never_overridden_by_the_estimate(monkeypatch):
+    """The provider's own meter wins whenever it reports one."""
+    _patch_estimate(
+        monkeypatch,
+        {"anchor": 0.0, "end": 5.0, "cost": 9.0, "tokens": 100},
+        budget=10.0,
+    )
+    win = usage_api._usage_window_for(_ClaudeLive({"end": 1.0, "percent_used": 7.0}))
+    assert win["percent_used"] == 7.0
+    assert win["source"] == "live"
+
+
+def test_group_quotas_are_left_alone(monkeypatch):
+    """Per-group quotas are their own presentation — no headline percent is
+    invented for them from an unrelated transcript estimate."""
+    _patch_estimate(
+        monkeypatch,
+        {"anchor": 0.0, "end": 5.0, "cost": 9.0, "tokens": 100},
+        budget=10.0,
+    )
+    win = usage_api._usage_window_for(
+        _ClaudeLive({"end": 1.0, "groups": [{"label": "g", "percent_used": 5.0}]})
+    )
+    assert win["percent_used"] is None
+    assert win["source"] == "live"


### PR DESCRIPTION
Three sidebar changes, all about what the left column tells you.

## Rename in place

Clicking the row that is **already selected** turns its name into an input with the text pre-selected — renaming no longer means hunting for "Rename…" in the actions menu.

The edit is armed on a 300ms timer rather than fired immediately, because the second click of a double-click lands on the same handler: `onDoubleClick` cancels it, so double-click still opens the IDE and never flashes an editor. Enter/blur commit, Escape cancels, and typing the real title back (or clearing the field) drops the alias instead of storing a redundant one. A 400ms guard stops the click that dismisses an edit from re-arming it.

The existing Rename dialog, its menu item and the palette entry are untouched — this is an added shortcut, and it writes through the same `setAlias` store action.

## Readable names for pipeline sessions

A ticket/PR/issue session is titled by its machine slug, which says nothing about the work. The feature name is already sitting in the branch, so the row now pulls it forward:

| Title | Branch | Sidebar shows |
|---|---|---|
| `sc-12345` | `feature/sc-12345/add-dark-mode` | `(tix) add-dark-mode/sc-12345` |
| `pr-app-42` | `fix/login-crash` | `(pr) login-crash/app-42` |
| `issue-app-77` | `feature/issue-app-77/cant-open` | `(iss) cant-open/app-77` |
| `my-refactor` | anything | `my-refactor` (untouched) |

The feature name is clipped to 20 chars in the row so a long branch can't push the identifying slug into the ellipsis; the tooltip carries the full name plus the real session title and branch.

Display only: `inst.title` remains the identity every API path, tmux name and workspace dir is keyed by, which is why the raw title stays in the tooltip. Sidebar search already matched on branch, so searching the feature name works.

## Provisioning is visible immediately

A forced PR review / issue / ticket answered 202 and then cloned for tens of seconds *before* it could register an instance — the sidebar showed nothing at all and the start looked like it had failed.

`backend/web/core/pending.py` records every accepted start the moment the request arrives — **before** the upstream lookup, using the session title the panel's cached list already carries (no slug re-derivation: providers set their own, e.g. Shortcut hardcodes `sc-<id>`, so a second implementation would drift). `/api/instances` renders each as a provisioning row the UI already knows how to draw (`status: loading` + `stage: provisioning`), and the entry is dropped once the real instance exists so the row is replaced rather than duplicated. A pending row offers no actions, since there's no session behind it yet.

The same registry fixes the status dots. The pipeline's activity beacon only knows the *pipeline's* queue, so a ticket forced from the UI provisioned for minutes with the light showing idle. `provisioning_kinds()` reports what this server is bringing in (accepted starts + sessions still provisioning) and the addon ORs it into `tickets_active` / `pr_active` / `issues_active`. Backend classification mirrors `sessionLabel` and is tested against the same cases. `active` now outranks the switch in all three bars — a forced start with automation off is genuinely in flight, and "off" was a lie about it. Status poll drops 10s → 4s to match the sessions poll, since the green window can be a single provisioning.

This covers starts triggered through MindFlock from any client. Auto-ingested sessions still arrive via the pipeline's own beacon and the 4s `state.json` reload, unchanged.

## Testing

- 3194 backend unit tests pass; 7 new in `test_server_routes.py` — the row is asserted to exist *during* the upstream lookup (by polling `/api/instances` from inside a stubbed `find_pr`), plus the early-title 409 guard, the status route turning green on a pending ticket, loading-session classification, and kind classification.
- 127 frontend tests pass; 9 new for `sessionLabel` covering each kind, the no-branch and branch-restates-slug cases, clipping, and regex-special characters in a title.
- `tsc --noEmit` clean, `black` clean, committed bundle rebuilt and verified current by `scripts/check-bundle-fresh.sh`.
- Verified in the running app: the restarted server serves the new bundle and `/api/mindflock/status` flips `tickets_active` for a pending start.

Not covered by automated tests: the click-timing interaction itself (the suite has no component-level tests), so the 300ms feel is worth a manual try.
