### PR TITLE
Document the release flow the rulesets actually require

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -134,15 +134,36 @@ gh workflow run release.yml        # builds all three, publishes nothing
 gh run watch                       # installers land as run artifacts
 ```
 
-Then:
+Then, on a branch — `main` requires a pull request (the **Safe-main** ruleset),
+and a release commit is not an exception to that:
 
 ```bash
+git switch -c release/<version>
 python3 scripts/bump-version.py <version>   # manifests + CHANGELOG
 $EDITOR CHANGELOG.md                        # fill in the new section
-git commit -am "Release <version>"
+git commit -sam "Release <version>"         # -s: every commit needs a DCO sign-off
+git push -u origin release/<version>
+gh pr create --base main --title "Release <version>"
+# merge it once CI is green, then tag the merged commit:
+git switch main && git pull --ff-only
 git tag -a v<version> -m "Release <version>"
-git push origin main --follow-tags
+git push origin v<version>
 ```
+
+Two things that reject a direct push here, both by design:
+
+* **Safe-main** (`main`) requires a pull request. Owner/admin bypass exists, so a
+  direct push *succeeds silently* — which is exactly why the flow above is
+  written out: a release commit gets the same CI-on-a-PR treatment as any other.
+* **Safe-release-tags** (`refs/tags/v*`) restricts *creation*, so the tag push
+  also lands on bypass. Push the tag only after the PR is merged, so the tag
+  names a commit that actually passed review.
+
+The local **leak-guard** (`.git/hooks/pre-push`, untracked) is happy with both:
+it passes any ref whose history is rooted in the squashed `main` and blocks
+anything else, so a release branch and its tag need no `--no-verify`. If it
+refuses something you believe is fine, check the roots it prints rather than
+reaching for the override.
 
 The tag push runs `release.yml`, which publishes to one GitHub release:
 


### PR DESCRIPTION
Cutting 0.1.4 pushed the release commit straight to `main` and created the tag directly. Both succeeded — and both were *refused by a ruleset first*, then allowed by owner bypass:

| Ruleset | Target | Rules |
|---|---|---|
| Safe-main | `main` | deletion, non-fast-forward, **pull_request** |
| Safe-release-tags | `refs/tags/v*` | **creation**, deletion, non-fast-forward |

A rule you always bypass isn't a rule, and the silent success is the trap: the push prints `Changes must be made through a pull request` and then updates the ref anyway, so nothing tells you the policy was skipped.

`docs/development.md` → *Cutting a release* now cuts the release on a `release/<version>` branch, opens a PR, and tags the **merged** commit — so a release commit gets the same CI-on-a-PR treatment as everything else, and the tag names a commit that passed review. Both bypass paths are called out explicitly, so the next person knows a direct push only "works" because of who they are. The `-s` sign-off is in the snippet too (DCO is checked on PRs, and a release commit is no exception).

It also documents that the local leak-guard no longer needs an override for this flow. That hook (`.git/hooks/pre-push`, untracked/local-only) used to be a literal allow-list of ref names — `main` plus each release tag, appended by hand — so every PR branch and every new tag tripped it and got a `--no-verify`. It now compares the pushed ref's **root commit set** against `origin/main`'s (post-squash root `4b50237` vs the pre-squash `03a5f35`), which is an exact test of the property it actually cares about: does this ref carry the private pre-launch history. Verified three ways: `main` and a brand-new `v*` tag both pass, and a pre-squash branch restored from the archive bundle is still refused. It fails closed when `origin/main` isn't fetched, and a re-squashed `main` still needs the explicit override — rewriting published history shouldn't be quiet.

This PR is itself the first push of the flow, and it needed no override.