### PR TITLE
Measure the productivity claim instead of asserting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   home. Worktree isolation, tmux and the grid are described as *how* it works.
   The README also states plainly what is **not** automatic (no commit, push, PR
   or merge without your click; no writes to your tracker; polling, not
-  webhooks), and carries the first published usage figures.
+  webhooks).
+- **The first published productivity figures, measured properly.** An earlier
+  draft leaned on volume counts, which turned out to prove nothing: pull requests
+  per month actually went *down*, and Shortcut's start→done clock got *longer*
+  (it measures review, QA and deploy queues that no coding tool touches). Three
+  eras of one repository — before agents, one agent at a time, and a flock —
+  recomputed from the git graph and the Shortcut API instead: the ticket rate
+  barely moved (43 → 55/month) while the median ticket went from **114 source
+  lines across 4 files to 979 across 13**, pull requests touching tests went from
+  **5% to 88%**, peak branches in flight went from 16 to 31, and reviewed source
+  per half-hour-with-a-commit went up **6.3×**. Source files only (lockfiles,
+  generated files, images and DB dumps excluded — under 1% of recent lines),
+  medians not means, because a single 1.6 M-line bulk import would otherwise
+  dominate every average. The method is documented in the README so the figures
+  can be re-derived.
 - **Ticket sessions land in the app by default.** `[mindflock].enabled` now
   defaults to `true`, and is exposed in Settings → Advanced instead of being
   file-only. Previously a fresh install that connected a tracker got detached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not need a running server, and behaves the same headless); if it is ever
   unimportable the pipeline falls back to the standalone path with a warning
   naming what was lost.
+- **Both ways in are stated as first-class.** Leading with ingestion is right —
+  nothing else does it — but the README now says plainly that MindFlock is also a
+  parallel-agent workspace you drive by hand (`+ New`, or `mindflock new`), that a
+  tracker is a source of sessions rather than a requirement for them, and that a
+  hand-started session runs whichever agent CLI you point it at. The website gets
+  a section of its own for it.
 - **The Ticket Ingestion bar is visible out of the box** (`DEFAULT_VISIBLE_BARS`),
   so the flagship feature is no longer hidden behind ⚙ Customize. The first-run
   footer hint now points at the bars that are still hidden.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md)
 
 [What is it?](#what-is-mindflock) •
-[What it looks like in use](#what-it-looks-like-in-use) •
+[Does it actually work?](#what-it-looks-like-in-use) •
 [How is this different?](#how-is-this-different) •
 [Quick Start](#quick-start) •
 [Download](#download) •
@@ -72,11 +72,63 @@ own* PRs.
 
 ## What it looks like in use
 
-Numbers from the author's own use, not a benchmark. Three different things, kept
-apart on purpose, because the interesting one is the smallest.
+One developer's own repository, measured three ways. Every figure below is
+recomputed from git and the Shortcut API, not estimated — method at the bottom.
 
-**What MindFlock itself has run** — 38 days, 2026-06-22 → 2026-07-29, on one
-private production repo:
+|  | before agents<br><sub>2024-07 → 2025-12</sub> | agents, one at a time<br><sub>2026-01 → 03</sub> | **the flock**<br><sub>2026-04 → 07</sub> |
+|---|---|---|---|
+| Tickets closed per month | 43 | 53 | **55** |
+| Median **source lines per ticket** | 114 | 168 | **979** |
+| Median source lines per PR | 68 | 210 | **873** |
+| Median files per PR | 4 | 7 | **13** |
+| Median modules touched per PR | 2 | 2 | **4** |
+| PRs that touch tests | 5% | 58% | **88%** |
+| Most branches in flight in one day | 16 | 13 | **31** |
+| Half-hour windows with a commit, per month | 87 | 93 | 138 |
+| **Reviewed source per engaged half-hour** | 72 | 208 | **453** |
+
+**The ticket count barely moved. What each ticket contains did.** A change that
+used to be 114 lines across 4 files is now 979 lines across 13 files in twice as
+many modules — and where 1 PR in 20 used to touch a test, 9 in 10 now do. Per
+half-hour that a commit actually landed in, **6.3× more reviewed source code**.
+
+That is the honest shape of it: the first step up came from using coding agents at
+all, and the second, larger one came from being able to run a flock of them
+without losing track — peak work in flight nearly doubled the old ceiling.
+
+Two things this is *not*. It is not a speed-up in wall-clock ticket cycle time:
+Shortcut's start→done clock got *longer*, because it measures review, QA and
+deploy queues that no coding tool touches. And it is not free: engaged windows per
+month went up by half, and 13.5 B tokens went through agents on this machine over
+46 logged days.
+
+<details>
+<summary>Method — so you can check it</summary>
+
+- **Source-only.** Lockfiles, generated and minified files, images, CSVs,
+  notebooks, `dist/`, `vendor/`, `node_modules/` and DB dumps are excluded. They
+  are under 1% of the lines in the recent period and 2.6% in the older one, so
+  they are not what moved.
+- **Medians, not means.** A handful of bulk-import PRs (one month has 1.6 M lines
+  in a single batch) dominate any average; medians are what a typical change looks
+  like. "Reviewed source per engaged half-hour" is PR count × median PR size ÷
+  engaged windows, so one giant import cannot inflate it.
+- **Diff per PR** = `git diff <base> <branch-tip>` at the merge commit, computed
+  from the local clone for all 2,210 merged PRs authored by one person.
+- **Engaged half-hour** = a distinct 30-minute window containing at least one
+  commit on one of those branches. In the recent period some of those commits are
+  an agent's while the human was elsewhere, which *overstates* engaged time and so
+  makes the 6.3× a floor.
+- **Tickets** = Shortcut stories owned by that person with a `completed_at`.
+- **Eras.** Agent-authored commits first appear 2026-02; the ingestion pipeline's
+  ancestor lands in the work repo 2026-04-22 and has been running ticket → agent →
+  PR in production since 2026-06-22.
+
+</details>
+
+## What MindFlock itself has run
+
+38 days, 2026-06-22 → 2026-07-29, from the pipeline's own dedup state:
 
 | | |
 |---|---|
@@ -85,27 +137,9 @@ private production repo:
 | Own pull requests triaged for review comments | **42** — the ones with nothing actionable were skipped automatically; the rest came back as sessions |
 | Agent CLIs the pipeline drove | **2** (`claude`, `ccc`) — of 5 driven on this machine overall |
 
-<sub>The ticket figure counts distinct tickets: the pipeline's dedup state holds
-47 records, of which 7 were throwaway test tickets and 2 were re-runs of the same
-ticket. Log rotation means the PR-session count is a floor, not a ceiling.</sub>
-
-**The workload it was built to serve** — the author's day job. This predates
-MindFlock by two years and is not a claim about it:
-
-| | |
-|---|---|
-| Tickets closed in the last 12 months | **626** (~52/month) |
-| Merged pull requests authored in that repo since June 2024 | **2,232** |
-| Merged PRs in the last 99 days | **230** (~2.3/day) |
-
-**Agent volume on this machine** — **13.5 B tokens over 46 logged days**
-(~294 M/day), as of 2026-07-29. A large share of that is MindFlock building
-MindFlock, so read it as "what supervising this many agents costs", not as
-day-job output.
-
-MindFlock has been built and used daily since May 2026; it has been running
-ticket → agent → pull request in production since 22 June. It did not make the
-ticket throughput go up — that was already high. It changed who does the typing.
+<sub>The ticket figure counts distinct tickets: the dedup state holds 47 records,
+of which 7 were throwaway test tickets and 2 were re-runs. Log rotation makes the
+PR-session count a floor.</sub>
 
 ## How is this different?
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ sessions the same way, on the PR's own branch, with every unresolved inline
 review comment in the prompt (outdated threads and top-level PR conversation are
 skipped).
 
-Parallel orchestration, worktree isolation and tmux are *how* it works — see
-[How It Works](#how-it-works). The point is that the work arrives on its own and
-leaves as a pull request.
+**Two ways in, and both are first-class.** The tracker path leads because
+nothing else does it — but MindFlock is also, plainly, a parallel-agent
+workspace, and plenty of days that is all it is: hit **+ New**, pick a repo and
+an agent, type a prompt, and you have another isolated worktree running beside
+the rest. Same grid, same live terminals, same Diff tab, same guided
+commit → push → PR → merge, same phone UI, same cost tracking. **A tracker is a
+source of sessions, not a requirement for them** — and unlike the ingestion path,
+a hand-started session runs whichever agent CLI you point it at.
 
 **What is not automatic** — because a pipeline you can't trust is worse than
 none. MindFlock never commits, pushes, opens or merges a PR by itself: every one
@@ -104,8 +109,9 @@ ticket throughput go up — that was already high. It changed who does the typin
 
 ## How is this different?
 
-Every tool below is a good way to *start* an AI coding session. The difference
-is that in MindFlock you don't start them — your tracker does.
+Every tool below is a good way to *start* an AI coding session, and MindFlock is
+a good way to start one too — `+ New`, a repo, an agent, a prompt. The difference
+is that in MindFlock you don't *have* to: your tracker can do it for you.
 
 | | **MindFlock** | **Claude Squad** | **Conductor** | **Claude Code Agent Teams** |
 |---|---|---|---|---|
@@ -191,7 +197,7 @@ those two change what your day looks like:
 
 [Install first](#download) — one command — then pick the half you came for.
 
-### The point: let your tracker start the sessions
+### Let your tracker start the sessions
 
 On a fresh install you connect a tracker in the desktop app under **Settings →
 Ticketing** — a token, plus the repo that source's tickets should land in — and
@@ -213,7 +219,7 @@ Prefer a file to a dialog? [`config.toml.example`](config.toml.example) is the
 headless equivalent, and `python -m backend.ticket_ingestion` runs the pipeline
 standalone — see [docs/ingestion-pipeline.md](docs/ingestion-pipeline.md).
 
-### Or start one by hand
+### Or start them yourself — no tracker required
 
 From zero to a supervised agent session (this CLI flow is verified in CI on
 every push by


### PR DESCRIPTION
Follow-up to #19, which merged while this was being written. Two things that PR
got wrong.

## 1. The numbers undersold it, because they measured the wrong things

#19 published volume counts — tickets closed, PRs merged — and a Shortcut cycle
time. Both are real and neither measures anything this tool affects: PR count
actually *fell* in the recent period, and Shortcut's start→done clock got
*longer*, because it's mostly review, QA and deploy queues.

Recomputed from the git graph and the Shortcut API across three eras of the same
repository — before coding agents, one agent at a time, and a flock. The ticket
rate barely moves. Everything about what a ticket *contains* does:

| | before agents<br>2024-07→2025-12 | one at a time<br>2026-01→03 | the flock<br>2026-04→07 |
|---|---|---|---|
| Tickets closed / month | 43 | 53 | **55** |
| Median **source lines per ticket** | 114 | 168 | **979** |
| Median source lines per PR | 68 | 210 | **873** |
| Median files per PR | 4 | 7 | **13** |
| Median modules touched per PR | 2 | 2 | **4** |
| PRs that touch tests | 5% | 58% | **88%** |
| Peak branches in flight in a day | 16 | 13 | **31** |
| **Reviewed source per engaged half-hour** | 72 | 208 | **453** |

**The test row is the one that answers the obvious objection.** If the extra
volume were an agent being verbose, tests wouldn't have gone from 1 PR in 20 to 9
in 10.

Method, written into the README as a collapsed section so every figure is
re-derivable:

- **Source files only.** Lockfiles, generated/minified files, images, CSVs,
  notebooks, `dist/`, `vendor/`, `node_modules/` and DB dumps excluded — under 1%
  of lines in the recent period, 2.6% in the older one. Not what moved.
- **Medians, not means.** One month contains a 1.6 M-line bulk import; it
  dominates every average. The per-half-hour figure is PR count × median PR size ÷
  engaged windows, so no single import can inflate it.
- **Per-PR diff** = `git diff <base> <tip>` at the merge commit, for all 2,210
  merged PRs by one author, from the local clone.
- **Engaged half-hour** = a distinct 30-minute window containing a commit on one
  of those branches. In the recent era some of those commits are an agent's while
  the human was elsewhere, which *overstates* engaged time — so 6.3× is a floor.

Stated plainly on both surfaces: this is **not** faster wall-clock cycle time, and
it is **not** free (engaged windows/month up by half; 13.5 B tokens over 46 logged
days).

## 2. It implied a tracker is required

It isn't, and that's not how the tool is used day to day. `+ New` with a repo, an
agent and a prompt is a first-class path that gets the same grid, Diff tab, guided
commit → push → PR → merge and phone UI — and unlike a provisioned ticket session,
it runs whichever agent CLI you point it at. The README now says "two ways in, and
both are first-class"; the comparison intro no longer claims you *don't* start
sessions, only that you don't have to; and the website has a `#manual` section for
it (MindFlock/webpage#4, merged).

Docs-only plus the README/CHANGELOG. No code changes.