### PR TITLE
Release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-07-30
+
 ### Changed
 
 - **SSH remotes work, and the GitHub CLI is genuinely optional.** `gh` was
@@ -452,7 +454,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.5
 [0.1.4]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.4
 [0.1.3]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.3
 [0.1.2]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.2

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.4"
+version = "0.1.5"
 description = "MindFlock — run a flock of AI coding agents, each in its own git worktree; started by your ticket queue (Jira, Linear, GitHub Issues, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump + CHANGELOG roll for **0.1.5**. No functional changes — every
manifest (`pyproject.toml`, `electron/package.json`, `frontend/package.json`,
`uv.lock`) written by `scripts/bump-version.py`, which also opened the
`[0.1.5] - 2026-07-30` heading and retargeted the compare links.

## Why now

`main` had been six commits ahead of `v0.1.4` since 2026-07-29 — not cosmetic
ones (`ticket_ingestion` providers, orchestrator, `cli.py`, the Jira
acceptance-criteria mining fix) — and #22 added two user-blocking fixes on top:

- **`gh` is genuinely optional and SSH remotes work.** Pushing is plain
  `git push` over whatever remote you have; Make PR / Merge fall back from `gh`
  to the REST API to a prefilled compare URL, so a missing `gh` never 400s.
- **Provisioned sessions no longer push into your own laptop.** The workspace's
  `origin` was the local checkout, so pushes "succeeded" while nothing reached
  the forge and Make PR then failed.

Install paths diverge here, which is the actual reason to tag: `install.sh`
defaults to `REF=main`, so CLI users already have this — but `release.yml` only
fires on `v*`, so desktop (dmg/exe) users do not until this ships.

## Verification

- `uv run --all-groups pytest -q` -> 3425 passed
- `scripts/bump-version.py --check --expect v0.1.5` -> ok, all manifests at 0.1.5
- A `workflow_dispatch` dry run of `release.yml` will be used to prove the
  Windows NSIS and macOS universal builds still compile **before** the tag makes
  anything public.