### PR TITLE
Ping your phone when a session needs you (optional ntfy channel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Optional ntfy push, so notifications reach your phone.** Until now the only
+  notification channel was the browser's `Notification` popup — which needs a
+  MindFlock tab open on a secure origin, exactly the situation you're not in when
+  you'd most like to know that a session is waiting on you. Settings →
+  Notifications gains a **Phone push (ntfy)** section: give it a topic
+  (**Generate** offers a random one), scan the QR into the free
+  [ntfy](https://ntfy.sh) app, and the **server** publishes matching events to
+  it — no tab, no browser, no MindFlock window required. **Send a test**
+  confirms the round trip and the row afterwards reports the last push or why it
+  failed. Off until you turn it on, and pointable at your own ntfy instance
+  (**Server**) with a token for a protected topic.
+
+  The existing per-rule switches are now labelled as governing *both* channels —
+  one "what notifies me" list, with channels deciding only where an alert lands.
+  Per-rule ntfy priority means the actionable rules (needs-input, budget
+  exceeded, pre-commit failed) buzz at priority 4 while the ambient opt-ins
+  (idle, pre-commit running) arrive quietly at 2.
+
+  New endpoints `GET|POST /api/notify/ntfy` and `POST /api/notify/ntfy/test`
+  (see [docs/web-api.md](docs/web-api.md)); new settings
+  `notifications.ntfy_enabled` / `_server` / `_topic` / `_token` / `_click_url`,
+  resolved through env → `settings.json` → defaults so a headless box can just
+  export `MINDFLOCK_NTFY_TOPIC` (an env topic is an implicit opt-in — there is no
+  Settings screen there to flip a switch in).
+
+  Care taken with the parts that could leak: the token is masked on read and
+  kept on an empty write like every other secret, **and** is dropped when the
+  server URL is retargeted at a different host without a fresh token, so one
+  server's credential is never handed to another. A `token=` query parameter in
+  the optional tap-to-open URL is stripped, because that URL is stored on the
+  ntfy server. Nothing logs the topic name (`mindflock.log` is served back out
+  over `GET /api/logs`, and on the public server the topic *is* the credential —
+  hence the random default and the on-screen warning while pointed at
+  `ntfy.sh`). Pushes are capped at 60/hour per process so a flapping session
+  can't burn a quota, and delivery is best-effort throughout: a failed push is
+  recorded for the settings screen and never touches the event that triggered it.
+
 ## [0.1.5] - 2026-07-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ those two change what your day looks like:
 - 📱 **Phone UI** — `mindflock serve tailscale` prints a QR code; the mobile
   UI at `/m` carries the same guided git action bar, so the full flow drives
   from a phone. Auth-token protected — never open to the LAN unauthenticated.
+- 🔔 **Notifications where you actually are** — desktop popups while a tab is
+  open, and optional **[ntfy](https://ntfy.sh) push to your phone** sent by the
+  server, so "session needs your input" or "pre-commit blocked the commit"
+  reaches you with MindFlock closed. Off by default; one rule list picks which
+  events notify you, and you can point it at your own ntfy instance.
 - 🌳 **Isolated workspaces** — every session gets its own git worktree, so
   agents never step on each other (or on you).
 - ⚡ **Terminal-first, too** — the `mindflock` CLI drives the same sessions as

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -568,7 +568,8 @@ class GeneralSettings:
 
 @dataclass
 class NotificationSettings:
-    """Which desktop-notification rules the user has toggled off/on.
+    """Which notification rules the user has toggled off/on, and the optional
+    ntfy push channel that delivers them to a phone.
 
     Rules carry a per-rule default (see ``notify.NOTIFY_RULES``):
 
@@ -576,10 +577,29 @@ class NotificationSettings:
       so new default-on rules added later start enabled.
     * **default-off** rules (e.g. "went idle", "pre-commit hooks running" — noisy
       by nature) fire only when their id is in ``enabled_rules`` (opt-in).
+
+    The rule list is shared by every delivery channel — one "what notifies me"
+    list, not one per channel. The ``ntfy_*`` fields configure the second
+    channel (:mod:`backend.web.core.ntfy`), which is off until the user opts in:
+
+    ``ntfy_enabled``: master switch for server-side pushes.
+    ``ntfy_server``: base URL of the ntfy server (``""`` -> the public
+    ``https://ntfy.sh``). ``ntfy_topic``: the topic to publish to — on a public
+    server the topic name IS the credential, so it should be long and random.
+    ``ntfy_token``: access token for a protected topic / self-hosted server, a
+    SECRET (masked on read, keep-on-empty on write by the settings addon).
+    ``ntfy_click_url``: optional URL a tapped notification opens (your phone
+    MindFlock URL); never store an access token in it — it would be handed to
+    the ntfy server.
     """
 
     muted_rules: List[str] = field(default_factory=list)
     enabled_rules: List[str] = field(default_factory=list)
+    ntfy_enabled: bool = False
+    ntfy_server: str = ""  # "" -> ntfy.ntfy DEFAULT_SERVER (https://ntfy.sh)
+    ntfy_topic: str = ""
+    ntfy_token: str = ""  # SECRET
+    ntfy_click_url: str = ""
 
     def to_dict(self) -> dict:
         out: dict = {}
@@ -587,6 +607,16 @@ class NotificationSettings:
             out["muted_rules"] = list(self.muted_rules)
         if self.enabled_rules:
             out["enabled_rules"] = list(self.enabled_rules)
+        if self.ntfy_enabled:
+            out["ntfy_enabled"] = True
+        if self.ntfy_server:
+            out["ntfy_server"] = self.ntfy_server
+        if self.ntfy_topic:
+            out["ntfy_topic"] = self.ntfy_topic
+        if self.ntfy_token:
+            out["ntfy_token"] = self.ntfy_token
+        if self.ntfy_click_url:
+            out["ntfy_click_url"] = self.ntfy_click_url
         return out
 
     @classmethod
@@ -594,6 +624,11 @@ class NotificationSettings:
         return cls(
             muted_rules=_str_list(d.get("muted_rules")),
             enabled_rules=_str_list(d.get("enabled_rules")),
+            ntfy_enabled=bool(d.get("ntfy_enabled", False)),
+            ntfy_server=str(d.get("ntfy_server", "") or "").strip(),
+            ntfy_topic=str(d.get("ntfy_topic", "") or "").strip(),
+            ntfy_token=str(d.get("ntfy_token", "") or "").strip(),
+            ntfy_click_url=str(d.get("ntfy_click_url", "") or "").strip(),
         )
 
 

--- a/backend/web/addons/base.py
+++ b/backend/web/addons/base.py
@@ -64,6 +64,13 @@ class ManagedProcess(Protocol):
     def is_running(self) -> bool: ...
 
 
+#: What a GET returns in place of a stored credential — it says "a value is
+#: saved" without ever transmitting the value. Writing it back (or writing "")
+#: means "keep the saved one". Shared so every addon that handles a credential
+#: agrees on the sentinel; the frontend's counterpart is ``SECRET_MASK`` in
+#: settings/useSettings.tsx.
+SECRET_MASK = "•••set"  # pragma: allowlist secret — it IS the placeholder
+
 #: Namespace every addon-originated event lives under (``emit()`` auto-prefixes).
 ADDON_EVENT_PREFIX = "addon."
 # The namespace reserved for core lifecycle events (web/core/events.py); an

--- a/backend/web/addons/notify.py
+++ b/backend/web/addons/notify.py
@@ -1,35 +1,55 @@
-"""Notify addon: desktop notifications for session events (roadmap B5).
+"""Notify addon: session-event notifications over two channels (roadmap B5).
 
 The reference implementation of the *generic* extension path — manifest →
 ``core/slots.js`` imports the descriptor's ``module`` → the module registers
 itself in ``window.mindflockAddons`` → ``init(ctx)`` subscribes to the client
 event bus (``window.mindflock.events``). See docs/extensions.md.
 
-What it does: shows a browser Notification when a session needs your input
-(activity → ``clarify``) or its open PR leaves the review stage (merged /
-closed). The event → notification rules live server-side (``GET
-/api/notify/config``) so the backend stays the one source of truth for which
-transitions matter; ``static/addons/notify.js`` applies them client-side, where
-the Notification API (and its permission prompt) lives.
+What it does: notifies you when a session needs your input (activity →
+``clarify``), when its open PR leaves the review stage (merged / closed), when it
+blows its cost budget, and a few opt-in transitions besides. One rule list
+(:data:`NOTIFY_RULES`), two delivery channels:
+
+* **Browser** — ``static/addons/notify.js`` applies the rules client-side, where
+  the Notification API (and its permission prompt) lives. Only fires while a tab
+  is open on a secure origin.
+* **ntfy** (optional, off by default) — this module applies the same rules
+  *server-side* on the event bus and pushes to the user's ntfy topic
+  (:mod:`backend.web.core.ntfy`), so the alert reaches a phone with nothing open
+  at all. That is the channel that makes "go check on session X" work while
+  you're away from the machine.
+
+The rules stay server-side data so the backend remains the one source of truth
+for which transitions matter, and so both channels agree on what "notify me"
+means — the per-rule switches in Settings → Notifications govern both.
 """
 
 from __future__ import annotations
 
+import asyncio
+import threading
+import time
 from typing import List, Optional
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from backend.config import settings as settings_store
+from backend.web.core import mobile_access, ntfy
 
-from .base import Addon, AppContext, FrontendDescriptor
+from .base import SECRET_MASK, Addon, AppContext, FrontendDescriptor
 
-#: Event → notification rules the frontend module applies. ``old``/``new`` of
-#: ``None`` match any value; ``{session}`` in title/body is replaced with the
-#: envelope's session title. Each rule has a stable ``id``, a short ``label`` for
-#: the settings UI, and a ``default_enabled`` flag: default-on rules are opt-out
+#: Event → notification rules both channels apply. ``old``/``new`` of ``None``
+#: match any value; ``{session}`` in title/body is replaced with the envelope's
+#: session title. Each rule has a stable ``id``, a short ``label`` for the
+#: settings UI, and a ``default_enabled`` flag: default-on rules are opt-out
 #: (muted via settings.notifications.muted_rules); default-off rules are opt-in
 #: (turned on via settings.notifications.enabled_rules) because they're noisy.
+#:
+#: ``priority``/``tags`` are ntfy-only presentation: priority 4 buzzes a phone
+#: through most do-not-disturb setups, 2 lands silently, 3 is normal — so the
+#: "come look at this" rules ring and the ambient ones don't. Tags are ntfy's
+#: emoji shortcodes, kept to widely-supported names.
 NOTIFY_RULES: List[dict] = [
     {
         "id": "needs_input",
@@ -40,6 +60,8 @@ NOTIFY_RULES: List[dict] = [
         "title": "{session} needs your input",
         "body": "The agent is waiting on a clarification.",
         "default_enabled": True,
+        "priority": 4,
+        "tags": ["question"],
     },
     {
         # There is no dedicated "merged" event: an open PR sets stage "pr", and
@@ -52,6 +74,8 @@ NOTIFY_RULES: List[dict] = [
         "title": "{session}: PR merged or closed",
         "body": "The pull request left the open-review stage.",
         "default_enabled": True,
+        "priority": 3,
+        "tags": ["white_check_mark"],
     },
     {
         # J5 — cost guardrail: emitted once per session when its estimated
@@ -64,6 +88,8 @@ NOTIFY_RULES: List[dict] = [
         "title": "{session} exceeded its cost budget",
         "body": "The session's estimated cost crossed its configured budget.",
         "default_enabled": True,
+        "priority": 4,
+        "tags": ["moneybag"],
     },
     {
         # Opt-in (noisy): fires whenever a session finishes its turn and goes
@@ -76,6 +102,8 @@ NOTIFY_RULES: List[dict] = [
         "title": "{session} is idle",
         "body": "The agent finished its turn and is waiting.",
         "default_enabled": False,
+        "priority": 2,
+        "tags": ["zzz"],
     },
     {
         # Opt-in (noisy): the commit hit the pre-commit lock — hooks are running
@@ -88,6 +116,8 @@ NOTIFY_RULES: List[dict] = [
         "title": "{session}: pre-commit hooks running",
         "body": "A commit triggered the pre-commit hooks.",
         "default_enabled": False,
+        "priority": 2,
+        "tags": ["hourglass"],
     },
     {
         # Default-on (actionable, not noisy): a commit was blocked by the
@@ -103,8 +133,19 @@ NOTIFY_RULES: List[dict] = [
         "title": "{session}: pre-commit hooks failed",
         "body": "A commit was blocked by the pre-commit hooks — re-commit to continue.",
         "default_enabled": True,
+        "priority": 4,
+        "tags": ["x"],
     },
 ]
+
+#: Rule fields the client never needs: opt-in/opt-out semantics (it gets the
+#: resolved ``enabled``) and the ntfy-only presentation hints.
+_INTERNAL_RULE_FIELDS = ("default_enabled", "priority", "tags")
+
+#: At most one push per (session, event) per this many seconds. Mirrors
+#: ``DEDUPE_MS`` in static/addons/notify.js so both channels collapse a flapping
+#: transition the same way.
+_DEDUPE_SECONDS = 5.0
 
 
 def _rule_enabled(rule: dict, muted: set, opted_in: set) -> bool:
@@ -116,11 +157,23 @@ def _rule_enabled(rule: dict, muted: set, opted_in: set) -> bool:
     return rule["id"] in opted_in
 
 
+def _enabled_rules() -> List[dict]:
+    """The raw rules currently switched on (internal fields intact — this is the
+    server-side dispatch view, not the client payload)."""
+    try:
+        notifs = settings_store.load_settings().notifications
+        muted = set(notifs.muted_rules)
+        opted_in = set(notifs.enabled_rules)
+    except Exception:  # noqa: BLE001 — settings must never break dispatch
+        muted, opted_in = set(), set()
+    return [r for r in NOTIFY_RULES if _rule_enabled(r, muted, opted_in)]
+
+
 def _rules_with_state() -> List[dict]:
     """NOTIFY_RULES each tagged with its current ``enabled`` flag from settings.
 
-    ``default_enabled`` is an internal field (opt-in vs opt-out semantics) and is
-    NOT exposed to the client — the frontend only needs the resolved ``enabled``.
+    Internal fields (:data:`_INTERNAL_RULE_FIELDS`) are NOT exposed to the
+    client — the frontend only needs the resolved ``enabled``.
     """
     try:
         notifs = settings_store.load_settings().notifications
@@ -130,11 +183,33 @@ def _rules_with_state() -> List[dict]:
         muted, opted_in = set(), set()
     return [
         {
-            **{k: v for k, v in rule.items() if k != "default_enabled"},
+            **{k: v for k, v in rule.items() if k not in _INTERNAL_RULE_FIELDS},
             "enabled": _rule_enabled(rule, muted, opted_in),
         }
         for rule in NOTIFY_RULES
     ]
+
+
+def _matches(rule: dict, envelope: dict) -> bool:
+    """Whether ``envelope`` satisfies ``rule`` (``None`` constraint = any value).
+
+    The server-side twin of ``ruleMatches`` in static/addons/notify.js — keep the
+    two in step, they decide the same thing for their own channel.
+    """
+    if rule.get("event") != envelope.get("event"):
+        return False
+    if rule.get("old") is not None and rule["old"] != envelope.get("old"):
+        return False
+    if rule.get("new") is not None and rule["new"] != envelope.get("new"):
+        return False
+    return True
+
+
+def _fill(template: str, envelope: dict) -> str:
+    """``{session}`` → the envelope's session title (the JS ``fill``'s twin)."""
+    return str(template or "").replace(
+        "{session}", str(envelope.get("session") or "session")
+    )
 
 
 class NotifyAddon(Addon):
@@ -144,6 +219,67 @@ class NotifyAddon(Addon):
     def __init__(self, ctx: Optional[AppContext] = None) -> None:
         super().__init__(ctx)
         self._router = self._build_router()
+        self._unsubscribe = None
+        # (session, event) -> monotonic ts of the last push, for _DEDUPE_SECONDS.
+        self._last_push: dict = {}
+        self._push_lock = threading.Lock()
+
+    # --- ntfy channel (server-side dispatch) ------------------------------- #
+    async def on_startup(self, ctx: AppContext) -> None:
+        """Subscribe the ntfy channel to the event bus.
+
+        Always subscribed, cheaply: the callback's first act is to check whether
+        ntfy is configured at all, so an unconfigured install pays one settings
+        read per event. Subscribing unconditionally means turning ntfy on in
+        Settings takes effect immediately instead of on the next restart.
+        """
+        try:
+            ntfy.set_loop(asyncio.get_running_loop())
+        except RuntimeError:  # no loop: publish_soon falls back to a thread
+            pass
+        if self._unsubscribe is None and ctx is not None:
+            self._unsubscribe = ctx.subscribe("*", self._on_event)
+
+    async def on_shutdown(self, ctx: AppContext) -> None:
+        if self._unsubscribe is not None:
+            try:
+                self._unsubscribe()
+            finally:
+                self._unsubscribe = None
+
+    def _on_event(self, envelope: dict) -> None:
+        """Push a matching event to ntfy. Runs on the emitting thread — so it
+        stays tiny and hands the HTTP call off to the loop.
+
+        Unlike the browser channel there is no replay to guard against (the bus
+        replays only to reconnecting websockets) and no first-poll burst after a
+        restart (``server._emit_state_changes`` seeds on first sighting without
+        emitting), so a restart doesn't re-push old news.
+        """
+        try:
+            cfg = ntfy.load()
+            if not cfg.active:
+                return
+            for rule in _enabled_rules():
+                if not _matches(rule, envelope):
+                    continue
+                key = (str(envelope.get("session") or ""), str(rule["id"]))
+                now = time.monotonic()
+                with self._push_lock:
+                    if now - self._last_push.get(key, 0.0) < _DEDUPE_SECONDS:
+                        continue
+                    self._last_push[key] = now
+                ntfy.publish_soon(
+                    cfg,
+                    title=_fill(rule.get("title", ""), envelope),
+                    message=_fill(rule.get("body", ""), envelope),
+                    priority=rule.get("priority"),
+                    tags=rule.get("tags"),
+                )
+        except Exception as err:  # noqa: BLE001 — a push never breaks an emit
+            ntfy.log_error(
+                "ntfy dispatch for %s failed: %s", envelope.get("event"), err
+            )
 
     # --- routes ----------------------------------------------------------- #
     def _build_router(self) -> APIRouter:
@@ -157,9 +293,9 @@ class NotifyAddon(Addon):
 
         @router.post("/rules/{rule_id}")
         def set_rule(rule_id: str, payload: dict) -> JSONResponse:
-            """Turn one rule on/off. Default-on rules persist as an opt-out
-            (``muted_rules``); default-off rules persist as an opt-in
-            (``enabled_rules``). Unknown ids are rejected."""
+            """Turn one rule on/off (for BOTH channels). Default-on rules persist
+            as an opt-out (``muted_rules``); default-off rules persist as an
+            opt-in (``enabled_rules``). Unknown ids are rejected."""
             rule = next((r for r in NOTIFY_RULES if r["id"] == rule_id), None)
             if rule is None:
                 return JSONResponse(
@@ -186,6 +322,125 @@ class NotifyAddon(Addon):
             )
             return JSONResponse({"rules": _rules_with_state()})
 
+        @router.get("/ntfy")
+        def get_ntfy() -> JSONResponse:
+            """The ntfy channel's state for Settings → Notifications.
+
+            Never returns the token — only ``has_token``. Includes a scannable
+            QR of the subscribe URL (the fastest path from "configured here" to
+            "subscribed on the phone") and, when no topic is set yet, a random
+            one to offer.
+            """
+            return JSONResponse(_ntfy_view())
+
+        @router.post("/ntfy")
+        def set_ntfy(payload: dict) -> JSONResponse:
+            """Save the ntfy channel config; returns the same view as ``GET``.
+
+            Only the keys present are touched. The token follows the store's
+            secret convention (empty / the mask sentinel = keep the saved one),
+            with one extra safety: retargeting the channel at a *different host*
+            without supplying a new token drops the old one rather than shipping
+            server A's credential to server B.
+            """
+            payload = payload or {}
+            stored = settings_store.load_settings().notifications
+            patch: dict = {}
+            note = ""
+
+            server = stored.ntfy_server
+            if "server" in payload:
+                server = ntfy.normalize_server(str(payload.get("server") or ""))
+                patch["ntfy_server"] = server
+            topic = stored.ntfy_topic
+            if "topic" in payload:
+                topic = str(payload.get("topic") or "").strip()
+                patch["ntfy_topic"] = topic
+            if "click_url" in payload:
+                click, stripped = ntfy.strip_token_param(
+                    str(payload.get("click_url") or "")
+                )
+                patch["ntfy_click_url"] = click
+                if stripped:
+                    note = (
+                        "The access token was removed from the tap-to-open URL — "
+                        "it would have been stored on the ntfy server."
+                    )
+            if "enabled" in payload:
+                patch["ntfy_enabled"] = bool(payload.get("enabled"))
+
+            # Validate whenever the channel is (or is becoming) on, and whenever
+            # a topic is present at all — but not "pick a topic" for someone who
+            # is clearing the field on their way to switching the channel off.
+            will_be_on = bool(patch.get("ntfy_enabled", stored.ntfy_enabled))
+            if will_be_on or topic:
+                problem = ntfy.validate(server, topic)
+                if problem:
+                    return JSONResponse({"error": problem}, status_code=400)
+
+            token = str(payload.get("token") or "").strip()
+            if token and token != SECRET_MASK:
+                patch["ntfy_token"] = token
+            elif stored.ntfy_token and not ntfy.same_host(
+                stored.ntfy_server or ntfy.DEFAULT_SERVER, server
+            ):
+                patch["ntfy_token"] = ""  # "" clears (see update_settings)
+                note = (
+                    ((note + " ") if note else "")
+                    + "The saved access token was cleared — it belonged to the previous ntfy server."
+                )
+
+            if patch:
+                settings_store.update_settings(notifications=patch)
+            view = _ntfy_view()
+            if note:
+                view["note"] = note
+            return JSONResponse(view)
+
+        @router.post("/ntfy/test")
+        async def test_ntfy(payload: Optional[dict] = None) -> JSONResponse:
+            """Send one test push and report the verdict.
+
+            Takes its config from the request body when supplied, so the user can
+            verify a topic *before* saving it (same shape as the ticketing
+            connection test). Exempt from the rate cap: it is an explicit,
+            hand-driven action.
+            """
+            payload = payload or {}
+            stored = settings_store.load_settings().notifications
+            server = ntfy.normalize_server(
+                str(payload.get("server") or stored.ntfy_server or "")
+            )
+            topic = str(payload.get("topic") or stored.ntfy_topic or "").strip()
+            token = str(payload.get("token") or "").strip()
+            if not token or token == SECRET_MASK:
+                token = stored.ntfy_token
+            problem = ntfy.validate(server, topic)
+            if problem:
+                return JSONResponse({"ok": False, "error": problem})
+            click, _ = ntfy.strip_token_param(
+                str(payload.get("click_url") or stored.ntfy_click_url or "")
+            )
+            cfg = ntfy.NtfyConfig(
+                enabled=True,
+                server=server,
+                topic=topic,
+                token=token,
+                click_url=click,
+            )
+            ok, error = await ntfy.publish(
+                cfg,
+                title="MindFlock is connected",
+                message=(
+                    "Push notifications are working — this is where session "
+                    "alerts will land."
+                ),
+                priority=3,
+                tags=["bell"],
+                budgeted=False,
+            )
+            return JSONResponse({"ok": ok, "error": error})
+
         return router
 
     @property
@@ -209,3 +464,29 @@ class NotifyAddon(Addon):
                 # the bell dropdown and Settings → Notifications.
             )
         ]
+
+
+def _ntfy_view() -> dict:
+    """The ntfy channel as the settings screen needs it — never the token.
+
+    ``suggested_topic`` is always a fresh random name: it seeds the field's
+    placeholder when nothing is set AND backs the Generate button, so the client
+    never has to invent a topic with its own weaker randomness.
+    """
+    cfg = ntfy.load()
+    return {
+        "enabled": cfg.enabled,
+        "server": cfg.server,
+        "server_default": ntfy.DEFAULT_SERVER,
+        "topic": cfg.topic,
+        "has_token": bool(cfg.token),
+        "click_url": cfg.click_url,
+        "configured": cfg.configured,
+        "active": cfg.active,
+        "public_server": cfg.is_public_server,
+        "subscribe_url": cfg.subscribe_url,
+        "last": ntfy.last_result(),
+        "suggested_topic": ntfy.random_topic(),
+        # Same renderer as the Settings → Mobile QR; None when segno is absent.
+        "qr_svg": mobile_access.qr_svg(cfg.subscribe_url) if cfg.topic else None,
+    }

--- a/backend/web/addons/settings.py
+++ b/backend/web/addons/settings.py
@@ -28,7 +28,7 @@ from backend import doctor, providers
 from backend.config import settings as settings_store
 from backend.providers import config as provider_config
 
-from .base import Addon, AppContext, FrontendDescriptor
+from .base import SECRET_MASK, Addon, AppContext, FrontendDescriptor
 
 # Field paths (group, field) that hold secrets — masked on read, keep-on-empty
 # on write.
@@ -37,8 +37,9 @@ from .base import Addon, AppContext, FrontendDescriptor
 _SECRET_FIELDS = {
     ("github", "token"),
     ("general", "auth_token"),
+    ("notifications", "ntfy_token"),
 }
-_MASK = "•••set"
+_MASK = SECRET_MASK  # the one sentinel, defined in addons/base.py
 
 
 def _mask_ticketing(d: dict) -> None:

--- a/backend/web/core/mobile_access.py
+++ b/backend/web/core/mobile_access.py
@@ -236,8 +236,12 @@ def _mobile_banner(*, for_log: bool = False) -> str:
     return "\n".join(lines)
 
 
-def _mobile_svg(data: str):
-    """``data`` as an inline, scannable SVG QR (dark-on-white), or None."""
+def qr_svg(data: str):
+    """``data`` as an inline, scannable SVG QR (dark-on-white), or None.
+
+    The one QR renderer any settings screen shares — Settings → Mobile's phone
+    URL and the notify addon's ntfy subscribe URL both come through here.
+    """
     try:
         import io
 
@@ -278,6 +282,11 @@ def _mobile_svg(data: str):
         return svg
     except Exception:  # noqa: BLE001
         return None
+
+
+#: Historical name, kept because server.py re-exports it (and _mobile_info calls
+#: it back through the server module).
+_mobile_svg = qr_svg
 
 
 def _mobile_info() -> dict:

--- a/backend/web/core/ntfy.py
+++ b/backend/web/core/ntfy.py
@@ -1,0 +1,445 @@
+"""Optional ntfy push channel for session notifications.
+
+The browser channel (``static/addons/notify.js``) can only fire while a tab is
+open on a secure origin. This module is its *server-side* counterpart: the
+running server POSTs matching events to an `ntfy <https://ntfy.sh>`_ topic, so
+"session X needs your input" reaches a phone with nothing open at all — which is
+the point of a flock you check on rather than watch.
+
+How the pieces divide up:
+
+* **Config** lives in ``settings.notifications`` (the ``ntfy_*`` fields),
+  resolved through the usual env → settings.json → default chain, so a headless
+  box can export ``MINDFLOCK_NTFY_TOPIC`` and be done.
+* **Which** events push is NOT decided here — the notify addon owns the rules
+  (``NOTIFY_RULES``) and both channels share them, so "what notifies me" stays
+  one list in one place (Settings → Notifications).
+* **Transport** is ntfy's JSON publish API (POST to the server root with the
+  topic in the body) rather than the ``POST /<topic>`` + ``X-Title`` header
+  form: session titles are arbitrary UTF-8 and HTTP headers are not.
+
+Everything here is best-effort — a failed push is recorded in
+:func:`last_result` (for Settings → Notifications to show) and logged, but never
+raises into the request path that emitted the event.
+
+Privacy notes, deliberate:
+
+* On a public server the **topic name is the credential** — anyone who knows it
+  can read every push and publish fakes. Hence :func:`random_topic` and the
+  UI's Generate button; hence also nothing here ever logs the topic (the log is
+  served back out over ``GET /api/logs``).
+* A push carries the session title and the rule's text to a third-party server.
+  That is inherent to the feature, so the UI says so out loud rather than
+  burying it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import secrets
+import threading
+import time
+import urllib.parse
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, List, Optional, Tuple
+
+from backend import log
+from backend.config import settings as settings_store
+
+#: Where pushes go when the user names no server: the public instance.
+DEFAULT_SERVER = "https://ntfy.sh"
+
+#: ntfy's topic charset. Anything outside it 404s (or lands on the wrong topic),
+#: so it is rejected at the edge instead of failing silently at publish time.
+_TOPIC_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+#: Total seconds one publish may take. Short: an event-bus subscriber is waiting
+#: on nothing, but a wedged server must not keep a task alive for minutes.
+_TIMEOUT = 10.0
+
+#: Runaway guard. A pathological session flip-flopping between states could
+#: otherwise burn the user's ntfy quota (and their patience) — cap the whole
+#: process at this many pushes per rolling window and log once when we start
+#: dropping. Well above any sane real rate: the default-on rules are all
+#: low-frequency, one-per-transition events.
+_RATE_LIMIT = 60
+_RATE_WINDOW = 3600.0
+
+_LOCK = threading.Lock()
+_SENT: Deque[float] = deque()  # monotonic ts of recent pushes (rate window)
+# Monotonic ts of the last "dropping pushes" log line; None = never logged. A
+# sentinel rather than 0.0 because monotonic()'s zero point is arbitrary, so
+# "now - 0 > window" is not a reliable "long ago".
+_THROTTLE_LOGGED: Optional[float] = None
+_LAST: dict = {}  # {"ts": epoch, "ok": bool, "error": str} of the last attempt
+
+#: The server's event loop, so a push can be fired from a bus callback running
+#: on any worker thread (same trick as ``EventBus.set_loop``).
+_LOOP: Optional[asyncio.AbstractEventLoop] = None
+
+
+def set_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Register the loop :func:`publish_soon` schedules onto (the notify addon
+    calls this from its startup hook, which runs on the server loop)."""
+    global _LOOP
+    _LOOP = loop
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class NtfyConfig:
+    """The resolved ntfy settings. Build with :func:`load` (or by hand in tests
+    and in the "test before you save" path, which configures from the request
+    body rather than the store)."""
+
+    enabled: bool = False
+    server: str = DEFAULT_SERVER
+    topic: str = ""
+    token: str = ""
+    click_url: str = ""
+
+    @property
+    def configured(self) -> bool:
+        """A topic is the one thing with no sensible default."""
+        return bool(self.topic)
+
+    @property
+    def active(self) -> bool:
+        """Turned on AND pointed somewhere — the check before every push."""
+        return bool(self.enabled and self.topic)
+
+    @property
+    def host(self) -> str:
+        """Host[:port] of the server, for log lines that must not leak the
+        topic."""
+        return urllib.parse.urlsplit(self.server).netloc or self.server
+
+    @property
+    def is_public_server(self) -> bool:
+        """True on the shared public instance, where every topic is world-
+        readable to anyone who guesses it (the UI warns on this)."""
+        return self.host.lower() in ("ntfy.sh", "www.ntfy.sh")
+
+    @property
+    def subscribe_url(self) -> str:
+        """The URL/deep link to hand a phone (what the settings QR encodes)."""
+        return "%s/%s" % (self.server.rstrip("/"), self.topic) if self.topic else ""
+
+
+def load() -> NtfyConfig:
+    """The ntfy config in effect: env → settings.json → defaults.
+
+    The env overrides (``MINDFLOCK_NTFY_*``) exist for headless/provisioned
+    boxes that configure by environment and never open Settings.
+    """
+    try:
+        enabled = settings_store.resolve_bool(
+            env="MINDFLOCK_NTFY_ENABLED",
+            settings_getter=lambda s: s.notifications.ntfy_enabled or None,
+            default=False,
+        )
+        server = settings_store.resolve_str(
+            env="MINDFLOCK_NTFY_SERVER",
+            settings_getter=lambda s: s.notifications.ntfy_server,
+            default=DEFAULT_SERVER,
+        )
+        topic = settings_store.resolve_str(
+            env="MINDFLOCK_NTFY_TOPIC",
+            settings_getter=lambda s: s.notifications.ntfy_topic,
+            default="",
+        )
+        token = settings_store.resolve_str(
+            env="MINDFLOCK_NTFY_TOKEN",
+            settings_getter=lambda s: s.notifications.ntfy_token,
+            default="",
+        )
+        click = settings_store.resolve_str(
+            env="MINDFLOCK_NTFY_CLICK_URL",
+            settings_getter=lambda s: s.notifications.ntfy_click_url,
+            default="",
+        )
+    except Exception:  # noqa: BLE001 — an unreadable store just means "off"
+        return NtfyConfig()
+    # An env-supplied topic is an implicit opt-in: nobody exports
+    # MINDFLOCK_NTFY_TOPIC on a headless box and then wants silence, and there
+    # is no Settings screen there to flip the switch in. But an EXPLICIT
+    # MINDFLOCK_NTFY_ENABLED still wins — "=0" has to mean off, or the only way
+    # to silence a configured box would be to unset the topic.
+    if (
+        topic
+        and not enabled
+        and os.environ.get("MINDFLOCK_NTFY_TOPIC")
+        and not os.environ.get("MINDFLOCK_NTFY_ENABLED")
+    ):
+        enabled = True
+    return NtfyConfig(
+        enabled=bool(enabled),
+        server=normalize_server(server),
+        topic=topic.strip(),
+        token=token.strip(),
+        click_url=click.strip(),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Validation / helpers for the settings edge
+# --------------------------------------------------------------------------- #
+def normalize_server(raw: str) -> str:
+    """A user-typed server into a canonical base URL.
+
+    ``""`` -> the public default; a bare host gets ``https://`` (typing
+    "ntfy.example.com" should not silently become a relative URL); the trailing
+    slash goes so ``server + "/" + topic`` never doubles up.
+    """
+    s = (raw or "").strip().rstrip("/")
+    if not s:
+        return DEFAULT_SERVER
+    if "://" not in s:
+        s = "https://" + s
+    return s
+
+
+def validate(server: str, topic: str) -> Optional[str]:
+    """``None`` when the pair is publishable, else a user-facing reason."""
+    parts = urllib.parse.urlsplit(normalize_server(server))
+    if parts.scheme not in ("http", "https"):
+        return "The ntfy server URL must start with http:// or https://"
+    if not parts.netloc:
+        return "That ntfy server URL has no host"
+    if not topic:
+        return "Pick a topic — it is the address your phone subscribes to"
+    if not _TOPIC_RE.match(topic):
+        return (
+            "A topic can only use letters, numbers, dashes and underscores "
+            "(up to 64 characters)"
+        )
+    return None
+
+
+def random_topic() -> str:
+    """An unguessable topic name.
+
+    On the public server the topic is the only thing standing between your
+    session titles and anyone who tries a word — so the default we offer is
+    random, not "mindflock". ``token_urlsafe`` emits ``[A-Za-z0-9_-]``, exactly
+    ntfy's charset.
+    """
+    return "mindflock-" + secrets.token_urlsafe(18)
+
+
+def strip_token_param(url: str) -> Tuple[str, bool]:
+    """``(url without any ``token=`` query param, whether one was removed)``.
+
+    A tapped-notification URL is stored on the ntfy server and travels with
+    every push. Users naturally paste the URL from Settings → Mobile, which
+    carries ``?token=<access token>`` — that would hand this machine's
+    credential to a third party, so it comes out here rather than in a warning
+    the user may not read.
+    """
+    raw = (url or "").strip()
+    if not raw:
+        return "", False
+    parts = urllib.parse.urlsplit(raw)
+    if not parts.query:
+        return raw, False
+    kept = [
+        (k, v)
+        for k, v in urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+        if k.lower() != "token"
+    ]
+    if len(kept) == len(urllib.parse.parse_qsl(parts.query, keep_blank_values=True)):
+        return raw, False
+    return (
+        urllib.parse.urlunsplit(parts._replace(query=urllib.parse.urlencode(kept))),
+        True,
+    )
+
+
+def same_host(a: str, b: str) -> bool:
+    """Whether two server URLs point at the same host[:port].
+
+    Used to decide whether a saved token still belongs to the server being
+    saved: retargeting the channel at a different host must not ship the old
+    server's token to the new one.
+    """
+    return (
+        urllib.parse.urlsplit(normalize_server(a)).netloc.lower()
+        == urllib.parse.urlsplit(normalize_server(b)).netloc.lower()
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Publish
+# --------------------------------------------------------------------------- #
+def _allow_one() -> bool:
+    """Consume one slot from the rolling rate budget (False = drop this push)."""
+    global _THROTTLE_LOGGED
+    now = time.monotonic()
+    with _LOCK:
+        while _SENT and now - _SENT[0] > _RATE_WINDOW:
+            _SENT.popleft()
+        if len(_SENT) < _RATE_LIMIT:
+            _SENT.append(now)
+            return True
+        # Over budget: log the first drop of each window, then stay quiet
+        # (a throttle that spams the log is its own problem).
+        should_log = _THROTTLE_LOGGED is None or now - _THROTTLE_LOGGED > _RATE_WINDOW
+        if should_log:
+            _THROTTLE_LOGGED = now
+    if should_log and log.ErrorLog is not None:
+        try:
+            log.ErrorLog.Printf(
+                "ntfy: over %d pushes/hour — dropping further pushes this window",
+                _RATE_LIMIT,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+    return False
+
+
+def _record(ok: bool, error: str = "") -> None:
+    """Remember the outcome of the last attempt for Settings → Notifications."""
+    with _LOCK:
+        _LAST.clear()
+        _LAST.update({"ts": time.time(), "ok": bool(ok), "error": error})
+
+
+def last_result() -> dict:
+    """``{}`` before the first attempt, else ``{ts, ok, error}`` of the last one.
+
+    A push channel is invisible when it works and baffling when it doesn't;
+    this is what the settings screen shows so a wrong token/topic is diagnosable
+    without reading the log.
+    """
+    with _LOCK:
+        return dict(_LAST)
+
+
+async def publish(
+    cfg: NtfyConfig,
+    *,
+    title: str,
+    message: str,
+    priority: Optional[int] = None,
+    tags: Optional[List[str]] = None,
+    click: Optional[str] = None,
+    budgeted: bool = True,
+) -> Tuple[bool, str]:
+    """POST one notification. Returns ``(ok, error)`` and never raises.
+
+    ``budgeted=False`` skips the rate cap — for the user-initiated "Send a test"
+    button, which cannot run away and whose whole job is to report a verdict.
+    """
+    if not cfg.topic:
+        return False, "No ntfy topic configured"
+    if budgeted and not _allow_one():
+        return False, "Rate limit: too many ntfy pushes this hour"
+    body: dict = {"topic": cfg.topic, "message": message or ""}
+    if title:
+        body["title"] = title
+    if priority:
+        body["priority"] = int(priority)
+    if tags:
+        body["tags"] = list(tags)
+    target = (click or cfg.click_url or "").strip()
+    if target:
+        body["click"] = target
+    headers = {"Content-Type": "application/json"}
+    if cfg.token:
+        headers["Authorization"] = "Bearer " + cfg.token
+    try:
+        import aiohttp
+
+        timeout = aiohttp.ClientTimeout(total=_TIMEOUT)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(cfg.server, json=body, headers=headers) as resp:
+                if resp.status >= 400:
+                    detail = await _error_detail(resp)
+                    err = "ntfy server returned %d%s" % (
+                        resp.status,
+                        (": " + detail) if detail else "",
+                    )
+                    _record(False, err)
+                    log_error("ntfy publish to %s failed: %s", cfg.host, err)
+                    return False, err
+        _record(True)
+        return True, ""
+    except asyncio.CancelledError:  # shutdown — not a delivery failure
+        raise
+    except Exception as err:  # noqa: BLE001 — DNS, TLS, timeout, aiohttp missing
+        msg = "%s: %s" % (type(err).__name__, err) if str(err) else type(err).__name__
+        _record(False, msg)
+        log_error("ntfy publish to %s failed: %s", cfg.host, msg)
+        return False, msg
+
+
+async def _error_detail(resp) -> str:
+    """The ``error`` field of ntfy's JSON error body, best-effort and bounded.
+
+    ntfy answers a bad token/topic with ``{"code":…,"error":"…"}``; surfacing
+    that sentence is the difference between "returned 403" and "topic is
+    reserved". A non-JSON body (a proxy's HTML error page) is truncated.
+    """
+    try:
+        data = await resp.json(content_type=None)
+        if isinstance(data, dict):
+            detail = str(data.get("error") or "").strip()
+            if detail:
+                return detail[:200]
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        return (await resp.text())[:200].strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def publish_soon(
+    cfg: NtfyConfig,
+    *,
+    title: str,
+    message: str,
+    priority: Optional[int] = None,
+    tags: Optional[List[str]] = None,
+) -> None:
+    """Fire-and-forget :func:`publish` from any thread.
+
+    Event-bus subscribers run synchronously on whichever thread emitted, so this
+    must never block: it hands the coroutine to the server loop (or, with no
+    loop at all — a bare sync context such as a unit test — a throwaway thread
+    with its own), exactly like ``EventBus._dispatch_hooks``.
+    """
+    coro = publish(cfg, title=title, message=message, priority=priority, tags=tags)
+    try:
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        target = running or _LOOP
+        if target is not None and not target.is_closed():
+            if running is target:
+                target.create_task(coro)
+            else:
+                asyncio.run_coroutine_threadsafe(coro, target)
+            return
+        threading.Thread(target=lambda: asyncio.run(coro), daemon=True).start()
+    except Exception as err:  # noqa: BLE001 — a push is never worth a 500
+        coro.close()
+        log_error("ntfy dispatch failed: %s", err)
+
+
+def log_error(fmt: str, *args) -> None:
+    """Log a line. Callers pass the server *host*, never the topic —
+    mindflock.log is served back out over ``GET /api/logs``, and on a public
+    server the topic is the credential."""
+    if log.ErrorLog is None:
+        return
+    try:
+        log.ErrorLog.Printf(fmt, *args)
+    except Exception:  # noqa: BLE001
+        pass

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29589,10 +29589,248 @@ function Notifications(_) {
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", id: "notif-browser-status", children: status }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(Ntfy, {}),
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "What triggers a notification" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Pick exactly which events notify you — turn off any you don't want." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Pick exactly which events notify you — turn off any you don't want. These switches apply to every channel above." }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "notif-rules-list", children: rulesError ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "Couldn't load notification rules." }) : rules === null ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "Loading…" }) : !rules.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "No notification rules configured." }) : rules.map((rule) => /* @__PURE__ */ jsxRuntimeExports.jsx(RuleRow, { rule }, rule.id)) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Also reachable from the bell in the sidebar header." })
+  ] });
+}
+function ago(ts) {
+  const secs = Math.max(0, Math.round(Date.now() / 1e3 - ts));
+  if (secs < 60) return "just now";
+  if (secs < 3600) return Math.round(secs / 60) + " min ago";
+  if (secs < 86400) return Math.round(secs / 3600) + "h ago";
+  return Math.round(secs / 86400) + "d ago";
+}
+function Ntfy() {
+  const [view, setView] = reactExports.useState(null);
+  const [failed, setFailed] = reactExports.useState(false);
+  const [server, setServer] = reactExports.useState("");
+  const [topic, setTopic] = reactExports.useState("");
+  const [token, setToken] = reactExports.useState("");
+  const [click, setClick] = reactExports.useState("");
+  const [testing, setTesting] = reactExports.useState(false);
+  const [verdict, setVerdict] = reactExports.useState(null);
+  const apply2 = reactExports.useCallback((v) => {
+    setView(v);
+    setServer(v.server || "");
+    setTopic(v.topic || "");
+    setClick(v.click_url || "");
+    setToken("");
+    if (v.note) toast(v.note);
+  }, []);
+  const load2 = reactExports.useCallback(async () => {
+    try {
+      apply2(await api("/api/notify/ntfy"));
+      setFailed(false);
+    } catch {
+      setFailed(true);
+    }
+  }, [apply2]);
+  reactExports.useEffect(() => {
+    load2();
+  }, [load2]);
+  const save2 = reactExports.useCallback(
+    async (patch) => {
+      try {
+        apply2(await api("/api/notify/ntfy", { json: patch }));
+      } catch (err) {
+        toast(err.message || "Couldn't save the ntfy settings");
+        load2();
+      }
+    },
+    [apply2, load2]
+  );
+  if (failed)
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Phone push (ntfy)" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "Couldn't load the ntfy settings." })
+    ] });
+  if (!view) return /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Phone push (ntfy)" });
+  const on = !!view.enabled;
+  const last = view.last || {};
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Phone push (ntfy)" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "set-hint", children: [
+      "Get these alerts on your phone — even with MindFlock closed, because the server sends them, not the browser. Install the free",
+      " ",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("a", { href: "https://ntfy.sh", target: "_blank", rel: "noopener noreferrer", children: "ntfy" }),
+      " ",
+      "app, subscribe to the topic below, and check in on the flock from anywhere."
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "div",
+      {
+        className: "set-row set-switch-row",
+        id: "ntfy-row",
+        title: "Push notifications to an ntfy topic your phone subscribes to",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Push to ntfy" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "checkbox",
+                id: "ntfy-toggle",
+                checked: on,
+                onChange: (e) => save2({
+                  enabled: e.target.checked,
+                  // Send the typed-but-uncommitted topic too, so flipping the
+                  // switch right after typing one doesn't fail validation.
+                  topic: topic.trim(),
+                  server: server.trim()
+                })
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
+          ] })
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ntfy-field-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Topic" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          id: "ntfy-topic",
+          value: topic,
+          autoComplete: "off",
+          spellCheck: false,
+          placeholder: view.suggested_topic || "mindflock-…",
+          onChange: (e) => setTopic(e.target.value),
+          onBlur: () => topic.trim() !== (view.topic || "") && save2({ topic: topic.trim() }),
+          onKeyDown: (e) => e.key === "Enter" && e.target.blur()
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          className: "test-btn",
+          id: "ntfy-generate",
+          title: "Use a long random topic name — on the public server the topic name is the only thing keeping strangers out",
+          onClick: () => {
+            const fresh = view.suggested_topic;
+            if (!fresh) return;
+            setTopic(fresh);
+            save2({ topic: fresh });
+          },
+          children: "Generate"
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ntfy-field-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Server" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          id: "ntfy-server",
+          value: server,
+          autoComplete: "off",
+          spellCheck: false,
+          placeholder: view.server_default || "https://ntfy.sh",
+          onChange: (e) => setServer(e.target.value),
+          onBlur: () => server.trim() !== (view.server || "") && save2({ server: server.trim() }),
+          onKeyDown: (e) => e.key === "Enter" && e.target.blur()
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Leave as-is for the public server, or point at your own." })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ntfy-field-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Access token" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          id: "ntfy-token",
+          type: "password",
+          value: token,
+          autoComplete: "off",
+          placeholder: view.has_token ? SECRET_MASK + " (saved)" : "only for a protected topic",
+          onChange: (e) => setToken(e.target.value),
+          onBlur: () => token && save2({ token }),
+          onKeyDown: (e) => e.key === "Enter" && e.target.blur()
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Needed only if your topic is access-protected (self-hosted, or a reserved ntfy.sh topic). Blank keeps the saved one." })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ntfy-field-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Tapping opens" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          id: "ntfy-click",
+          value: click,
+          autoComplete: "off",
+          spellCheck: false,
+          placeholder: "optional — e.g. your phone URL from Settings → Mobile",
+          onChange: (e) => setClick(e.target.value),
+          onBlur: () => click.trim() !== (view.click_url || "") && save2({ click_url: click.trim() }),
+          onKeyDown: (e) => e.key === "Enter" && e.target.blur()
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Opened when you tap the notification. Don't paste an access token into it — it would be stored on the ntfy server (MindFlock strips one if you do)." })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ntfy-test-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          className: "test-btn",
+          id: "ntfy-test",
+          disabled: testing || !topic.trim(),
+          onClick: async () => {
+            setTesting(true);
+            setVerdict(null);
+            try {
+              const r = await api("/api/notify/ntfy/test", {
+                json: {
+                  server: server.trim(),
+                  topic: topic.trim(),
+                  token: token || void 0,
+                  click_url: click.trim()
+                }
+              });
+              setVerdict(
+                (r == null ? void 0 : r.ok) ? { ok: true, text: "Sent — check your phone." } : { ok: false, text: (r == null ? void 0 : r.error) || "The push failed." }
+              );
+            } catch (err) {
+              setVerdict({ ok: false, text: err.message || "The push failed." });
+            }
+            setTesting(false);
+          },
+          children: testing ? "Sending…" : "Send a test"
+        }
+      ),
+      verdict && /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "span",
+        {
+          id: "ntfy-verdict",
+          className: verdict.ok ? "ntfy-verdict-ok" : "ntfy-verdict-bad",
+          children: verdict.text
+        }
+      ),
+      !verdict && last.ts && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: last.ok ? "ntfy-verdict-ok" : "ntfy-verdict-bad", children: last.ok ? "Last push sent " + ago(last.ts) : "Last push failed: " + last.error })
+    ] }),
+    view.qr_svg && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "ntfy-qr", className: "qr-card", dangerouslySetInnerHTML: { __html: view.qr_svg } }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "set-hint", children: [
+        "Scan this in the ntfy app to subscribe, or open",
+        " ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("a", { href: view.subscribe_url, target: "_blank", rel: "noopener noreferrer", children: view.subscribe_url }),
+        "."
+      ] })
+    ] }),
+    on && view.public_server && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "ntfy-warning", id: "ntfy-public-warning", children: [
+      "You're using the public ",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "ntfy.sh" }),
+      " server: your session titles travel through it, and ",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "anyone who knows the topic name can read them" }),
+      " (or send you fakes). Keep a long random topic — or self-host ntfy and point the Server field at it."
+    ] })
   ] });
 }
 function RuleRow({ rule }) {

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -7368,8 +7368,11 @@ button.linklike {
   margin-right: auto;
 }
 } /* 250 */ @layer components{
-/* Settings → Mobile: white QR card + URL rows */
-#mobile-qr {
+/* Settings → Mobile: white QR card + URL rows.
+   .qr-card is shared with Settings → Notifications (the ntfy subscribe QR) —
+   a QR must stay dark-on-white to scan, whatever the app theme is doing. */
+#mobile-qr,
+.qr-card {
   background: #fff;
   border-radius: 12px;
   padding: 12px;
@@ -7378,7 +7381,8 @@ button.linklike {
   box-shadow: 0 1px 4px rgba(0, 0, 0, .3);
 }
 
-#mobile-qr svg {
+#mobile-qr svg,
+.qr-card svg {
   display: block;
   width: 200px;
   height: 200px;
@@ -7497,6 +7501,64 @@ button.linklike {
   background: var(--bg);
   color: var(--text);
   font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+} /* 260 */ @layer components{
+
+/* Settings → Notifications: the ntfy (phone push) section.
+   The QR card itself is the shared .qr-card from mobileLogs.css. */
+
+/* Label + field + trailing button on one line (Topic […] [Generate]), so the
+   generate/test affordance sits with the field it acts on instead of below it. */
+.ntfy-field-row {
+  display: grid;
+  grid-template-columns: 150px 1fr auto;
+  align-items: center;
+  gap: 6px 12px;
+  margin: 8px 0;
+}
+
+.ntfy-field-row .set-label {
+  min-width: 0;
+}
+
+.ntfy-field-row input {
+  min-width: 0; /* let the input shrink inside the grid track instead of overflowing */
+  width: 100%;
+}
+
+/* The hint under a field spans the whole row, aligned under the input. */
+.ntfy-field-row .set-hint {
+  grid-column: 2 / -1;
+  margin: 0;
+}
+
+/* "Anyone who knows your topic can read these" — a real caveat of the public
+   server, so it gets a callout rather than another grey hint nobody reads. */
+.ntfy-warning {
+  border: 1px solid var(--gold);
+  border-radius: 10px;
+  background: var(--panel-2);
+  padding: 10px 14px;
+  margin: 10px 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+/* Test button + its verdict on one line. */
+.ntfy-test-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 12px 0 4px;
+}
+
+.ntfy-verdict-ok {
+  color: var(--green);
+}
+
+.ntfy-verdict-bad {
+  color: var(--red);
 }
 } /* 260 */ @layer components{
 /* --- Capability gating (git / tailscale / ticketing) ------------------------

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,17 @@ FastAPI app `backend.web.server:app`. Key pieces:
 - **`core/events.py`** — the server-side session event bus: `session.*` events
   broadcast over `WS /api/events`, delivered to in-process addons via
   `AppContext.subscribe`, and to user shell hooks under `~/.mindflock/hooks/`.
+  Note the asymmetry: websocket clients and shell hooks are decoupled from the
+  emitter, but `subscribe` callbacks run **synchronously on the emitting thread**,
+  so every subscriber is on `emit()`'s critical path and must neither block nor
+  raise. Anything slow gets offloaded — `ntfy.publish_soon` is the reference
+  pattern, handing its HTTP call to the server loop via the same trampoline
+  `EventBus._dispatch_hooks` uses for shell hooks.
+- **`core/ntfy.py`** — the optional [ntfy](https://ntfy.sh) push channel: the
+  transport (JSON publish, rate cap, last-result reporting) behind the notify
+  addon's server-side bus subscriber, so a "needs your input" reaches a phone
+  with no browser tab open. Off until configured; see
+  [web-ui.md](web-ui.md#notifications-).
 - **`core/auth.py`** — shared bearer-token ASGI middleware gating HTTP + websockets
   whenever the server is exposed beyond localhost (cookie / header / `?token=`,
   QR deep-link for the mobile page).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,6 +333,11 @@ Override the directory with `MINDFLOCK_ASSISTANT_DIR`.
 | `MINDFLOCK_LOG_QUIET` | unset | Web server request log — by default **every** request is logged; set `1` to drop the UI's high-frequency poll endpoints (`/api/instances`, `/api/events`, `/static/…`, `/vendor/…`, favicon), which are still logged when they error or take ≥ 1.5 s |
 | `MINDFLOCK_PIPELINE_LOG_MAX_BYTES` | `51200` (50 KB) | Ingestion pipeline log (`[logging].log_file`) rotation cap — current file ≤ this plus one rollover backup |
 | `MINDFLOCK_SETTINGS_FILE` | `~/.mindflock/settings.json` | Path of the web settings store (tests point it at a tmp file) |
+| `MINDFLOCK_NTFY_TOPIC` | — | ntfy topic session notifications are pushed to. Setting it is an **implicit opt-in** (a headless box has no Settings screen to flip the switch in); wins over `notifications.ntfy_topic` |
+| `MINDFLOCK_NTFY_SERVER` | `https://ntfy.sh` | ntfy server the pushes go to — point it at your own instance to keep session titles off the public one |
+| `MINDFLOCK_NTFY_TOKEN` | — | ntfy access token, for a protected topic or an authenticated self-hosted server |
+| `MINDFLOCK_NTFY_ENABLED` | unset | Master switch for the ntfy channel (`1`/`0`). Redundant when `MINDFLOCK_NTFY_TOPIC` is set, which already implies on — but not powerless against it: setting this **explicitly** wins either way, so `MINDFLOCK_NTFY_ENABLED=0` silences a box whose topic var stays exported |
+| `MINDFLOCK_NTFY_CLICK_URL` | — | URL a tapped ntfy notification opens (e.g. your tailnet `/m` URL). Never put an access token in it — it is stored on the ntfy server |
 | `MINDFLOCK_TEMPLATES_FILE` | `~/.mindflock/session_templates.json` | Path of the session-template store |
 | `MINDFLOCK_PROMPT_QUEUE_FILE` | `~/.mindflock/prompt_queues.json` | Path of the per-session prompt-queue store (queued prompts, loop/enabled flags) |
 | `MINDFLOCK_PORTS_FILE` | `~/.mindflock/ports.json` | Path of the session port-block allocation store (the O4 `PORT`/`MINDFLOCK_PORT_BASE` blocks) |
@@ -350,6 +355,17 @@ Override the directory with `MINDFLOCK_ASSISTANT_DIR`.
 | `MINDFLOCK_INSTALL_SCRIPT` | bundled `install.sh` | Desktop app only — path to the installer the **Install the engine** button runs. Point it at a stub to exercise that flow without reinstalling anything |
 
 > Naming note: launcher variables kept their historical `CS_` prefix
+
+> **`MINDFLOCK_NTFY_*` wins over Settings → Notifications.** Each of the five
+> resolves `env → settings.json → default` **per field** (the standard
+> `config/settings.py` resolver: a non-empty env var short-circuits, an empty one
+> counts as unset). The consequence is worth stating plainly because it is
+> invisible from the UI: on a box where these are exported the Notifications
+> screen still renders as editable and still saves, but the saved value has no
+> effect while the env var is set — and since `GET /api/notify/ntfy` reports the
+> *resolved* value, the screen shows the env value rather than what was typed.
+> Precedence being per field, exporting only `MINDFLOCK_NTFY_SERVER` pins the
+> server while topic and token still come from the UI. Pick one source per field.
 
 ## Web-exposed settings
 
@@ -384,3 +400,40 @@ Settable from the UI settings dialog (⚙) and persisted server-side:
   (empty entries dropped); a **bare string** left by an older build is coerced to
   the current `default_provider` key on load (dropped if no default provider is
   set).
+- **Notification rules** (`notifications.muted_rules` / `enabled_rules`,
+  Settings → Notifications) — which session events notify you. Default-on rules
+  are opt-*out* (their id lands in `muted_rules`), noisier ones are opt-*in*
+  (`enabled_rules`), so a rule added in a later release starts in the state its
+  author intended. One list governs every delivery channel.
+- **ntfy push** (`notifications.ntfy_enabled` / `_server` / `_topic` / `_token` /
+  `_click_url`, Settings → Notifications) — the optional server-side push channel
+  that reaches a phone with no browser tab open (see
+  [web-ui.md](web-ui.md#notifications-) for the UI and
+  [web-api.md](web-api.md) for the endpoints). Off until configured. `_server`
+  defaults to the public `https://ntfy.sh`; `_topic` is the address your phone
+  subscribes to and, on a public server, the *only* thing keeping strangers out —
+  so let the UI generate a random one. `_token` is a secret (masked on read, kept
+  on an empty write, and dropped if `_server` is retargeted at a different host).
+  `_click_url` is opened when you tap the notification; a `token=` parameter is
+  stripped from it, since it is stored on the ntfy server.
+
+The whole `notifications` group as it lands in `settings.json`:
+
+```jsonc
+"notifications": {
+  "muted_rules": ["pr_closed"],          // default-on rules switched OFF
+  "enabled_rules": ["session_idle"],     // default-off rules switched ON
+  "ntfy_enabled": true,
+  "ntfy_server": "https://ntfy.sh",      // omitted = the public default
+  "ntfy_topic": "mindflock-xTPq…",       // on a public server this IS the credential
+  "ntfy_token": "tk_…",                  // secret: masked on read as "•••set"
+  "ntfy_click_url": "https://box.tailnet.ts.net/m"
+}
+```
+
+**Absent means default, not corrupt.** Every key here is omitted from the written
+file when its value is falsy (`NotificationSettings.to_dict` writes only what is
+set), so a freshly-configured install shows `"notifications": {"ntfy_enabled":
+true, "ntfy_topic": "…"}` and nothing else — no empty strings, no `false`. A group
+missing entirely means "all defaults". Editing the file by hand works, but the
+server caches the store per process, so a hand edit needs a restart to be seen.

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,14 @@ Dependency groups (`pyproject.toml`): base (`aiohttp`, `tomli`), `dev` (pytest,
 pytest-asyncio, hypothesis, httpx), `engine` (pyperclip, ptyprocess), `web`
 (engine + fastapi, uvicorn, segno).
 
+`segno` (pure-Python QR codes) is imported **lazily and optionally**: it renders
+the startup banner's mobile-URL QR, the Settings → Mobile QR, and the ntfy
+subscribe QR, all through `mobile_access.qr_svg` / `_qr_lines`. Without it
+installed, `qr_svg` returns `None`, the API fields that carry it (`GET /api/mobile`,
+`GET /api/notify/ntfy` → `qr_svg`) are `null`, and each surface falls back to the
+plain URL — a graceful degradation, not a bug to chase. Anything asserting on a QR
+should skip when the import fails rather than fail.
+
 External tools the code shells out to: `git`, `tmux`, `uv`, plus the agent
 CLI (`claude`) and optionally `gh` (PR create/merge only — pushing is plain
 `git push`), `cursor`, `tailscale`, `wt.exe`.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -173,6 +173,26 @@ class Addon(abc.ABC):
     async def on_shutdown(self, ctx: AppContext) -> None: ...
 ```
 
+`on_startup` / `on_shutdown` are the lifecycle pair, awaited on the server loop
+around the app's lifespan, and they are where an **in-process subscription**
+belongs — a constructor runs too early to have a loop to hand work to.
+The contract:
+
+- `ctx.subscribe(...)` returns an **unsubscribe callable**. The addon must retain
+  it and call it from `on_shutdown`; nothing reclaims it otherwise, so a
+  re-subscribing addon accumulates live callbacks (the notify addon guards with
+  `if self._unsubscribe is None`, making startup idempotent).
+- Subscribe **unconditionally** and let the *callback* decide whether the feature
+  is switched on. The alternative — subscribing only when configured — means a
+  toggle in Settings does nothing until the next restart.
+- `on_startup` runs on the server's event loop, so it is the place to capture that
+  loop for later cross-thread work (`ntfy.set_loop(asyncio.get_running_loop())`).
+- Both hooks are isolated: the server calls each in a `try/except` and logs a
+  failure as `addon <id> startup failed`, so one broken addon neither takes the
+  server down nor stops its siblings' hooks — but it *does* fail silently apart
+  from that log line, so don't rely on a raise to surface misconfiguration.
+  Shutdown hooks run in reverse registration order.
+
 Optionally implement the structural `ManagedProcess` protocol
 (`start/stop/status/is_running`) to get generic start/stop/logs treatment.
 
@@ -271,6 +291,45 @@ window.mindflockAddons.mine = {
   notification (with the session title; click focuses the tab) when a session
   hits `clarify` or its PR leaves the open stage.
 - **Registry**: one `NotifyAddon(ctx)` line in `build_addons()`.
+
+It also demonstrates the *server-side* half of the seam. `on_startup` takes
+`ctx.subscribe("*", …)` and runs the same rules in-process, pushing matches to
+the user's [ntfy](https://ntfy.sh) topic (`web/core/ntfy.py`) — which is how a
+notification arrives with no browser open at all. Three things generalize to any
+addon that reacts to events in-process:
+
+- The subscription is registered unconditionally and the **callback** checks
+  whether the feature is configured, so turning it on in Settings takes effect
+  immediately instead of at the next restart.
+- Bus callbacks run synchronously on whichever thread emitted, so the handler
+  stays tiny and hands its HTTP call to the loop (`ntfy.publish_soon`, the same
+  trampoline `EventBus._dispatch_hooks` uses for shell hooks). It also swallows
+  its own exceptions — one subscriber must not break an `emit()` for everyone.
+- There is no replay to guard against server-side (the bus replays only to
+  reconnecting websockets) and no first-poll burst after a restart, because
+  `server._emit_state_changes` seeds its snapshot on first sighting without
+  emitting. The browser channel, which *does* see a replayed backlog, filters it
+  with `ctx.events.isReplay(env)`.
+
+**Invariant: the rule engine is implemented twice, by hand.** The rule *data*
+(`NOTIFY_RULES`) is served from one place, but each channel evaluates it in its own
+language, and those evaluators are hand-mirrored twins with no shared code and no
+test that diffs them:
+
+| `notify.py` (server / ntfy) | `notify.js` (browser / desktop) |
+|---|---|
+| `_matches(rule, envelope)` | `ruleMatches(rule, env)` |
+| `_fill(template, envelope)` | `fill(template, env)` |
+| `_DEDUPE_SECONDS = 5.0` | `DEDUPE_MS = 5000` |
+
+Any change to rule *semantics* — a new constraint field, different `{…}`
+placeholder handling, a different dedupe key or window — must land in **both**, or
+the two channels quietly disagree and the same event notifies you on one channel
+and not the other. (The `priority`/`tags` fields are the deliberate exception:
+ntfy-only presentation, stripped from the client payload by
+`_INTERNAL_RULE_FIELDS` along with `default_enabled`, since the browser gets the
+already-resolved `enabled`.) A third channel should factor the evaluator out
+rather than add a third twin.
 
 ## `window.mindflock` client API reference
 

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -376,6 +376,17 @@ of the masked settings store (groups include `general`, e.g.
 `general.session_budget_usd`, the J5 per-session cost guardrail; `0`/absent =
 off), the account-attach "Test" validations (C5):
 
+**The secret convention** (cross-cutting, not settings-only): every field the
+server treats as a secret — API tokens, the ntfy access token — reads back as the
+sentinel `•••set` when one is stored and `""` when none is, and a write of either
+`""` **or** the sentinel *keeps* the saved value rather than clearing it. Only a
+different non-empty string replaces a secret; clearing one is a deliberate
+product decision per field (the ntfy token, for instance, is cleared by
+retargeting the server — see Notify below). The sentinel is one shared constant,
+`SECRET_MASK` in `web/addons/base.py`, with a hand-mirrored counterpart in the
+frontend's `settings/useSettings.tsx`; changing the string means changing both,
+or the UI starts writing the literal mask into the store as a password.
+
 | Method | Path | Returns |
 |---|---|---|
 | GET/POST | `/api/settings` | The masked settings store (secrets never echoed). POST **rejects** `coding_cli.default_provider` when that CLI is not installed (a `ValueError`-derived 400) — an absent CLI can never become the launch default |
@@ -436,8 +447,64 @@ the generic extension path (see [docs/extensions.md](extensions.md)):
 
 | Method | Path | Returns |
 |---|---|---|
-| GET | `/api/notify/config` | `{rules: [{event, old, new, title, body}]}` — the event → desktop-notification rules `static/addons/notify.js` applies |
-| POST | `/api/notify/rules/{rule_id}` | Enable/disable one rule |
+| GET | `/api/notify/config` | `{rules: [{id, label, event, old, new, title, body, enabled}]}` — the event → notification rules, applied client-side by `static/addons/notify.js` and server-side by the ntfy channel |
+| POST | `/api/notify/rules/{rule_id}` | Enable/disable one rule (for **both** channels) |
+| GET | `/api/notify/ntfy` | The ntfy channel's state: `{enabled, server, server_default, topic, has_token, click_url, configured, active, public_server, subscribe_url, qr_svg, suggested_topic, last}`. Never the token — only `has_token`; `suggested_topic` is a fresh random name, `last` is `{ts, ok, error}` of the most recent push |
+| POST | `/api/notify/ntfy` | Save `{enabled?, server?, topic?, token?, click_url?}` (only the keys present are touched); returns the `GET` view, plus a `note` when something was rewritten. `400 {error}` on an invalid topic/server URL |
+| POST | `/api/notify/ntfy/test` | Send one test push — `{ok, error}`. Takes its config from the body when supplied, so a topic can be verified before it is saved; exempt from the rate cap |
+
+The ntfy channel is a **server-side** delivery path for the same rules
+(`web/core/ntfy.py`): the server publishes to the topic over ntfy's JSON publish
+API (POST to the server root, topic in the body — session titles are arbitrary
+UTF-8, which an `X-Title` header could not carry), so an alert arrives with no
+browser tab open. It is off until configured, resolves through
+env → `settings.json` → defaults (`MINDFLOCK_NTFY_ENABLED` / `_SERVER` /
+`_TOPIC` / `_TOKEN` / `_CLICK_URL`, where an env-supplied topic is an implicit
+opt-in for headless boxes), and is capped at 60 pushes/hour per process.
+
+Two write-path guards worth knowing: the token follows the store's secret
+convention (empty or the `•••set` sentinel keeps the saved one) **and** is
+dropped when the server URL is retargeted at a different host without a fresh
+token, so server A's credential is never sent to server B; and a `token=` query
+parameter in `click_url` is stripped, since that URL is stored on the ntfy
+server.
+
+**Errors: branch on the body, not the status.** The two write endpoints report
+failure differently on purpose. `POST /api/notify/ntfy` is a validating write, so
+a bad topic or server URL is a `400 {error}` and nothing is saved.
+`POST /api/notify/ntfy/test` is a *probe* — every outcome it produces itself is a
+`200` with `{ok, error}`, including an invalid config and a send that failed
+outright (DNS, TLS, timeout, a `403` from ntfy); only a malformed request body gets
+a status error, from FastAPI's own validation. A client that branches on HTTP
+status therefore reads every failed test as a success: branch on `ok` and display
+`error`, which carries the ntfy server's own error sentence when it sent one.
+
+**Rate cap** — pushes are capped at **60 per rolling hour, per server process**,
+shared across every session and every rule (not per-session, not per-rule). It is
+a runaway guard, not a tunable: no env var or setting changes it. `POST
+/api/notify/ntfy/test` is **exempt**, so a test still reports a true verdict while
+the event channel is being throttled.
+
+A throttled push is **not** observable over the API. The cap is checked before the
+HTTP attempt and returns `"Rate limit: too many ntfy pushes this hour"` to its
+caller, but the event path is fire-and-forget and discards that return value, and
+the drop is deliberately *not* recorded as a `last` result — so `last` keeps
+showing the last real attempt rather than being buried under throttle noise. The
+only trace is one server-log line per window (`ntfy: over 60 pushes/hour …`). If a
+client needs to explain missing pushes, that log line is the evidence; `last: {ok:
+true}` alongside silent phones is the symptom.
+
+**Outbound reach** — `POST /api/notify/ntfy/test` publishes to the `server` in the
+*request body*, so an authenticated caller can make the MindFlock process issue
+one outbound `http(s)` POST (with a JSON body they largely control) to a host of
+their choosing, and — when that host answers `4xx`/`5xx` — read back the first
+~200 characters of its response body, surfaced as `error`. That is inherent to
+"test before you save", and it is bounded (one call, 10 s total timeout, nothing
+echoed back on a `2xx`), but a request-forgery probe is a fair way to describe it.
+Hence two things worth not undoing: this endpoint takes the same auth middleware as
+everything else, and the gate switches itself on for any non-local `CS_WEB_MODE`
+(see [Authentication](#authentication)). An exposed server with `MINDFLOCK_AUTH=0`
+would hand this probe to the network.
 
 ## Authentication
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -205,6 +205,63 @@ the events bus, **including the backlog replayed on connect** so it answers
 opened it (keyed on timestamp so it survives server restarts); clicking an entry
 focuses that session.
 
+**One rule list, two delivery channels.** Settings → Notifications is split that
+way on purpose: *What triggers a notification* (needs-input, PR merged/closed,
+budget exceeded, pre-commit failed — plus the noisy opt-ins) governs **both**
+channels, and each channel decides only where an alert lands.
+
+- **Browser / desktop** — the notify addon's `Notification` popup. Needs a tab
+  open on a secure origin (HTTPS or localhost), so it is silent on a plain-http
+  tailnet URL and says so in the toggle's status line.
+- **Phone push (ntfy)** — optional, off until you turn it on. The *server*
+  publishes to an [ntfy](https://ntfy.sh) topic your phone subscribes to, so an
+  alert reaches you with MindFlock closed and no tab anywhere. Set a topic
+  (**Generate** offers a random one), scan the QR into the ntfy app, and
+  **Send a test** confirms the round trip; the row afterwards reports the last
+  push (or why it failed). Point **Server** at your own ntfy instance to keep
+  everything in-house, and give **Access token** a value only if the topic is
+  protected. *Tapping opens* is an optional URL the notification opens — paste
+  your phone URL from Settings → Mobile; MindFlock strips an `?token=` from it,
+  since that URL is stored on the ntfy server.
+
+  Priority is per rule: "needs your input", "budget exceeded" and "pre-commit
+  failed" go out at ntfy priority 4 (buzzes through most do-not-disturb
+  setups), PR merged/closed at 3, and the ambient opt-ins (idle, pre-commit
+  running) at 2 so they arrive quietly.
+
+  On the **public ntfy.sh server the topic name is the credential** — anyone who
+  knows it can read your session titles or send you fakes — so keep the
+  generated random name, or self-host. The screen shows that warning while the
+  channel is on and pointed at ntfy.sh.
+
+**Diagnosing a channel you can't see.** A push channel is invisible when it works
+and baffling when it doesn't, so the row beside **Send a test** is the whole
+diagnostic surface — no log reading required:
+
+- Straight after a test it shows that test's verdict: *"Sent — check your phone."*
+  or the failure reason. The reason is ntfy's **own** sentence when the server
+  sent one (`{"error": …}` from its JSON body — "topic is reserved", an auth
+  refusal), otherwise the transport error (DNS, TLS, timeout).
+- Otherwise it shows the last *real* push, either **"Last push sent 4 min ago"**
+  (relative: "just now" under a minute, then minutes, hours, days) or
+  **"Last push failed: …"** with the same surfaced reason. Blank means nothing has
+  been attempted yet this server run — the record lives in memory, so it resets on
+  restart, and a fresh reload of a long-running server shows the real history.
+- A missing QR is not a failure: it means the optional `segno` package isn't
+  installed, and the subscribe URL printed beside it is the intended fallback.
+- One failure mode this row will *not* show you: the 60-pushes/hour runaway cap.
+  Throttled pushes are dropped before any HTTP attempt and deliberately don't
+  overwrite the last result, so the symptom is a cheerful "Last push sent …"
+  next to a silent phone. **Send a test** is exempt from the cap and will still
+  succeed; the evidence is a single line in Settings → System logs
+  (`ntfy: over 60 pushes/hour — dropping further pushes this window`).
+
+Delivery is best-effort in one direction only: **a failed push never touches the
+session it was reporting on.** The event that triggered it has already been
+emitted, the websocket clients and shell hooks have already seen it, and the
+browser channel fires independently. A wrong token or an unreachable ntfy server
+costs you the phone alert and nothing else.
+
 ## Diff → instruction
 
 Select any text in a pane's **Diff** tab and a floating **✦ Ask agent** button
@@ -362,7 +419,8 @@ default); submitting calls `submitMakePr` → `POST /api/instances/{title}/make-
 - **Per-session budget (USD, 0 = off)** — cost guardrail: when a session's
   estimated cost crosses this figure the server emits a one-shot
   `session.budget_exceeded` event → warning toast (click focuses the session),
-  desktop notification (notify addon), and shell hooks. An over-budget session's
+  a notification on every enabled channel (desktop and/or ntfy — see
+  [Notifications](#notifications-)), and shell hooks. An over-budget session's
   pane shows a lock overlay with a **Raise budget** action
   (`POST /api/instances/{title}/budget/raise`); sends are refused (409) until
   raised.
@@ -414,7 +472,16 @@ default); submitting calls `submitMakePr` → `POST /api/instances/{title}/make-
   **launch flags** (`[launch] args`). The per-provider **default launch flags**
   (`coding_cli.default_launch_args`) that pre-fill the New-session dialog are
   also edited here.
-- **Mobile** — the `/m` URLs and QR code (`GET /api/mobile`).
+- **Mobile** — the `/m` URLs and QR code (`GET /api/mobile`). The tailnet URL here
+  is also the natural paste target for *Tapping opens* on the
+  [Notifications](#notifications-) screen, so a phone push lands in the mobile UI
+  — with one wrinkle worth knowing before you blame the link. The URL is offered
+  with `?token=…` baked in so a scan lands signed in, and MindFlock **strips that
+  token** when saving it as an ntfy click URL (it would otherwise be stored on the
+  ntfy server). A tap therefore only lands signed in if that device already holds
+  the `mf_auth` cookie — i.e. you scanned the QR there once before. Otherwise it
+  lands on the login prompt, which is the intended trade: one extra tap on a new
+  device instead of this machine's token sitting on a third party's server.
 - **Security** — view/copy this device's web-auth token, plus a **Regenerate**
   button (`POST /api/settings/auth-token/rotate`) for compromise recovery: it
   mints a new token and invalidates every issued cookie, QR code, and paired
@@ -551,7 +618,8 @@ SPA provides one. A module that fails to load is skipped with a console warning.
 The hand-wired built-ins (MindFlock, Assistant, Settings, Doctor) are
 `builtin_ui: true` with `module: null`; the **notify** addon
 (`static/addons/notify.js`, desktop notifications on clarify / PR close /
-budget exceeded — rules are data-driven from `GET /api/notify/config`) is the
+budget exceeded — rules are data-driven from `GET /api/notify/config`, and the
+same rules drive the server-side ntfy push in `web/core/ntfy.py`) is the
 reference for this generic path — the full contract lives in
 [docs/extensions.md](extensions.md). `slots.js` also feeds the provider list
 into the New-session dialog's Program field.

--- a/frontend/src/components/settings/screens/Notifications.tsx
+++ b/frontend/src/components/settings/screens/Notifications.tsx
@@ -1,10 +1,12 @@
 /** Settings → Notifications (partial 105 + section 21's wiring): the browser
- * notification opt-in (shared addon API, synced via "mf-notify-state") and
- * the per-rule on/off list (POST /api/notify/rules/<id>). */
+ * notification opt-in (shared addon API, synced via "mf-notify-state"), the
+ * optional ntfy phone-push channel (/api/notify/ntfy), and the per-rule on/off
+ * list (POST /api/notify/rules/<id>) that governs BOTH channels. */
 
 import { useCallback, useEffect, useState } from "react";
 import { api } from "../../../api/client";
 import { toast } from "../../../lib/toast";
+import { SECRET_MASK } from "../useSettings";
 import type { ScreenProps } from "../SettingsDialog";
 
 const NOTIFY_KEY = "mindflock.notify.enabled";
@@ -113,8 +115,12 @@ export function Notifications(_: ScreenProps) {
         </label>
       </div>
       <p className="set-hint" id="notif-browser-status">{status}</p>
+      <Ntfy />
       <h3 className="set-section-title">What triggers a notification</h3>
-      <p className="set-hint">Pick exactly which events notify you — turn off any you don't want.</p>
+      <p className="set-hint">
+        Pick exactly which events notify you — turn off any you don't want. These switches
+        apply to every channel above.
+      </p>
       <div id="notif-rules-list">
         {rulesError ? (
           <p className="muted">Couldn't load notification rules.</p>
@@ -129,6 +135,287 @@ export function Notifications(_: ScreenProps) {
         )}
       </div>
       <p className="set-hint">Also reachable from the bell in the sidebar header.</p>
+    </>
+  );
+}
+
+/* --------------------------------------------------------------------------
+ * ntfy — the phone-push channel.
+ *
+ * Why it's a section of its own rather than another rule switch: it's a
+ * *delivery channel*, not a trigger. The rule list below decides WHAT notifies
+ * you; browser and ntfy decide WHERE. ntfy is the one that works with MindFlock
+ * closed, since the push happens server-side.
+ * ------------------------------------------------------------------------ */
+interface NtfyView {
+  enabled?: boolean;
+  server?: string;
+  server_default?: string;
+  topic?: string;
+  has_token?: boolean;
+  click_url?: string;
+  configured?: boolean;
+  active?: boolean;
+  public_server?: boolean;
+  subscribe_url?: string;
+  qr_svg?: string | null;
+  suggested_topic?: string;
+  last?: { ts?: number; ok?: boolean; error?: string };
+  note?: string;
+}
+
+function ago(ts: number): string {
+  const secs = Math.max(0, Math.round(Date.now() / 1000 - ts));
+  if (secs < 60) return "just now";
+  if (secs < 3600) return Math.round(secs / 60) + " min ago";
+  if (secs < 86400) return Math.round(secs / 3600) + "h ago";
+  return Math.round(secs / 86400) + "d ago";
+}
+
+function Ntfy() {
+  const [view, setView] = useState<NtfyView | null>(null);
+  const [failed, setFailed] = useState(false);
+  // Text fields are uncontrolled between saves (same flow as SettingField):
+  // seeded from the server view, committed on blur/Enter.
+  const [server, setServer] = useState("");
+  const [topic, setTopic] = useState("");
+  const [token, setToken] = useState("");
+  const [click, setClick] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [verdict, setVerdict] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const apply = useCallback((v: NtfyView) => {
+    setView(v);
+    setServer(v.server || "");
+    setTopic(v.topic || "");
+    setClick(v.click_url || "");
+    setToken(""); // never populated with the stored secret
+    if (v.note) toast(v.note);
+  }, []);
+
+  const load = useCallback(async () => {
+    try {
+      apply(await api<NtfyView>("/api/notify/ntfy"));
+      setFailed(false);
+    } catch {
+      setFailed(true);
+    }
+  }, [apply]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  /** Persist a patch; on rejection show why and re-sync from the server. */
+  const save = useCallback(
+    async (patch: Record<string, unknown>) => {
+      try {
+        apply(await api<NtfyView>("/api/notify/ntfy", { json: patch }));
+      } catch (err) {
+        toast((err as Error).message || "Couldn't save the ntfy settings");
+        load();
+      }
+    },
+    [apply, load]
+  );
+
+  if (failed)
+    return (
+      <>
+        <h3 className="set-section-title">Phone push (ntfy)</h3>
+        <p className="muted">Couldn't load the ntfy settings.</p>
+      </>
+    );
+  if (!view) return <h3 className="set-section-title">Phone push (ntfy)</h3>;
+
+  const on = !!view.enabled;
+  const last = view.last || {};
+
+  return (
+    <>
+      <h3 className="set-section-title">Phone push (ntfy)</h3>
+      <p className="set-hint">
+        Get these alerts on your phone — even with MindFlock closed, because the server
+        sends them, not the browser. Install the free{" "}
+        <a href="https://ntfy.sh" target="_blank" rel="noopener noreferrer">
+          ntfy
+        </a>{" "}
+        app, subscribe to the topic below, and check in on the flock from anywhere.
+      </p>
+      <div
+        className="set-row set-switch-row"
+        id="ntfy-row"
+        title="Push notifications to an ntfy topic your phone subscribes to"
+      >
+        <span className="set-label">Push to ntfy</span>
+        <label className="ca-switch">
+          <input
+            type="checkbox"
+            id="ntfy-toggle"
+            checked={on}
+            onChange={(e) =>
+              save({
+                enabled: e.target.checked,
+                // Send the typed-but-uncommitted topic too, so flipping the
+                // switch right after typing one doesn't fail validation.
+                topic: topic.trim(),
+                server: server.trim(),
+              })
+            }
+          />
+          <span className="ca-slider" />
+        </label>
+      </div>
+      <div className="ntfy-field-row">
+        <span className="set-label">Topic</span>
+        <input
+          id="ntfy-topic"
+          value={topic}
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={view.suggested_topic || "mindflock-…"}
+          onChange={(e) => setTopic(e.target.value)}
+          onBlur={() => topic.trim() !== (view.topic || "") && save({ topic: topic.trim() })}
+          onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+        />
+        <button
+          type="button"
+          className="test-btn"
+          id="ntfy-generate"
+          title="Use a long random topic name — on the public server the topic name is the only thing keeping strangers out"
+          onClick={() => {
+            // The server supplies the random name (crypto-strength, and the
+            // same charset ntfy accepts); every response carries a fresh one.
+            const fresh = view.suggested_topic;
+            if (!fresh) return;
+            setTopic(fresh);
+            save({ topic: fresh });
+          }}
+        >
+          Generate
+        </button>
+      </div>
+      <div className="ntfy-field-row">
+        <span className="set-label">Server</span>
+        <input
+          id="ntfy-server"
+          value={server}
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={view.server_default || "https://ntfy.sh"}
+          onChange={(e) => setServer(e.target.value)}
+          onBlur={() =>
+            server.trim() !== (view.server || "") && save({ server: server.trim() })
+          }
+          onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+        />
+        <span />
+        <span className="set-hint">Leave as-is for the public server, or point at your own.</span>
+      </div>
+      <div className="ntfy-field-row">
+        <span className="set-label">Access token</span>
+        <input
+          id="ntfy-token"
+          type="password"
+          value={token}
+          autoComplete="off"
+          placeholder={view.has_token ? SECRET_MASK + " (saved)" : "only for a protected topic"}
+          onChange={(e) => setToken(e.target.value)}
+          onBlur={() => token && save({ token })}
+          onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+        />
+        <span />
+        <span className="set-hint">
+          Needed only if your topic is access-protected (self-hosted, or a reserved ntfy.sh
+          topic). Blank keeps the saved one.
+        </span>
+      </div>
+      <div className="ntfy-field-row">
+        <span className="set-label">Tapping opens</span>
+        <input
+          id="ntfy-click"
+          value={click}
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="optional — e.g. your phone URL from Settings → Mobile"
+          onChange={(e) => setClick(e.target.value)}
+          onBlur={() =>
+            click.trim() !== (view.click_url || "") && save({ click_url: click.trim() })
+          }
+          onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+        />
+        <span />
+        <span className="set-hint">
+          Opened when you tap the notification. Don't paste an access token into it — it
+          would be stored on the ntfy server (MindFlock strips one if you do).
+        </span>
+      </div>
+      <div className="ntfy-test-row">
+        <button
+          type="button"
+          className="test-btn"
+          id="ntfy-test"
+          disabled={testing || !topic.trim()}
+          onClick={async () => {
+            setTesting(true);
+            setVerdict(null);
+            try {
+              const r = await api<{ ok?: boolean; error?: string }>("/api/notify/ntfy/test", {
+                json: {
+                  server: server.trim(),
+                  topic: topic.trim(),
+                  token: token || undefined,
+                  click_url: click.trim(),
+                },
+              });
+              setVerdict(
+                r?.ok
+                  ? { ok: true, text: "Sent — check your phone." }
+                  : { ok: false, text: r?.error || "The push failed." }
+              );
+            } catch (err) {
+              setVerdict({ ok: false, text: (err as Error).message || "The push failed." });
+            }
+            setTesting(false);
+          }}
+        >
+          {testing ? "Sending…" : "Send a test"}
+        </button>
+        {verdict && (
+          <span
+            id="ntfy-verdict"
+            className={verdict.ok ? "ntfy-verdict-ok" : "ntfy-verdict-bad"}
+          >
+            {verdict.text}
+          </span>
+        )}
+        {!verdict && last.ts && (
+          <span className={last.ok ? "ntfy-verdict-ok" : "ntfy-verdict-bad"}>
+            {last.ok ? "Last push sent " + ago(last.ts) : "Last push failed: " + last.error}
+          </span>
+        )}
+      </div>
+      {view.qr_svg && (
+        <>
+          {/* Server-generated segno SVG (trusted), same renderer as Settings → Mobile. */}
+          <div id="ntfy-qr" className="qr-card" dangerouslySetInnerHTML={{ __html: view.qr_svg }} />
+          <p className="set-hint">
+            Scan this in the ntfy app to subscribe, or open{" "}
+            <a href={view.subscribe_url} target="_blank" rel="noopener noreferrer">
+              {view.subscribe_url}
+            </a>
+            .
+          </p>
+        </>
+      )}
+      {on && view.public_server && (
+        <p className="ntfy-warning" id="ntfy-public-warning">
+          You're using the public <code>ntfy.sh</code> server: your session titles travel
+          through it, and <strong>anyone who knows the topic name can read them</strong> (or
+          send you fakes). Keep a long random topic — or self-host ntfy and point the Server
+          field at it.
+        </p>
+      )}
     </>
   );
 }

--- a/frontend/src/components/settings/screens/mobileLogs.css
+++ b/frontend/src/components/settings/screens/mobileLogs.css
@@ -1,5 +1,8 @@
-/* Settings → Mobile: white QR card + URL rows */
-#mobile-qr {
+/* Settings → Mobile: white QR card + URL rows.
+   .qr-card is shared with Settings → Notifications (the ntfy subscribe QR) —
+   a QR must stay dark-on-white to scan, whatever the app theme is doing. */
+#mobile-qr,
+.qr-card {
   background: #fff;
   border-radius: 12px;
   padding: 12px;
@@ -8,7 +11,8 @@
   box-shadow: 0 1px 4px rgba(0, 0, 0, .3);
 }
 
-#mobile-qr svg {
+#mobile-qr svg,
+.qr-card svg {
   display: block;
   width: 200px;
   height: 200px;

--- a/frontend/src/components/settings/screens/notifications.css
+++ b/frontend/src/components/settings/screens/notifications.css
@@ -1,0 +1,56 @@
+/* Settings → Notifications: the ntfy (phone push) section.
+   The QR card itself is the shared .qr-card from mobileLogs.css. */
+
+/* Label + field + trailing button on one line (Topic […] [Generate]), so the
+   generate/test affordance sits with the field it acts on instead of below it. */
+.ntfy-field-row {
+  display: grid;
+  grid-template-columns: 150px 1fr auto;
+  align-items: center;
+  gap: 6px 12px;
+  margin: 8px 0;
+}
+
+.ntfy-field-row .set-label {
+  min-width: 0;
+}
+
+.ntfy-field-row input {
+  min-width: 0; /* let the input shrink inside the grid track instead of overflowing */
+  width: 100%;
+}
+
+/* The hint under a field spans the whole row, aligned under the input. */
+.ntfy-field-row .set-hint {
+  grid-column: 2 / -1;
+  margin: 0;
+}
+
+/* "Anyone who knows your topic can read these" — a real caveat of the public
+   server, so it gets a callout rather than another grey hint nobody reads. */
+.ntfy-warning {
+  border: 1px solid var(--gold);
+  border-radius: 10px;
+  background: var(--panel-2);
+  padding: 10px 14px;
+  margin: 10px 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+/* Test button + its verdict on one line. */
+.ntfy-test-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 12px 0 4px;
+}
+
+.ntfy-verdict-ok {
+  color: var(--green);
+}
+
+.ntfy-verdict-bad {
+  color: var(--red);
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -47,6 +47,7 @@
 @import "../components/grid/missingWorkspace.css" layer(components); /* 240 */
 @import "../components/settings/screens/ticketingConnections.css" layer(components); /* 250 */
 @import "../components/settings/screens/mobileLogs.css" layer(components); /* 260 */
+@import "../components/settings/screens/notifications.css" layer(components); /* 260 */
 @import "../components/capsGate.css" layer(components); /* 270 */
 @import "../components/dialogs/DeviceDialog.css" layer(components); /* 270 */
 @import "../components/settings/screens/Appearance.css" layer(components); /* 280 */

--- a/tests/unit/test_ntfy.py
+++ b/tests/unit/test_ntfy.py
@@ -1,0 +1,789 @@
+"""The ntfy push channel: settings, the transport, and rule dispatch.
+
+Covers the settings group, the /api/notify/ntfy read/write/test endpoints (with
+their secret handling), the JSON body actually sent to an ntfy server, the rate
+cap, the cross-thread dispatch trampoline, and the server-side dispatch that
+turns a bus event into a push — including the cases where it must stay silent
+(channel off, rule muted, duplicate) and the ones where it must stay quiet about
+the topic and the token.
+
+The QR renderer shared with Settings → Mobile is here too: the ntfy view is why
+``mobile_access._mobile_svg`` became the public ``qr_svg``, and both callers have
+to keep working.
+"""
+
+import asyncio
+import sys
+import threading
+import time
+import types
+
+import pytest
+from starlette.testclient import TestClient
+
+from backend.config import settings as S
+from backend.web import server
+from backend.web.addons import notify as notify_addon
+from backend.web.addons.base import AppContext
+from backend.web.core import events, mobile_access, ntfy
+
+client = TestClient(server.app)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store(isolate_settings_store):
+    """Delegate to the shared settings-store isolation (tests/conftest.py)."""
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    """Drop the transport's process-wide state (rate window, last result, the
+    registered loop) and any ntfy env overrides, so tests don't leak into each
+    other — a loop left behind by one test is a closed loop by the next."""
+    ntfy._SENT.clear()
+    ntfy._LAST.clear()
+    monkeypatch.setattr(ntfy, "_THROTTLE_LOGGED", None, raising=False)
+    monkeypatch.setattr(ntfy, "_LOOP", None, raising=False)
+    for name in (
+        "MINDFLOCK_NTFY_ENABLED",
+        "MINDFLOCK_NTFY_SERVER",
+        "MINDFLOCK_NTFY_TOPIC",
+        "MINDFLOCK_NTFY_TOKEN",
+        "MINDFLOCK_NTFY_CLICK_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    ntfy._SENT.clear()
+    ntfy._LAST.clear()
+
+
+# --------------------------------------------------------------------------- #
+# A fake aiohttp, so publish() is exercised without a network
+# --------------------------------------------------------------------------- #
+class _FakeResponse:
+    def __init__(self, status=200, payload=None, text=""):
+        self.status = status
+        self._payload = payload
+        self._text = text
+
+    async def json(self, content_type=None):
+        if self._payload is None:
+            raise ValueError("not json")
+        return self._payload
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, calls, response, **kwargs):
+        self._calls = calls
+        self._response = response
+
+    def post(self, url, json=None, headers=None):
+        self._calls.append({"url": url, "json": json, "headers": headers or {}})
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _Calls(list):
+    """The recorded POSTs, with a ``state`` dict a test can retarget so the fake
+    server answers something other than 200."""
+
+    state: dict
+
+
+@pytest.fixture
+def http(monkeypatch):
+    """Install a fake ``aiohttp`` and return the recorded-calls list. Assign
+    ``http.state["response"] = _FakeResponse(...)`` to change the answer."""
+    calls = _Calls()
+    calls.state = {"response": _FakeResponse(200)}
+
+    mod = types.ModuleType("aiohttp")
+
+    class ClientTimeout:
+        def __init__(self, total=None):
+            self.total = total
+
+    mod.ClientTimeout = ClientTimeout
+    # Read the response through `state` at call time, so a test can swap it
+    # after the fixture has been built.
+    mod.ClientSession = lambda **kw: _FakeSession(calls, calls.state["response"], **kw)
+    mod.ClientError = OSError
+    monkeypatch.setitem(sys.modules, "aiohttp", mod)
+    return calls
+
+
+def _wait(pred, timeout: float = 5.0) -> bool:
+    """Poll ``pred`` until true — for the publishes that run on a thread or loop
+    of their own (also the join: the fake aiohttp must be asserted on while the
+    monkeypatched sys.modules entry is still installed)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(0.01)
+    return pred()
+
+
+async def _settle(pred, timeout: float = 5.0) -> bool:
+    """:func:`_wait` for a coroutine scheduled on the loop we're running on."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        await asyncio.sleep(0.01)
+    return pred()
+
+
+def _ctx() -> AppContext:
+    """A minimal AppContext — only ``subscribe`` is exercised by this addon."""
+    return AppContext(engine=None, register_task=lambda coro: coro.close())
+
+
+# --------------------------------------------------------------------------- #
+# Settings model
+# --------------------------------------------------------------------------- #
+def test_ntfy_settings_roundtrip():
+    ns = S.NotificationSettings(
+        ntfy_enabled=True,
+        ntfy_server="https://push.example.com",
+        ntfy_topic="mindflock-abc",
+        ntfy_token="tk_secret",
+        ntfy_click_url="http://host/m",
+    )
+    back = S.NotificationSettings.from_dict(ns.to_dict())
+    assert back.ntfy_enabled is True
+    assert back.ntfy_server == "https://push.example.com"
+    assert back.ntfy_topic == "mindflock-abc"
+    assert back.ntfy_token == "tk_secret"
+    assert back.ntfy_click_url == "http://host/m"
+    # Off/empty stays omitted, so an untouched store serializes as before.
+    assert S.NotificationSettings().to_dict() == {}
+
+
+# --------------------------------------------------------------------------- #
+# Transport helpers
+# --------------------------------------------------------------------------- #
+def test_normalize_server_defaults_and_scheme():
+    assert ntfy.normalize_server("") == ntfy.DEFAULT_SERVER
+    assert ntfy.normalize_server("  ") == ntfy.DEFAULT_SERVER
+    assert ntfy.normalize_server("https://ntfy.sh/") == "https://ntfy.sh"
+    # A bare host becomes https, never a relative URL.
+    assert ntfy.normalize_server("push.example.com") == "https://push.example.com"
+    assert ntfy.normalize_server("http://box.local:8080") == "http://box.local:8080"
+
+
+def test_validate_rejects_bad_topic_and_scheme():
+    assert ntfy.validate("https://ntfy.sh", "mindflock-ok_1") is None
+    assert "topic" in (ntfy.validate("https://ntfy.sh", "") or "")
+    assert "letters" in (ntfy.validate("https://ntfy.sh", "has space") or "")
+    assert "letters" in (ntfy.validate("https://ntfy.sh", "a/b") or "")
+    assert "letters" in (ntfy.validate("https://ntfy.sh", "x" * 65) or "")
+    assert "http" in (ntfy.validate("ftp://ntfy.sh", "topic") or "")
+
+
+def test_random_topic_is_unguessable_and_valid():
+    a, b = ntfy.random_topic(), ntfy.random_topic()
+    assert a != b
+    assert a.startswith("mindflock-") and len(a) > 24
+    assert ntfy.validate(ntfy.DEFAULT_SERVER, a) is None
+
+
+def test_strip_token_param_removes_access_token():
+    url, stripped = ntfy.strip_token_param("http://host:8080/m?token=SECRET")
+    assert stripped is True and "SECRET" not in url and "token" not in url
+    # Other params survive; a clean URL is untouched.
+    url, stripped = ntfy.strip_token_param("http://h/m?a=1&token=S&b=2")
+    assert stripped is True and "a=1" in url and "b=2" in url and "token" not in url
+    assert ntfy.strip_token_param("http://h/m?a=1") == ("http://h/m?a=1", False)
+    assert ntfy.strip_token_param("") == ("", False)
+
+
+def test_same_host_compares_host_not_path():
+    assert ntfy.same_host("https://ntfy.sh", "https://ntfy.sh/") is True
+    assert ntfy.same_host("ntfy.sh", "https://NTFY.sh") is True
+    assert ntfy.same_host("https://ntfy.sh", "https://push.example.com") is False
+
+
+def test_config_active_and_public_flags():
+    off = ntfy.NtfyConfig(enabled=True)
+    assert off.active is False  # enabled but no topic
+    on = ntfy.NtfyConfig(enabled=True, topic="t")
+    assert on.active is True and on.subscribe_url == "https://ntfy.sh/t"
+    assert on.is_public_server is True
+    mine = ntfy.NtfyConfig(enabled=True, topic="t", server="http://box.local:8080")
+    assert mine.is_public_server is False and mine.host == "box.local:8080"
+
+
+# --------------------------------------------------------------------------- #
+# Config resolution
+# --------------------------------------------------------------------------- #
+def test_load_defaults_to_off():
+    cfg = ntfy.load()
+    assert cfg.enabled is False and cfg.topic == ""
+    assert cfg.server == ntfy.DEFAULT_SERVER and cfg.active is False
+
+
+def test_load_reads_store():
+    S.update_settings(
+        notifications={"ntfy_enabled": True, "ntfy_topic": "mindflock-store"}
+    )
+    cfg = ntfy.load()
+    assert cfg.active is True and cfg.topic == "mindflock-store"
+
+
+def test_env_topic_is_an_implicit_opt_in(monkeypatch):
+    """A headless box exports a topic and expects pushes — there is no Settings
+    screen there to flip the switch in."""
+    monkeypatch.setenv("MINDFLOCK_NTFY_TOPIC", "mindflock-env")
+    monkeypatch.setenv("MINDFLOCK_NTFY_SERVER", "http://box.local:8080")
+    cfg = ntfy.load()
+    assert cfg.topic == "mindflock-env" and cfg.enabled is True and cfg.active is True
+    assert cfg.server == "http://box.local:8080"
+
+
+def test_explicit_env_disable_beats_the_implicit_topic_opt_in(monkeypatch):
+    """The implicit opt-in must not trap you: with the topic var still exported,
+    MINDFLOCK_NTFY_ENABLED=0 is the way to go quiet."""
+    monkeypatch.setenv("MINDFLOCK_NTFY_TOPIC", "mindflock-env")
+    monkeypatch.setenv("MINDFLOCK_NTFY_ENABLED", "0")
+    cfg = ntfy.load()
+    assert cfg.topic == "mindflock-env" and cfg.enabled is False and cfg.active is False
+    # And "1" is still on, of course.
+    monkeypatch.setenv("MINDFLOCK_NTFY_ENABLED", "1")
+    assert ntfy.load().active is True
+
+
+def test_env_beats_store(monkeypatch):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "from-store"})
+    monkeypatch.setenv("MINDFLOCK_NTFY_TOPIC", "from-env")
+    assert ntfy.load().topic == "from-env"
+
+
+# --------------------------------------------------------------------------- #
+# publish(): the wire contract
+# --------------------------------------------------------------------------- #
+async def test_publish_posts_json_to_server_root(http):
+    cfg = ntfy.NtfyConfig(
+        enabled=True, topic="mindflock-x", token="tk_1", server="https://ntfy.sh"
+    )
+    ok, err = await ntfy.publish(
+        cfg, title="Hi", message="Body", priority=4, tags=["question"]
+    )
+    assert (ok, err) == (True, "")
+    (call,) = http
+    # The topic goes in the BODY (the JSON publish API), not the path: a session
+    # title is arbitrary UTF-8 and would not survive an X-Title header.
+    assert call["url"] == "https://ntfy.sh"
+    assert call["json"] == {
+        "topic": "mindflock-x",
+        "message": "Body",
+        "title": "Hi",
+        "priority": 4,
+        "tags": ["question"],
+    }
+    assert call["headers"]["Authorization"] == "Bearer tk_1"
+    assert ntfy.last_result()["ok"] is True
+
+
+async def test_publish_sends_unicode_title(http):
+    """The reason for the JSON body: non-ASCII titles must survive."""
+    cfg = ntfy.NtfyConfig(enabled=True, topic="t")
+    await ntfy.publish(cfg, title="refactor-ünïcode ✅", message="")
+    assert http[0]["json"]["title"] == "refactor-ünïcode ✅"
+
+
+async def test_publish_includes_click_url(http):
+    cfg = ntfy.NtfyConfig(enabled=True, topic="t", click_url="http://box:8080/m")
+    await ntfy.publish(cfg, title="T", message="M")
+    assert http[0]["json"]["click"] == "http://box:8080/m"
+
+
+async def test_publish_omits_empty_optional_fields(http):
+    cfg = ntfy.NtfyConfig(enabled=True, topic="t")
+    await ntfy.publish(cfg, title="", message="M")
+    assert set(http[0]["json"]) == {"topic", "message"}
+    assert "Authorization" not in http[0]["headers"]
+
+
+async def test_publish_surfaces_server_error_sentence(http):
+    http.state["response"] = _FakeResponse(
+        403, payload={"code": 40301, "error": "topic is reserved"}
+    )
+    cfg = ntfy.NtfyConfig(enabled=True, topic="t")
+    ok, err = await ntfy.publish(cfg, title="T", message="M")
+    assert ok is False
+    assert "403" in err and "topic is reserved" in err
+    assert ntfy.last_result()["ok"] is False
+
+
+async def test_publish_survives_a_dead_server(http, monkeypatch):
+    def _boom(**kw):
+        raise OSError("Name or service not known")
+
+    monkeypatch.setattr(sys.modules["aiohttp"], "ClientSession", _boom)
+    ok, err = await ntfy.publish(
+        ntfy.NtfyConfig(enabled=True, topic="t"), title="T", message="M"
+    )
+    assert ok is False and "Name or service not known" in err
+
+
+async def test_publish_without_topic_is_refused(http):
+    ok, err = await ntfy.publish(ntfy.NtfyConfig(enabled=True), title="T", message="M")
+    assert ok is False and "topic" in err.lower() and not http
+
+
+async def test_publish_rate_cap_drops_the_flood(http, monkeypatch):
+    monkeypatch.setattr(ntfy, "_RATE_LIMIT", 3)
+    cfg = ntfy.NtfyConfig(enabled=True, topic="t")
+    for _ in range(3):
+        assert (await ntfy.publish(cfg, title="T", message="M"))[0] is True
+    ok, err = await ntfy.publish(cfg, title="T", message="M")
+    assert ok is False and "Rate limit" in err
+    assert len(http) == 3
+    # The hand-driven test push is exempt — it can't run away.
+    ok, _ = await ntfy.publish(cfg, title="T", message="M", budgeted=False)
+    assert ok is True and len(http) == 4
+
+
+# --------------------------------------------------------------------------- #
+# Endpoints
+# --------------------------------------------------------------------------- #
+def test_get_ntfy_defaults():
+    v = client.get("/api/notify/ntfy").json()
+    assert v["enabled"] is False and v["topic"] == "" and v["active"] is False
+    assert v["server"] == ntfy.DEFAULT_SERVER == v["server_default"]
+    assert v["has_token"] is False and v["public_server"] is True
+    assert v["qr_svg"] is None  # nothing to encode yet
+    # A random topic is always offered, so the client never invents one.
+    assert ntfy.validate(ntfy.DEFAULT_SERVER, v["suggested_topic"]) is None
+
+
+def test_save_and_enable_ntfy():
+    v = client.post(
+        "/api/notify/ntfy", json={"enabled": True, "topic": "mindflock-abc123"}
+    ).json()
+    assert v["enabled"] is True and v["topic"] == "mindflock-abc123"
+    assert v["active"] is True
+    assert v["subscribe_url"] == "https://ntfy.sh/mindflock-abc123"
+    S.invalidate()
+    saved = S.load_settings().notifications
+    assert saved.ntfy_enabled is True and saved.ntfy_topic == "mindflock-abc123"
+
+
+def test_save_rejects_a_bad_topic():
+    r = client.post("/api/notify/ntfy", json={"enabled": True, "topic": "no spaces"})
+    assert r.status_code == 400 and "letters" in r.json()["error"]
+    S.invalidate()
+    assert S.load_settings().notifications.ntfy_topic == ""  # nothing persisted
+
+
+def test_enabling_without_a_topic_is_rejected():
+    r = client.post("/api/notify/ntfy", json={"enabled": True})
+    assert r.status_code == 400 and "topic" in r.json()["error"]
+
+
+def test_clearing_the_topic_while_off_is_allowed():
+    client.post("/api/notify/ntfy", json={"enabled": False, "topic": ""})
+    assert client.get("/api/notify/ntfy").json()["topic"] == ""
+
+
+def test_server_url_is_normalized_on_save():
+    v = client.post(
+        "/api/notify/ntfy", json={"topic": "t1", "server": "push.example.com/"}
+    ).json()
+    assert v["server"] == "https://push.example.com"
+    assert v["public_server"] is False
+
+
+def test_token_is_kept_on_empty_and_never_returned():
+    client.post("/api/notify/ntfy", json={"topic": "t1", "token": "tk_secret"})
+    v = client.get("/api/notify/ntfy").json()
+    assert v["has_token"] is True
+    assert "tk_secret" not in client.get("/api/notify/ntfy").text
+    # An empty submit (and the mask sentinel) keep the saved token.
+    client.post("/api/notify/ntfy", json={"topic": "t2", "token": ""})
+    assert client.get("/api/notify/ntfy").json()["has_token"] is True
+    client.post("/api/notify/ntfy", json={"topic": "t3", "token": "•••set"})
+    S.invalidate()
+    assert S.load_settings().notifications.ntfy_token == "tk_secret"
+
+
+def test_token_is_dropped_when_the_server_host_changes():
+    """Retargeting the channel must not hand server A's credential to server B."""
+    client.post(
+        "/api/notify/ntfy",
+        json={"topic": "t1", "server": "https://a.example.com", "token": "tk_a"},
+    )
+    v = client.post("/api/notify/ntfy", json={"server": "https://b.example.com"}).json()
+    assert v["has_token"] is False
+    assert "previous ntfy server" in v.get("note", "")
+    S.invalidate()
+    assert S.load_settings().notifications.ntfy_token == ""
+
+
+def test_token_survives_an_unrelated_save():
+    client.post(
+        "/api/notify/ntfy",
+        json={"topic": "t1", "server": "https://a.example.com", "token": "tk_a"},
+    )
+    v = client.post("/api/notify/ntfy", json={"topic": "t2"}).json()
+    assert v["has_token"] is True
+
+
+def test_click_url_access_token_is_stripped():
+    v = client.post(
+        "/api/notify/ntfy",
+        json={"topic": "t1", "click_url": "http://box:8080/m?token=SUPERSECRET"},
+    ).json()
+    assert "SUPERSECRET" not in v["click_url"] and "token" not in v["click_url"]
+    assert "access token was removed" in v.get("note", "")
+    S.invalidate()
+    assert "SUPERSECRET" not in S.load_settings().notifications.ntfy_click_url
+
+
+def test_ntfy_token_is_masked_in_the_settings_read():
+    """The generic /api/settings must not leak the token either."""
+    client.post("/api/notify/ntfy", json={"topic": "t1", "token": "tk_secret"})
+    r = client.get("/api/settings")
+    assert "tk_secret" not in r.text
+    assert r.json()["settings"]["notifications"]["ntfy_token"] == "•••set"
+
+
+def test_settings_write_keeps_the_token_on_a_masked_submit():
+    client.post("/api/notify/ntfy", json={"topic": "t1", "token": "tk_secret"})
+    client.post("/api/settings", json={"notifications": {"ntfy_token": "•••set"}})
+    S.invalidate()
+    assert S.load_settings().notifications.ntfy_token == "tk_secret"
+
+
+def test_qr_is_offered_once_a_topic_exists():
+    client.post("/api/notify/ntfy", json={"topic": "mindflock-qr"})
+    qr = client.get("/api/notify/ntfy").json()["qr_svg"]
+    # segno is a soft dependency: present -> a bare inline <svg>, absent -> None.
+    assert qr is None or qr.lstrip().startswith("<svg")
+
+
+def test_test_endpoint_uses_the_request_body(http):
+    """ "Send a test" must verify a topic the user hasn't saved yet."""
+    r = client.post(
+        "/api/notify/ntfy/test", json={"topic": "unsaved-topic", "token": "tk_body"}
+    ).json()
+    assert r == {"ok": True, "error": ""}
+    assert http[0]["json"]["topic"] == "unsaved-topic"
+    assert http[0]["headers"]["Authorization"] == "Bearer tk_body"
+    S.invalidate()
+    assert S.load_settings().notifications.ntfy_topic == ""  # a test saves nothing
+
+
+def test_test_endpoint_falls_back_to_the_saved_token(http):
+    client.post("/api/notify/ntfy", json={"topic": "t1", "token": "tk_saved"})
+    client.post("/api/notify/ntfy/test", json={"topic": "t1", "token": "•••set"})
+    assert http[-1]["headers"]["Authorization"] == "Bearer tk_saved"
+
+
+def test_test_endpoint_reports_a_bad_config_without_sending(http):
+    r = client.post("/api/notify/ntfy/test", json={"topic": ""}).json()
+    assert r["ok"] is False and "topic" in r["error"]
+    assert not http
+
+
+def test_test_endpoint_reports_the_server_error(http):
+    http.state["response"] = _FakeResponse(401, payload={"error": "unauthorized"})
+    r = client.post("/api/notify/ntfy/test", json={"topic": "t1"}).json()
+    assert r["ok"] is False and "unauthorized" in r["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Rule dispatch (the server-side channel)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def pushes(monkeypatch):
+    """Capture what dispatch would push, without touching the transport."""
+    sent: list = []
+    monkeypatch.setattr(
+        ntfy,
+        "publish_soon",
+        lambda cfg, **kw: sent.append({"cfg": cfg, **kw}),
+    )
+    return sent
+
+
+def _addon() -> notify_addon.NotifyAddon:
+    return notify_addon.NotifyAddon()
+
+
+def _clarify(session="alpha") -> dict:
+    return {
+        "seq": 1,
+        "event": "session.activity_changed",
+        "session": session,
+        "old": "working",
+        "new": "clarify",
+        "ts": 0.0,
+        "data": {},
+    }
+
+
+def test_dispatch_pushes_a_matching_event(pushes):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    _addon()._on_event(_clarify())
+    (push,) = pushes
+    assert push["title"] == "alpha needs your input"
+    assert push["message"] == "The agent is waiting on a clarification."
+    # Priority 4 is what rings a phone through most do-not-disturb setups.
+    assert push["priority"] == 4 and push["tags"] == ["question"]
+    assert push["cfg"].topic == "t1"
+
+
+def test_dispatch_is_silent_when_the_channel_is_off(pushes):
+    _addon()._on_event(_clarify())  # nothing configured
+    S.update_settings(notifications={"ntfy_topic": "t1"})  # topic but not enabled
+    _addon()._on_event(_clarify())
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": ""})
+    _addon()._on_event(_clarify())  # enabled but no topic
+    assert pushes == []
+
+
+def test_dispatch_respects_a_muted_rule(pushes):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    client.post("/api/notify/rules/needs_input", json={"enabled": False})
+    _addon()._on_event(_clarify())
+    assert pushes == []
+
+
+def test_dispatch_honours_an_opted_in_rule(pushes):
+    """Default-off rules push only once the user turns them on."""
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    idle = {**_clarify(), "new": "idle"}
+    _addon()._on_event(idle)
+    assert pushes == []
+    client.post("/api/notify/rules/session_idle", json={"enabled": True})
+    _addon()._on_event(idle)
+    assert len(pushes) == 1 and pushes[0]["priority"] == 2  # ambient: no buzz
+
+
+def test_dispatch_dedupes_a_flapping_transition(pushes):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    addon = _addon()
+    addon._on_event(_clarify())
+    addon._on_event(_clarify())
+    assert len(pushes) == 1
+    # A different session is its own stream.
+    addon._on_event(_clarify(session="beta"))
+    assert len(pushes) == 2
+
+
+def test_dispatch_ignores_unrelated_events(pushes):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    addon = _addon()
+    addon._on_event({**_clarify(), "event": "session.created", "new": None})
+    # stage_changed off "pr" matches pr_closed; onto "pr" must not.
+    addon._on_event(
+        {**_clarify(), "event": "session.stage_changed", "old": "pushed", "new": "pr"}
+    )
+    assert pushes == []
+
+
+def test_pr_closed_matches_leaving_the_pr_stage(pushes):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    _addon()._on_event(
+        {**_clarify(), "event": "session.stage_changed", "old": "pr", "new": "pushed"}
+    )
+    (push,) = pushes
+    assert push["title"] == "alpha: PR merged or closed"
+
+
+def test_dispatch_never_raises_into_the_emitter(monkeypatch):
+    """A push failure must not break the event bus for everyone else."""
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+
+    def _boom(*a, **kw):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(ntfy, "publish_soon", _boom)
+    _addon()._on_event(_clarify())  # no exception
+
+
+async def test_startup_is_idempotent():
+    """A second on_startup must not stack a second subscriber (nothing reclaims
+    an unsubscribe callable the addon drops)."""
+    addon = _addon()
+    await addon.on_startup(_ctx())
+    first = addon._unsubscribe
+    await addon.on_startup(_ctx())
+    assert addon._unsubscribe is first
+    await addon.on_shutdown(_ctx())
+    assert addon._unsubscribe is None
+
+
+async def test_startup_registers_the_loop_for_cross_thread_pushes():
+    """on_startup runs on the server loop — that's where publish_soon gets the
+    loop it trampolines onto from bus callbacks on worker threads."""
+    addon = _addon()
+    await addon.on_startup(_ctx())
+    assert ntfy._LOOP is asyncio.get_running_loop()
+    await addon.on_shutdown(_ctx())
+
+
+async def test_startup_subscribes_to_the_bus(pushes):
+    """End to end through the real bus: emit -> push, and unsubscribe on stop."""
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    addon = _addon()
+    ctx = _ctx()
+    await addon.on_startup(ctx)
+    events.BUS.emit(
+        "session.activity_changed", session="gamma", old="working", new="clarify"
+    )
+    assert len(pushes) == 1 and pushes[0]["title"] == "gamma needs your input"
+    await addon.on_shutdown(ctx)
+    events.BUS.emit(
+        "session.activity_changed", session="delta", old="working", new="clarify"
+    )
+    assert len(pushes) == 1  # unsubscribed
+
+
+# --------------------------------------------------------------------------- #
+# publish_soon: the cross-thread trampoline
+#
+# Bus callbacks run synchronously on whatever thread emitted, so this is the
+# seam that keeps a 10s HTTP call off the emitter's critical path. Each branch
+# (running loop / registered loop from another thread / no loop at all) is a
+# different failure if it regresses: a blocked emit, a dropped push, or a
+# "coroutine was never awaited" warning.
+# --------------------------------------------------------------------------- #
+async def test_publish_soon_schedules_on_the_running_loop(http):
+    cfg = ntfy.NtfyConfig(enabled=True, topic="t1")
+    ntfy.publish_soon(cfg, title="T", message="M")
+    assert await _settle(lambda: len(http) == 1)
+    assert http[0]["json"]["topic"] == "t1"
+
+
+async def test_publish_soon_from_a_worker_thread_uses_the_registered_loop(http):
+    """The real path: emit() on a FastAPI worker thread, HTTP on the server loop."""
+    ntfy.set_loop(asyncio.get_running_loop())
+    cfg = ntfy.NtfyConfig(enabled=True, topic="from-thread")
+    done = threading.Event()
+
+    def _emit_off_loop():
+        ntfy.publish_soon(cfg, title="T", message="M")
+        done.set()
+
+    threading.Thread(target=_emit_off_loop, daemon=True).start()
+    assert done.wait(5)
+    assert await _settle(lambda: len(http) == 1)
+    assert http[0]["json"]["topic"] == "from-thread"
+
+
+def test_publish_soon_without_a_loop_runs_on_a_throwaway_thread(http):
+    """A bare sync context (CLI, a unit test) still delivers — no loop needed."""
+    assert ntfy._LOOP is None  # the fixture cleared it
+    ntfy.publish_soon(
+        ntfy.NtfyConfig(enabled=True, topic="no-loop"), title="T", message="M"
+    )
+    assert _wait(lambda: len(http) == 1)
+    assert http[0]["json"]["topic"] == "no-loop"
+
+
+def test_publish_soon_never_raises_at_the_emitter(monkeypatch, http):
+    """Whatever the dispatch does, emit() must survive it — and the coroutine it
+    could not schedule must be *closed*, not abandoned to a "never awaited"
+    warning at some later GC.
+
+    Asserting on the warning is not enough: the raised OSError's traceback keeps
+    the frame (and the coroutine) alive, so the warning never fires during the
+    test either way. So hold the coroutine ourselves and check its frame.
+    """
+    made: list = []
+    real_publish = ntfy.publish
+
+    def _tracked(*a, **kw):
+        coro = real_publish(*a, **kw)
+        made.append(coro)
+        return coro
+
+    monkeypatch.setattr(ntfy, "publish", _tracked)
+    monkeypatch.setattr(
+        ntfy.threading,
+        "Thread",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("cannot spawn")),
+    )
+
+    ntfy.publish_soon(ntfy.NtfyConfig(enabled=True, topic="t1"), title="T", message="M")
+
+    assert len(made) == 1
+    assert made[0].cr_frame is None, "the unscheduled coroutine was left un-closed"
+    assert not http  # nothing was sent, and nothing raised at the call site
+
+
+# --------------------------------------------------------------------------- #
+# The QR renderer, shared with Settings → Mobile
+# --------------------------------------------------------------------------- #
+def test_qr_svg_is_the_shared_renderer():
+    """The ntfy view is why ``_mobile_svg`` became the public ``qr_svg``; the old
+    name is still what server.py imports, so both have to keep working."""
+    assert mobile_access._mobile_svg is mobile_access.qr_svg
+    assert server._mobile_svg is mobile_access.qr_svg
+    svg = mobile_access.qr_svg("https://ntfy.sh/mindflock-abc")
+    if svg is None:
+        pytest.skip("segno is not installed — qr_svg degrades to None by design")
+    # A bare <svg> (no XML prolog) with a viewBox, so it scales in whatever box
+    # the settings CSS gives it — injected via innerHTML at both call sites.
+    assert svg.lstrip().startswith("<svg") and "viewBox=" in svg
+    assert "<?xml" not in svg
+
+
+# --------------------------------------------------------------------------- #
+# What must never leak
+# --------------------------------------------------------------------------- #
+def test_nothing_logs_the_topic_or_the_token(monkeypatch, http):
+    """mindflock.log is served back out over GET /api/logs, and on a public
+    server the topic IS the credential — so log lines carry the host only."""
+    lines: list = []
+    monkeypatch.setattr(ntfy, "log_error", lambda fmt, *a: lines.append(fmt % a))
+    http.state["response"] = _FakeResponse(403, payload={"error": "forbidden"})
+    cfg = ntfy.NtfyConfig(
+        enabled=True, topic="super-secret-topic", token="tk_secret", server="https://h"
+    )
+    asyncio.run(ntfy.publish(cfg, title="T", message="M"))
+    assert lines, "a failed push should log something"
+    blob = "\n".join(lines)
+    assert "super-secret-topic" not in blob and "tk_secret" not in blob
+    assert "h" in blob  # the host is what identifies the failure
+
+
+# --------------------------------------------------------------------------- #
+# Rule payload + frontend wiring
+# --------------------------------------------------------------------------- #
+def test_every_rule_carries_push_metadata():
+    for rule in notify_addon.NOTIFY_RULES:
+        assert rule["priority"] in (2, 3, 4), rule["id"]
+        assert rule["tags"] and all(isinstance(t, str) for t in rule["tags"])
+
+
+def test_push_metadata_is_not_exposed_to_the_client():
+    """The client needs the resolved ``enabled``, not our internals."""
+    for rule in client.get("/api/notify/config").json()["rules"]:
+        assert "priority" not in rule and "tags" not in rule
+        assert "default_enabled" not in rule
+        assert rule["event"] and "enabled" in rule
+
+
+def test_frontend_wires_the_ntfy_section():
+    js = client.get("/app.js").text
+    assert "/api/notify/ntfy" in js
+    assert "/api/notify/ntfy/test" in js
+    assert "suggested_topic" in js  # Generate uses the server's random topic


### PR DESCRIPTION
Adds an optional **ntfy** delivery channel for session notifications, so an
alert reaches your phone with MindFlock closed.

## Why

The only notification channel was the browser's `Notification` API, which needs
a MindFlock tab open **on a secure origin** — and the default serving mode is
http over tailscale/LAN, where the API is gated off entirely. So the one moment
the feature exists for ("an agent is waiting on a clarification, go look") is
exactly the moment it can't fire. This channel is published by the *server*, so
no tab, no browser, and no window is required.

## The shape of it

**One rule list, two delivery channels.** The existing per-rule switches
(`NOTIFY_RULES`) now govern both channels; a channel only decides *where* an
alert lands. The rules gained per-rule ntfy priority, so the actionable ones
(needs-input, over-budget, pre-commit-failed) buzz through do-not-disturb at
priority 4 while the ambient opt-ins (idle, pre-commit running) arrive quietly
at 2.

- `backend/web/core/ntfy.py` — config resolution (env → settings.json →
  defaults), validation, and the transport. Publishes via ntfy's **JSON** API
  (POST to the server root, topic in the body) rather than `POST /<topic>` +
  `X-Title`: session titles are arbitrary UTF-8 and HTTP headers are not.
- `backend/web/addons/notify.py` — `on_startup` subscribes to the event bus and
  evaluates the same rules server-side. Subscribes unconditionally and checks
  configuration in the *callback*, so turning ntfy on in Settings takes effect
  immediately instead of at the next restart.
- Settings → Notifications gains the section: toggle, topic with **Generate**,
  server, token, tap-to-open URL, **Send a test** with a verdict line, and a QR
  of the subscribe URL (sharing the Settings → Mobile renderer, which is why
  `_mobile_svg` became the public `qr_svg`).
- New: `GET|POST /api/notify/ntfy`, `POST /api/notify/ntfy/test`, and
  `notifications.ntfy_*` settings. Off until configured.

## Care taken where it could leak

- **The token is dropped** when `Server` is retargeted at a different host
  without a fresh token — server A's credential is never sent to server B.
  Otherwise it follows the normal secret convention (masked on read, kept on an
  empty write, registered in the settings addon's `_SECRET_FIELDS`).
- **A `token=` parameter is stripped** from the tap-to-open URL, because that
  URL is stored on the ntfy server. Users will naturally paste the one from
  Settings → Mobile, which carries `?token=<access token>`.
- **Nothing logs the topic.** `mindflock.log` is served back out over
  `GET /api/logs`, and on the public server the topic *is* the credential —
  hence the random default, the on-screen warning, and host-only log lines.
- Pushes are capped at **60/hour per process** so a flapping session can't burn
  a quota, and delivery is best-effort throughout: a failed push is recorded for
  the settings screen and never touches the event that triggered it.
- `POST /api/notify/ntfy/test` publishes to the server in the *request body* —
  inherent to "test before you save", bounded, auth-gated, and now documented as
  the request-forgery surface it is (private/LAN hosts are deliberately allowed:
  self-hosted ntfy on a tailnet is a first-class case).

## Verification

- `tests/unit/test_ntfy.py` — 57 new tests: the wire contract (including a
  non-ASCII title), the rate cap, every endpoint and its secret handling, the
  cross-thread dispatch trampoline in all three branches, and dispatch silence
  (channel off, rule muted, duplicate, unrelated event).
- Full suite **3482 passed**; frontend `vitest` 148 passed, `tsc --noEmit`
  clean; `uvx black` and `detect-secrets` clean; committed bundle verified fresh
  by the pre-push hook.
- **End-to-end unstubbed** against a local fake ntfy server: a real
  `session.activity_changed → clarify` bus event produced exactly one push
  (`title: "fix-login-bug needs your input"`, priority 4, `question` tag, bearer
  token) while a `status_changed` was correctly ignored.
- UI verified in a running server (screenshots): the section, the QR, the
  public-server warning, and the shared rule list all render.
