### PR TITLE
Release 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-07-30
+
 ### Added
 
 - **Optional ntfy push, so notifications reach your phone.** Until now the only
@@ -493,7 +495,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.6
 [0.1.5]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.5
 [0.1.4]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.4
 [0.1.3]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.3

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.5"
+version = "0.1.6"
 description = "MindFlock — run a flock of AI coding agents, each in its own git worktree; started by your ticket queue (Jira, Linear, GitHub Issues, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump + CHANGELOG roll for **0.1.6**. No functional changes — every
manifest (`pyproject.toml`, `electron/package.json`, `frontend/package.json`,
`uv.lock`) written by `scripts/bump-version.py`, which also opened the
`[0.1.6] - 2026-07-30` heading and retargeted the compare links.

## Why now

#24 added a user-facing feature — the optional **ntfy phone-push channel** for
session notifications — and the install paths diverge on exactly that kind of
change: `install.sh` defaults to `REF=main`, so CLI users already have it, but
`release.yml` only fires on `v*`, so **desktop (dmg/exe/AppImage) users do not
until this is tagged**.

Worth tagging on its own merits, too: the notification a phone can receive while
MindFlock is closed is the piece that makes an unattended flock checkable, and it
is off by default, so shipping it costs existing users nothing.

## Contents

Just the one feature since `v0.1.5` (which was tagged earlier the same day):

- **Optional ntfy push** — one rule list, two delivery channels; the server
  publishes so no browser tab is needed. Per-rule priority, a topic-generator +
  QR + test-send in Settings → Notifications, self-hostable server, and env
  configuration for headless boxes. Full entry in the CHANGELOG.

## Verification

Everything green on #24 before merge (both matrix legs, black, dco, version
consistency, frontend-bundle freshness, cold install) and the suite is
**3482 passed** on `main`. `electron/build/installer.nsh` and the
electron-builder config are untouched, so no desktop-matrix dry run was needed
ahead of the tag.
