### PR TITLE
Put phone push below the trigger list, and tell people it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,42 @@ Or toggle it from the web UI sidebar (**Ticket Ingestion** bar), which runs
 it as a managed subprocess and tails its log. The pipeline is a singleton per
 directory (`.mindflock-pipeline.lock`); a second copy exits cleanly.
 
+### Notifications & phone push (ntfy)
+
+Settings → **Notifications** holds one rule list — *What triggers a
+notification* (needs-input, PR merged/closed, budget exceeded, pre-commit
+failed, plus quieter opt-ins) — and two channels it feeds:
+
+- **Browser / desktop** popups, which need a tab open on a secure origin
+  (HTTPS or localhost).
+- **Phone push via [ntfy](https://ntfy.sh)** — off until you turn it on. The
+  *server* publishes to a topic your phone subscribes to, so an alert reaches
+  you with MindFlock closed and no tab anywhere.
+
+To set it up: install the free ntfy app, then in Settings → Notifications →
+**Phone push (ntfy)** hit **Generate** for a random topic, scan the QR into the
+app, and **Send a test**. Point **Server** at your own ntfy instance to keep
+session titles off the public one, and set *Tapping opens* to your phone URL
+from Settings → Mobile so a tap lands in the mobile UI.
+
+> On the public `ntfy.sh` server **the topic name is the credential** — anyone
+> who knows it can read your session titles or send you fakes. Keep the
+> generated random name, or self-host.
+
+Headless boxes have no Settings screen, so the same channel configures from the
+environment — exporting `MINDFLOCK_NTFY_TOPIC` is an implicit opt-in:
+
+```bash
+export MINDFLOCK_NTFY_TOPIC=mindflock-xTPq…      # implicit opt-in
+export MINDFLOCK_NTFY_SERVER=https://ntfy.example  # optional: your own instance
+export MINDFLOCK_NTFY_TOKEN=tk_…                   # optional: protected topic
+```
+
+See [docs/web-ui.md](docs/web-ui.md#notifications-) for the full screen guide
+(including how to diagnose a push that doesn't arrive) and
+[docs/configuration.md](docs/configuration.md) for every `MINDFLOCK_NTFY_*`
+variable and its precedence over the Settings values.
+
 ### Extensions & hooks
 
 Every session event (created, status/activity/stage changed, paused, deleted…)

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29589,11 +29589,11 @@ function Notifications(_) {
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", id: "notif-browser-status", children: status }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(Ntfy, {}),
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "What triggers a notification" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Pick exactly which events notify you — turn off any you don't want. These switches apply to every channel above." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Pick exactly which events notify you — turn off any you don't want. These switches apply to both channels — the browser above and phone push below." }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "notif-rules-list", children: rulesError ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "Couldn't load notification rules." }) : rules === null ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "Loading…" }) : !rules.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "No notification rules configured." }) : rules.map((rule) => /* @__PURE__ */ jsxRuntimeExports.jsx(RuleRow, { rule }, rule.id)) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Also reachable from the bell in the sidebar header." })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Also reachable from the bell in the sidebar header." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(Ntfy, {})
   ] });
 }
 function ago(ts) {

--- a/frontend/src/components/settings/screens/Notifications.tsx
+++ b/frontend/src/components/settings/screens/Notifications.tsx
@@ -115,11 +115,10 @@ export function Notifications(_: ScreenProps) {
         </label>
       </div>
       <p className="set-hint" id="notif-browser-status">{status}</p>
-      <Ntfy />
       <h3 className="set-section-title">What triggers a notification</h3>
       <p className="set-hint">
         Pick exactly which events notify you — turn off any you don't want. These switches
-        apply to every channel above.
+        apply to both channels — the browser above and phone push below.
       </p>
       <div id="notif-rules-list">
         {rulesError ? (
@@ -135,6 +134,7 @@ export function Notifications(_: ScreenProps) {
         )}
       </div>
       <p className="set-hint">Also reachable from the bell in the sidebar header.</p>
+      <Ntfy />
     </>
   );
 }
@@ -143,9 +143,10 @@ export function Notifications(_: ScreenProps) {
  * ntfy — the phone-push channel.
  *
  * Why it's a section of its own rather than another rule switch: it's a
- * *delivery channel*, not a trigger. The rule list below decides WHAT notifies
+ * *delivery channel*, not a trigger. The rule list above decides WHAT notifies
  * you; browser and ntfy decide WHERE. ntfy is the one that works with MindFlock
- * closed, since the push happens server-side.
+ * closed, since the push happens server-side. It renders last on purpose: the
+ * triggers read first, then the two channels they feed.
  * ------------------------------------------------------------------------ */
 interface NtfyView {
   enabled?: boolean;


### PR DESCRIPTION
Settings → Notifications read in the wrong order: the ntfy phone-push channel sat between the browser toggle and the rule list, so you met a delivery channel before you knew what it delivered. Triggers now read first, then the two channels they feed — browser above, phone below.

The README never mentioned how to turn ntfy on, only that it existed, so the feature was undiscoverable outside the Settings dialog.

## Changes

- `frontend/src/components/settings/screens/Notifications.tsx` — `<Ntfy />` moves below the rule list; the "applies to every channel above" hint and the component's own doc comment updated to match the new order.
- `README.md` — new **Notifications & phone push (ntfy)** section under Usage: the two channels, the phone setup walkthrough, the public-`ntfy.sh` topic-is-the-credential warning, and the `MINDFLOCK_NTFY_*` env vars for headless boxes, with links to `docs/web-ui.md` and `docs/configuration.md`.
- `backend/web/static/app.js` — rebuilt bundle (build output).

## Verification

- `npx tsc --noEmit` clean; `npm run build` clean.
- `pytest -k "ntfy or notify"` → 73 passed.
- Confirmed the running server serves the rebuilt bundle (served `/app.js` md5 matches the repo's).

No API or prop changes — the reorder is internal to the screen, whose only consumer is `SettingsDialog.tsx`.