### PR TITLE
Let people remove a saved ntfy token

### DIFF
--- a/backend/web/addons/notify.py
+++ b/backend/web/addons/notify.py
@@ -342,6 +342,15 @@ class NotifyAddon(Addon):
             with one extra safety: retargeting the channel at a *different host*
             without supplying a new token drops the old one rather than shipping
             server A's credential to server B.
+
+            That convention has no way to say "I want no token at all", which
+            matters here more than for the app's other secrets: an ntfy token is
+            *optional* (public topics need none), and a wrong one is worse than
+            none — ntfy rejects a bad credential with 401 instead of ignoring
+            it, so a stray token breaks a push that would otherwise work.
+            ``{"clear_token": true}`` is that escape hatch, and it wins over any
+            ``token`` in the same payload: it is the destructive intent, and the
+            only way to send both is to mean it.
             """
             payload = payload or {}
             stored = settings_store.load_settings().notifications
@@ -379,7 +388,13 @@ class NotifyAddon(Addon):
                     return JSONResponse({"error": problem}, status_code=400)
 
             token = str(payload.get("token") or "").strip()
-            if token and token != SECRET_MASK:
+            if payload.get("clear_token"):
+                patch["ntfy_token"] = ""  # "" clears (see update_settings)
+                if stored.ntfy_token:
+                    note = (
+                        (note + " ") if note else ""
+                    ) + "The saved access token was cleared."
+            elif token and token != SECRET_MASK:
                 patch["ntfy_token"] = token
             elif stored.ntfy_token and not ntfy.same_host(
                 stored.ntfy_server or ntfy.DEFAULT_SERVER, server

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29753,8 +29753,25 @@ function Ntfy() {
           onKeyDown: (e) => e.key === "Enter" && e.target.blur()
         }
       ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Needed only if your topic is access-protected (self-hosted, or a reserved ntfy.sh topic). Blank keeps the saved one." })
+      view.has_token ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          className: "test-btn",
+          id: "ntfy-token-clear",
+          title: "Remove the saved access token — most public topics need none",
+          onClick: () => {
+            setToken("");
+            save2({ clear_token: true });
+          },
+          children: "Clear"
+        }
+      ) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "set-hint", children: [
+        "Needed only if your topic is access-protected (self-hosted, or a reserved ntfy.sh topic). Blank keeps the saved one — use ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "Clear" }),
+        " to remove it."
+      ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ntfy-field-row", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Tapping opens" }),

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -382,7 +382,8 @@ sentinel `•••set` when one is stored and `""` when none is, and a write of
 `""` **or** the sentinel *keeps* the saved value rather than clearing it. Only a
 different non-empty string replaces a secret; clearing one is a deliberate
 product decision per field (the ntfy token, for instance, is cleared by
-retargeting the server — see Notify below). The sentinel is one shared constant,
+retargeting the server, or explicitly with `{"clear_token": true}` — see Notify
+below). The sentinel is one shared constant,
 `SECRET_MASK` in `web/addons/base.py`, with a hand-mirrored counterpart in the
 frontend's `settings/useSettings.tsx`; changing the string means changing both,
 or the UI starts writing the literal mask into the store as a password.
@@ -450,7 +451,7 @@ the generic extension path (see [docs/extensions.md](extensions.md)):
 | GET | `/api/notify/config` | `{rules: [{id, label, event, old, new, title, body, enabled}]}` — the event → notification rules, applied client-side by `static/addons/notify.js` and server-side by the ntfy channel |
 | POST | `/api/notify/rules/{rule_id}` | Enable/disable one rule (for **both** channels) |
 | GET | `/api/notify/ntfy` | The ntfy channel's state: `{enabled, server, server_default, topic, has_token, click_url, configured, active, public_server, subscribe_url, qr_svg, suggested_topic, last}`. Never the token — only `has_token`; `suggested_topic` is a fresh random name, `last` is `{ts, ok, error}` of the most recent push |
-| POST | `/api/notify/ntfy` | Save `{enabled?, server?, topic?, token?, click_url?}` (only the keys present are touched); returns the `GET` view, plus a `note` when something was rewritten. `400 {error}` on an invalid topic/server URL |
+| POST | `/api/notify/ntfy` | Save `{enabled?, server?, topic?, token?, click_url?, clear_token?}` (only the keys present are touched); returns the `GET` view, plus a `note` when something was rewritten. `clear_token: true` removes the saved token — the escape hatch from "empty = keep", and it wins over a `token` in the same payload. `400 {error}` on an invalid topic/server URL |
 | POST | `/api/notify/ntfy/test` | Send one test push — `{ok, error}`. Takes its config from the body when supplied, so a topic can be verified before it is saved; exempt from the rate cap |
 
 The ntfy channel is a **server-side** delivery path for the same rules
@@ -468,6 +469,14 @@ dropped when the server URL is retargeted at a different host without a fresh
 token, so server A's credential is never sent to server B; and a `token=` query
 parameter in `click_url` is stripped, since that URL is stored on the ntfy
 server.
+
+Unlike the app's other secrets, this one can also be *removed*, with
+`{"clear_token": true}`. The reason is specific to ntfy: the token is optional
+(public topics need none), and a wrong token is strictly worse than no token —
+ntfy answers a bad credential with `401 unauthorized` rather than ignoring it,
+so a stray value breaks a publish that would have succeeded unauthenticated.
+Without an explicit clear, "empty = keep" would make a mistyped token permanent
+short of retargeting the server or hand-editing `settings.json`.
 
 **Errors: branch on the body, not the status.** The two write endpoints report
 failure differently on purpose. `POST /api/notify/ntfy` is a validating write, so

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -220,7 +220,10 @@ channels, and each channel decides only where an alert lands.
   **Send a test** confirms the round trip; the row afterwards reports the last
   push (or why it failed). Point **Server** at your own ntfy instance to keep
   everything in-house, and give **Access token** a value only if the topic is
-  protected. *Tapping opens* is an optional URL the notification opens — paste
+  protected — **Clear** beside it removes a saved one, since blanking the field
+  means "keep" and a *wrong* token is worse than none (ntfy 401s a bad
+  credential on a topic that needed no credential at all).
+  *Tapping opens* is an optional URL the notification opens — paste
   your phone URL from Settings → Mobile; MindFlock strips an `?token=` from it,
   since that URL is stored on the ntfy server.
 

--- a/frontend/src/components/settings/screens/Notifications.tsx
+++ b/frontend/src/components/settings/screens/Notifications.tsx
@@ -325,10 +325,29 @@ function Ntfy() {
           onBlur={() => token && save({ token })}
           onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
         />
-        <span />
+        {/* Blanking the field means "keep" (the app-wide secret convention), so
+            without this there is no way back to having no token at all — and a
+            wrong token is worse than none: ntfy 401s a bad credential on a
+            topic that needs no credential. */}
+        {view.has_token ? (
+          <button
+            type="button"
+            className="test-btn"
+            id="ntfy-token-clear"
+            title="Remove the saved access token — most public topics need none"
+            onClick={() => {
+              setToken("");
+              save({ clear_token: true });
+            }}
+          >
+            Clear
+          </button>
+        ) : (
+          <span />
+        )}
         <span className="set-hint">
           Needed only if your topic is access-protected (self-hosted, or a reserved ntfy.sh
-          topic). Blank keeps the saved one.
+          topic). Blank keeps the saved one — use <strong>Clear</strong> to remove it.
         </span>
       </div>
       <div className="ntfy-field-row">

--- a/tests/unit/test_ntfy.py
+++ b/tests/unit/test_ntfy.py
@@ -435,6 +435,41 @@ def test_token_is_dropped_when_the_server_host_changes():
     assert S.load_settings().notifications.ntfy_token == ""
 
 
+def test_clear_token_removes_the_saved_token():
+    """The escape hatch from the "empty = keep" convention.
+
+    An ntfy token is optional, and a wrong one is worse than none (ntfy answers
+    a bad credential with 401 even on a topic that needs no credential), so
+    there has to be a way back to having none at all.
+    """
+    client.post("/api/notify/ntfy", json={"topic": "t1", "token": "tk_secret"})
+    v = client.post("/api/notify/ntfy", json={"clear_token": True}).json()
+    assert v["has_token"] is False
+    assert "cleared" in v.get("note", "")
+    S.invalidate()
+    assert S.load_settings().notifications.ntfy_token == ""
+    # Same server, same topic: clearing must not disturb the rest of the config.
+    assert v["topic"] == "t1"
+
+
+def test_clear_token_wins_over_a_token_in_the_same_payload():
+    client.post("/api/notify/ntfy", json={"topic": "t1", "token": "tk_secret"})
+    v = client.post(
+        "/api/notify/ntfy", json={"token": "tk_new", "clear_token": True}
+    ).json()
+    assert v["has_token"] is False
+    S.invalidate()
+    assert S.load_settings().notifications.ntfy_token == ""
+
+
+def test_clear_token_on_a_channel_with_no_token_is_a_no_op():
+    """No stored token: still fine, and no note claiming something was cleared."""
+    client.post("/api/notify/ntfy", json={"topic": "t1"})
+    v = client.post("/api/notify/ntfy", json={"clear_token": True}).json()
+    assert v["has_token"] is False
+    assert "cleared" not in v.get("note", "")
+
+
 def test_token_survives_an_unrelated_save():
     client.post(
         "/api/notify/ntfy",


### PR DESCRIPTION
The **Access token** field in Settings → Notifications was write-only. Blanking it means "keep the saved one" (the app-wide secret convention, `SECRET_MASK`), so once any value was stored there was no way back to having none — short of retargeting the server at a different host or hand-editing `settings.json`.

That convention fits a *rotatable* secret, but an ntfy token is **optional** and a wrong one is strictly worse than none: ntfy answers a bad credential with `401 unauthorized` rather than ignoring it, so a mistyped token permanently breaks pushes to a public topic that needs no credential at all. Typing something into the field to see what it did was enough to wedge the channel, with no way out from the UI.

## Changes

- `backend/web/addons/notify.py` — `POST /api/notify/ntfy` accepts `{"clear_token": true}`, which empties the stored token and notes it in the response. It wins over a `token` in the same payload: it's the destructive intent, and the only way to send both is to mean it. A clear with nothing stored is a no-op and does not claim otherwise in `note`.
- `frontend/src/components/settings/screens/Notifications.tsx` — a **Clear** button beside the field, rendered only when `has_token` (it occupies the grid slot the empty `<span />` held, so the row layout is unchanged). The field hint now says blank keeps, Clear removes.
- `tests/unit/test_ntfy.py` — three tests: clear removes the token and leaves the rest of the config alone, clear beats a token in the same payload, clear with nothing stored is a quiet no-op.
- `docs/web-api.md`, `docs/web-ui.md` — the new field and *why* this secret is clearable when the others aren't.
- `backend/web/static/app.js` — rebuilt bundle (build output).

## Verification

- `pytest -k "ntfy or notify"` → 76 passed (was 73).
- `black --check`, `tsc --noEmit`, `npm run build` all clean.
- Behaviour confirmed against live ntfy.sh beforehand: publishing to an open topic with no auth header returns `200`, and the identical request with a bogus `Bearer` token returns `{"code":40101,"http":401,"error":"unauthorized"}` — the 401 this fix makes recoverable.