### PR TITLE
Release 0.1.7 — phone URL in every push, mobile Diff tab, self-applying tailscale mode, usage-limit resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-07-31
+
+### Added
+
+- **Your phone URL now travels with the notifications.** When Tailscale is up,
+  every ntfy push carries this machine's tailnet `/m` address — in the message
+  and as the tap target — deep-linked to the session it is about (`/m?s=<title>`),
+  so a notification is one tap from the thing it's telling you about instead of
+  the start of a hunt for the URL. On top of that, one push announces the URL
+  whenever it becomes newly reachable: at server start, when the ntfy channel is
+  switched on, and when tailscale mode is turned on. The access token is never
+  included — the message is stored on a third-party server, so it goes bare and
+  says that a new device will meet the sign-in page. Deduplicated (turning on
+  push and tailscale mode back to back is one intent), and a URL that isn't live
+  until a restart says so. *Tapping opens* stays available for sending taps
+  somewhere else entirely.
+
+- **A Diff tab in the phone UI.** `/m` gains a third tab beside Agent and Shell,
+  reading the same `GET /api/instances/<title>/diff` as the desktop Diff tab
+  with the same two baselines behind one button (**All changes** vs
+  **Uncommitted**, persisted under the shared `mf_diffbase` key). Unified and
+  colorized like the desktop, with each file's name lifted into a header that
+  sticks while its hunks scroll past, sideways scrolling contained inside the
+  panel, and a cap for very large diffs. The terminal stays attached behind it,
+  so switching back is instant — and the git action bar (with its status toast)
+  stays on screen, because reading the diff is exactly when you decide to push.
+  A phone can now approve work, not just unblock it.
+
+- **Tailscale mode applies itself.** Which interface uvicorn binds is fixed at
+  process start, so the Settings → Mobile toggle only ever meant something after
+  a restart. Turning it on now takes that restart: `POST /api/settings` answers
+  `{"restarting": true}` and the screen waits for the server to come back and
+  refreshes the URLs/QR in place. Bounded at three attempts (counted in the
+  environment, since each attempt is a new process image) before it gives up and
+  leaves the manual button, rather than restart-looping a server that isn't
+  going to come up on the tailnet. The same check runs at every boot, so a
+  server started in local mode while the setting says tailscale corrects itself.
+
+- **Sessions that run out of usage get picked back up.** The prompt queue has
+  always ridden out a usage limit for sessions with something queued; a session
+  that simply ran out mid-task had an empty queue, so nothing was watching it —
+  it sat on its CLI's limit screen until a human came back, often hours after
+  the window reopened. The drain pass now also walks the sessions whose activity
+  is `limit` (a free read of the state snapshot — no probes when nothing has run
+  out), waits the window out with the same meter/banner logic, and sends
+  Esc + `continue` so the agent resumes its task. New setting
+  `general.resume_on_usage_reset` (Settings → General, default on).
+
+  Two notification rules go with it, both default-on and mutable like the rest:
+  **"A session runs out of usage"** and **"Usage comes back after running out"**.
+  The second rides on a new `session.usage_restored` event, emitted once per
+  reopening by that watcher — so it cannot fire for a window that merely rolled
+  over while nothing was blocked, and several sessions unblocking together still
+  make one notification.
+
 ## [0.1.6] - 2026-07-30
 
 ### Added
@@ -495,7 +550,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.7
 [0.1.6]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.6
 [0.1.5]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.5
 [0.1.4]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.4

--- a/README.md
+++ b/README.md
@@ -244,13 +244,19 @@ those two change what your day looks like:
   next-step buttons, in a window that follows each OS's own chrome conventions
   (native traffic lights on macOS, frameless with our own – □ ✕ elsewhere).
 - 📱 **Phone UI** — `mindflock serve tailscale` prints a QR code; the mobile
-  UI at `/m` carries the same guided git action bar, so the full flow drives
-  from a phone. Auth-token protected — never open to the LAN unauthenticated.
+  UI at `/m` carries the same guided git action bar **and a Diff tab**, so you
+  can read the work before approving it and drive the full flow from a phone.
+  Auth-token protected — never open to the LAN unauthenticated.
 - 🔔 **Notifications where you actually are** — desktop popups while a tab is
   open, and optional **[ntfy](https://ntfy.sh) push to your phone** sent by the
   server, so "session needs your input" or "pre-commit blocked the commit"
   reaches you with MindFlock closed. Off by default; one rule list picks which
-  events notify you, and you can point it at your own ntfy instance.
+  events notify you, and you can point it at your own ntfy instance. Each push
+  carries your tailnet phone URL, deep-linked to the session it's about.
+- ⏳ **Usage limits ride themselves out** — when an agent runs out of tokens it
+  parks on its CLI's limit screen and would sit there long after the window
+  reopens. MindFlock notices, tells you, and picks the work back up the moment
+  usage returns — queued prompt or not — then tells you that too.
 - 🌳 **Isolated workspaces** — every session gets its own git worktree, so
   agents never step on each other (or on you).
 - ⚡ **Terminal-first, too** — the `mindflock` CLI drives the same sessions as
@@ -566,7 +572,8 @@ directory (`.mindflock-pipeline.lock`); a second copy exits cleanly.
 
 Settings → **Notifications** holds one rule list — *What triggers a
 notification* (needs-input, PR merged/closed, budget exceeded, pre-commit
-failed, plus quieter opt-ins) — and two channels it feeds:
+failed, out of usage / usage back, plus quieter opt-ins) — and two channels it
+feeds:
 
 - **Browser / desktop** popups, which need a tab open on a secure origin
   (HTTPS or localhost).
@@ -577,8 +584,17 @@ failed, plus quieter opt-ins) — and two channels it feeds:
 To set it up: install the free ntfy app, then in Settings → Notifications →
 **Phone push (ntfy)** hit **Generate** for a random topic, scan the QR into the
 app, and **Send a test**. Point **Server** at your own ntfy instance to keep
-session titles off the public one, and set *Tapping opens* to your phone URL
-from Settings → Mobile so a tap lands in the mobile UI.
+session titles off the public one.
+
+**Every push carries your phone URL.** When Tailscale is up, MindFlock appends
+its tailnet `/m` address to each notification and makes it the tap target —
+deep-linked to the session the alert is about, so "alpha needs your input"
+opens the mobile UI already showing alpha. You also get one push with that URL
+whenever it becomes newly reachable: at server start, when you switch the ntfy
+channel on, and when you turn on tailscale mode. The access token is never
+included (it would be stored on the ntfy server) — a device that has not
+scanned the QR before lands on the sign-in page, which the message says.
+*Tapping opens* stays available for pointing pushes somewhere else entirely.
 
 > On the public `ntfy.sh` server **the topic name is the credential** — anyone
 > who knows it can read your session titles or send you fakes. Keep the

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -521,6 +521,14 @@ class GeneralSettings:
     web server start the pipeline on boot, so a reboot restores the toggle
     to where the user left it; ``None`` (never toggled) / ``False`` = stay
     stopped.
+
+    ``resume_on_usage_reset``: whether a session parked on a usage-limit screen
+    is nudged to carry on once the window reopens. The prompt queue has always
+    done this for sessions with something queued (``wait_for_limit``); this
+    extends it to sessions that ran out mid-task with an empty queue, which
+    otherwise sit on the limit screen until a human comes back. ``None``
+    (never set) reads as ON — the whole point of the limit gate is that running
+    out is temporary. ``False`` turns it off.
     """
 
     session_budget_usd: Optional[float] = None
@@ -531,6 +539,7 @@ class GeneralSettings:
     remote_control: str = ""  # "" / "off" | "on"
     serve_mode: str = ""  # "" / "local" | "tailscale"
     ingestion_autostart: Optional[bool] = None
+    resume_on_usage_reset: Optional[bool] = None  # None = on (see docstring)
 
     def to_dict(self) -> dict:
         d: dict = {}
@@ -550,6 +559,8 @@ class GeneralSettings:
             d["serve_mode"] = self.serve_mode
         if self.ingestion_autostart is not None:
             d["ingestion_autostart"] = self.ingestion_autostart
+        if self.resume_on_usage_reset is not None:
+            d["resume_on_usage_reset"] = self.resume_on_usage_reset
         return d
 
     @classmethod
@@ -563,6 +574,7 @@ class GeneralSettings:
             remote_control=str(d.get("remote_control", "") or "").strip().lower(),
             serve_mode=str(d.get("serve_mode", "") or "").strip().lower(),
             ingestion_autostart=_opt_bool(d.get("ingestion_autostart")),
+            resume_on_usage_reset=_opt_bool(d.get("resume_on_usage_reset")),
         )
 
 

--- a/backend/web/addons/notify.py
+++ b/backend/web/addons/notify.py
@@ -35,7 +35,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from backend.config import settings as settings_store
-from backend.web.core import mobile_access, ntfy
+from backend.web.core import mobile_access, mobile_announce, ntfy
 
 from .base import SECRET_MASK, Addon, AppContext, FrontendDescriptor
 
@@ -90,6 +90,38 @@ NOTIFY_RULES: List[dict] = [
         "default_enabled": True,
         "priority": 4,
         "tags": ["moneybag"],
+    },
+    {
+        # Roadmap D: the agent ran out of usage and is parked on its CLI's
+        # limit screen. Actionable in the "stop waiting for this one" sense —
+        # nothing will move until the provider's window resets, and MindFlock
+        # picks it back up on its own when it does.
+        "id": "usage_limit",
+        "label": "A session runs out of usage",
+        "event": "session.activity_changed",
+        "old": None,
+        "new": "limit",
+        "title": "{session} ran out of usage",
+        "body": "The agent hit its usage limit. MindFlock resumes it when the window resets.",
+        "default_enabled": True,
+        "priority": 3,
+        "tags": ["hourglass"],
+    },
+    {
+        # The other end of the same story. Emitted once per reopening by the
+        # drain-loop watcher (server._watch_one_limited), which only ever looks
+        # at sessions that had run out — so this cannot fire on a window that
+        # merely rolled over while everything was fine.
+        "id": "usage_restored",
+        "label": "Usage comes back after running out",
+        "event": "session.usage_restored",
+        "old": None,
+        "new": None,
+        "title": "Usage is back",
+        "body": "The provider's window reset — {session} can run again.",
+        "default_enabled": True,
+        "priority": 3,
+        "tags": ["arrows_counterclockwise"],
     },
     {
         # Opt-in (noisy): fires whenever a session finishes its turn and goes
@@ -269,12 +301,25 @@ class NotifyAddon(Addon):
                     if now - self._last_push.get(key, 0.0) < _DEDUPE_SECONDS:
                         continue
                     self._last_push[key] = now
+                # Tap the notification -> the mobile view, already on the
+                # session it is about. Cached, never probed here: this runs on
+                # the emitting thread. Empty when there's no tailnet — and then
+                # publish() falls back to the user's own configured click URL.
+                click = mobile_announce.click_for(str(envelope.get("session") or ""))
+                message = _fill(rule.get("body", ""), envelope)
+                if click:
+                    # Also in the text: a notification you have to go find the
+                    # server for is a notification that made you get up. The
+                    # click action covers most clients; the line covers the rest
+                    # (and a phone that shows the push without acting on it).
+                    message += "\n" + click
                 ntfy.publish_soon(
                     cfg,
                     title=_fill(rule.get("title", ""), envelope),
-                    message=_fill(rule.get("body", ""), envelope),
+                    message=message,
                     priority=rule.get("priority"),
                     tags=rule.get("tags"),
+                    click=click or None,
                 )
         except Exception as err:  # noqa: BLE001 — a push never breaks an emit
             ntfy.log_error(
@@ -407,6 +452,10 @@ class NotifyAddon(Addon):
 
             if patch:
                 settings_store.update_settings(notifications=patch)
+            # Channel just came on: the first thing worth pushing to a phone
+            # that has never heard from this machine is how to reach it.
+            if patch.get("ntfy_enabled") and not stored.ntfy_enabled:
+                mobile_announce.announce_soon(mobile_announce.REASON_NTFY)
             view = _ntfy_view()
             if note:
                 view["note"] = note
@@ -443,15 +492,25 @@ class NotifyAddon(Addon):
                 token=token,
                 click_url=click,
             )
+            # The test push is the first one anyone sees, so it shows what the
+            # real ones will: the phone URL, tappable. Probed here (an async
+            # route can afford it) rather than read from the cache — this is
+            # also where a first-run install *fills* that cache.
+            phone_url, _live = await asyncio.to_thread(mobile_access.tailnet_url)
+            mobile_announce.remember_url(phone_url)
+            message = (
+                "Push notifications are working — this is where session "
+                "alerts will land."
+            )
+            if phone_url:
+                message += "\n" + phone_url
             ok, error = await ntfy.publish(
                 cfg,
                 title="MindFlock is connected",
-                message=(
-                    "Push notifications are working — this is where session "
-                    "alerts will land."
-                ),
+                message=message,
                 priority=3,
                 tags=["bell"],
+                click=phone_url or None,
                 budgeted=False,
             )
             return JSONResponse({"ok": ok, "error": error})

--- a/backend/web/addons/settings.py
+++ b/backend/web/addons/settings.py
@@ -27,6 +27,7 @@ from fastapi.responses import JSONResponse
 from backend import doctor, providers
 from backend.config import settings as settings_store
 from backend.providers import config as provider_config
+from backend.web.core import mobile_announce, restart
 
 from .base import SECRET_MASK, Addon, AppContext, FrontendDescriptor
 
@@ -457,6 +458,20 @@ class SettingsAddon(Addon):
                 "enabled" in gh_in or "issues_enabled" in gh_in
             )
             before = _toggle_states() if watch_toggle else None
+
+            # Settings → Mobile's tailscale-mode switch (general.serve_mode).
+            # Turning it ON is the moment a phone URL starts to exist, so it is
+            # also the moment worth pushing that URL to the phone.
+            def _serve_mode() -> str:
+                return (
+                    (settings_store.load_settings().general.serve_mode or "")
+                    .strip()
+                    .lower()
+                )
+
+            gen_in = payload.get("general")
+            watch_serve = isinstance(gen_in, dict) and "serve_mode" in gen_in
+            serve_before = _serve_mode() if watch_serve else None
             try:
                 _apply_post(payload)
             except Exception as err:  # noqa: BLE001
@@ -467,7 +482,30 @@ class SettingsAddon(Addon):
                         self.ctx.emit("settings.github_toggled")
                     except Exception:  # noqa: BLE001 — never let the bus break a save
                         pass
-            return JSONResponse({"settings": _masked_view()})
+
+            view = {"settings": _masked_view()}
+            if (
+                watch_serve
+                and serve_before != "tailscale"
+                and _serve_mode() == "tailscale"
+            ):
+                # A hand-flipped toggle is a fresh intent — it gets the full
+                # retry budget back even if an earlier one was spent giving up.
+                restart.reset_tailscale_attempts()
+                if restart.auto_restart_for_tailscale(delay=0.5):
+                    # Which bind uvicorn holds is fixed at boot, so the toggle
+                    # only means something after a restart — take it here rather
+                    # than leaving the user a button to press. `restarting` tells
+                    # the client to wait for the server to come back instead of
+                    # reporting the dropped connection as a failure.
+                    view["restarting"] = True
+                else:
+                    # Already listening on the tailnet (or we've given up
+                    # restarting): the URL is as live as it is going to get, so
+                    # push it now. When a restart IS coming, the fresh process
+                    # announces instead — it can say the URL works.
+                    mobile_announce.announce_soon(mobile_announce.REASON_MOBILE)
+            return JSONResponse(view)
 
         # --- account-attach validation (C5): "Test" buttons ----------------- #
         @router.post("/settings/test/shortcut")

--- a/backend/web/core/events.py
+++ b/backend/web/core/events.py
@@ -57,6 +57,12 @@ EVENT_NAMES = (
     # "loop": bool}).
     "session.prompt_sent",
     "session.queue_changed",
+    # Usage limits (roadmap D): the provider's window reopened for a session
+    # that had run out — emitted once per reopening, by the drain-loop watcher
+    # that also nudges such a session to carry on (data: {"resumed": bool}).
+    # Running OUT needs no event of its own: that is
+    # ``session.activity_changed`` with ``new == "limit"``.
+    "session.usage_restored",
 )
 
 _HISTORY = 100  # envelopes kept for ?since= replay

--- a/backend/web/core/mobile_access.py
+++ b/backend/web/core/mobile_access.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Optional, Tuple
 
 from backend.web.core import auth as _auth
 
@@ -103,6 +104,35 @@ def _tailscale_serves_port(port: int) -> bool:
     return any(
         s in out for s in (":%d" % port, "localhost:%d" % port, "127.0.0.1:%d" % port)
     )
+
+
+def tailnet_url() -> Tuple[Optional[str], bool]:
+    """``(the phone URL for this machine, whether it works right now)``.
+
+    The same "best URL a phone on the tailnet can reach" the banner and the
+    Settings → Mobile QR advertise — but deliberately **without** ``?token=``:
+    this one is handed to a third party (the ntfy push in
+    :mod:`backend.web.core.mobile_announce`), and the access token is not
+    theirs to store. Same call ``ntfy.strip_token_param`` makes for the
+    tap-to-open URL.
+
+    ``(None, False)`` when Tailscale isn't up — there is no phone URL to give,
+    and inventing one would just be wrong. The second element is False when the
+    URL is *right but not live yet*: uvicorn is still bound to 127.0.0.1
+    (``mindflock serve local``), so the tailnet address only starts answering
+    after a restart in tailscale mode.
+    """
+    srv = _server()
+    port = srv._server_port()
+    name, ip = srv._tailscale_info()
+    if name and srv._tailscale_serves_port(port):
+        # `tailscale serve` fronts localhost with HTTPS, so this URL works even
+        # while uvicorn stays bound to 127.0.0.1 — local mode is not a caveat.
+        return "https://%s/m" % name, True
+    host = name or ip
+    if not host:
+        return None, False
+    return "http://%s:%d/m" % (host, port), not srv._local_only_mode()
 
 
 def _qr_lines(data: str):

--- a/backend/web/core/mobile_announce.py
+++ b/backend/web/core/mobile_announce.py
@@ -1,0 +1,217 @@
+"""Push the phone URL to ntfy whenever this machine becomes reachable.
+
+The ntfy channel (:mod:`backend.web.core.ntfy`) exists so a session alert
+reaches you with nothing open. This module closes the other half of that loop:
+the phone also has to know *where* MindFlock is. Whenever both halves come
+alive — Tailscale is up AND ntfy is configured — one push carries the tailnet
+``/m`` URL, so opening the mobile view is a tap on a notification instead of a
+QR scan at the desk. Three moments qualify, and they are exactly the three that
+change the answer:
+
+* the server starts (:data:`REASON_STARTUP` — from the startup warmups, next to
+  the banner that prints the same URL to the console),
+* the ntfy channel is switched on (:data:`REASON_NTFY` — before that there was
+  nowhere to push it),
+* Settings → Mobile turns on tailscale mode (:data:`REASON_MOBILE` — before
+  that the URL was not going to work).
+
+The same URL then rides along on *every* push: :func:`click_for` hands the
+notify addon a cached, session-deep-linked copy for each session alert, so any
+notification is one tap from the thing it is about. Cached because that path
+runs on the event-bus thread, where a ``tailscale status`` shell-out has no
+business being.
+
+Deliberately *not* in any of it: the access token. These messages travel to —
+and are stored on — a third-party ntfy server, so the URL goes bare, the same
+call :func:`ntfy.strip_token_param` makes for the tap-to-open URL. The phone
+signs in once with the token from Settings → Security and keeps the cookie.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import urllib.parse
+from typing import Optional, Tuple
+
+from backend.web.core import auth as _auth
+from backend.web.core import mobile_access, ntfy
+
+#: Why we're announcing → the opening line of the push. Each is the answer to
+#: "why is my phone buzzing", which is the only thing the reason has to carry.
+REASON_STARTUP = "startup"
+REASON_NTFY = "ntfy"
+REASON_MOBILE = "mobile"
+
+_LINES = {
+    REASON_STARTUP: "MindFlock just started.",
+    REASON_NTFY: "Phone push is on.",
+    REASON_MOBILE: "Tailscale mode is on.",
+}
+
+#: Don't say the same thing twice inside this window. Turning on ntfy and
+#: tailscale mode back to back is one intent, not two notifications — and a
+#: server that restart-loops shouldn't narrate every attempt. Keyed by
+#: ``(url, live)`` so a URL that becomes *live* still announces: that is the
+#: push the user is actually waiting for after "restart to apply".
+_DEDUPE_SECONDS = 120.0
+
+_LOCK = threading.Lock()
+_SEEN: dict = {}  # (url, live) -> monotonic ts of the last push
+
+
+def _should_send(key: Tuple[str, bool]) -> bool:
+    """Consume the dedupe slot for ``key`` (False = we just said this)."""
+    now = time.monotonic()
+    with _LOCK:
+        for k, ts in list(_SEEN.items()):
+            if now - ts > _DEDUPE_SECONDS:
+                del _SEEN[k]
+        if key in _SEEN:
+            return False
+        _SEEN[key] = now
+        return True
+
+
+# --------------------------------------------------------------------------- #
+# The cached URL every push taps through to
+# --------------------------------------------------------------------------- #
+#: How long a probed URL is trusted before a refresh is started. A tailnet name
+#: changes about never; the point of re-probing at all is noticing that
+#: Tailscale came up (or went away) since the last push.
+_CACHE_TTL = 300.0
+
+_CACHE_LOCK = threading.Lock()
+_CACHED_URL: Optional[str] = None
+_CACHED_AT = 0.0  # monotonic; 0.0 = never probed
+_REFRESHING = False
+
+
+def remember_url(url: Optional[str]) -> None:
+    """Record a freshly probed phone URL (or its absence) for :func:`click_for`.
+
+    Public because probing is expensive and a couple of callers do it for their
+    own reasons — the startup announce, the "Send a test" button — and their
+    answer is exactly as good as one this module paid for itself.
+    """
+    global _CACHED_URL, _CACHED_AT
+    with _CACHE_LOCK:
+        _CACHED_URL = url
+        _CACHED_AT = time.monotonic()
+
+
+def _refresh_cache_soon() -> None:
+    """Probe for the phone URL on a thread of our own, at most one at a time.
+
+    Never on the caller's thread: the only caller is :func:`click_for`, which
+    runs inside an event-bus emit — the same critical path ``publish_soon``
+    exists to stay off. ``tailscale status`` can take seconds.
+    """
+    global _REFRESHING
+    with _CACHE_LOCK:
+        if _REFRESHING:
+            return
+        _REFRESHING = True
+
+    def _run() -> None:
+        global _REFRESHING
+        try:
+            url, _live = mobile_access.tailnet_url()
+            remember_url(url)
+        except Exception:  # noqa: BLE001 — a stale cache beats a crashed thread
+            pass
+        finally:
+            with _CACHE_LOCK:
+                _REFRESHING = False
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def click_for(session: str = "") -> str:
+    """The tap-target for a push: this machine's phone URL, deep-linked to
+    ``session`` — or ``""`` when we don't know it.
+
+    Every notification is about something you'd want to *look* at, and a phone
+    notification that leaves you hunting for the URL wastes the trip. So each
+    push carries this as its ``click``: tapping "alpha needs your input" opens
+    the mobile view already showing alpha (``/m?s=…`` — the same query param
+    mobile.js honours when picking the session).
+
+    Reads the cache only — never probes on the caller's thread, which is
+    whatever thread emitted the event. A stale (or missing) answer starts a
+    background refresh and returns what it has, so at worst the *first* push
+    after Tailscale comes up has no link and the next one does.
+    """
+    with _CACHE_LOCK:
+        url, at = _CACHED_URL, _CACHED_AT
+    if at == 0.0 or time.monotonic() - at > _CACHE_TTL:
+        _refresh_cache_soon()
+    if not url:
+        return ""
+    if not session:
+        return url
+    sep = "&" if "?" in url else "?"
+    return "%s%ss=%s" % (url, sep, urllib.parse.quote(session, safe=""))
+
+
+def _auth_on() -> bool:
+    """Whether the phone will meet a sign-in page (advisory, never raises)."""
+    try:
+        return bool(_auth.auth_enabled())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def announce(reason: str) -> bool:
+    """Push the tailnet phone URL, if there is one and anyone to push it to.
+
+    Returns whether a push was actually sent — False is the ordinary case (no
+    Tailscale, no ntfy, or we just said this), not an error. Never raises: this
+    runs inside a startup hook and two settings saves, none of which should fail
+    because a notification didn't go out.
+    """
+    try:
+        cfg = ntfy.load()
+        if not cfg.active:
+            return False
+        # Both probes shell out to `tailscale` with a timeout — off the loop.
+        url, live = await asyncio.to_thread(mobile_access.tailnet_url)
+        # We probed anyway; every later push taps through to this (click_for).
+        remember_url(url)
+        if not url:
+            return False
+        if not _should_send((url, live)):
+            return False
+        lines = [_LINES.get(reason, _LINES[REASON_STARTUP]), url]
+        if not live:
+            lines.append("(restart the server to apply tailscale mode)")
+        if _auth_on():
+            lines.append("Sign in with the access token from Settings → Security.")
+        ok, _err = await ntfy.publish(
+            cfg,
+            title="MindFlock on your phone",
+            message="\n".join(lines),
+            priority=3,
+            tags=["iphone"],
+            # Tap the notification -> the mobile view. Overrides the user's
+            # configured click URL for this one push: this notification IS the
+            # URL, so opening anything else would be a bug.
+            click=url,
+        )
+        return ok
+    except asyncio.CancelledError:  # shutdown — not a delivery failure
+        raise
+    except Exception as err:  # noqa: BLE001 — never break the caller
+        ntfy.log_error("mobile URL announce failed: %s", err)
+        return False
+
+
+def announce_soon(reason: str) -> None:
+    """Fire-and-forget :func:`announce` from a sync caller.
+
+    The settings routes are plain ``def`` handlers on a worker thread, so they
+    can neither await this nor afford to wait for it (the Tailscale probe alone
+    can take seconds). Same trampoline the ntfy channel uses for pushes.
+    """
+    ntfy.dispatch(announce(reason))

--- a/backend/web/core/ntfy.py
+++ b/backend/web/core/ntfy.py
@@ -406,6 +406,7 @@ def publish_soon(
     message: str,
     priority: Optional[int] = None,
     tags: Optional[List[str]] = None,
+    click: Optional[str] = None,
 ) -> None:
     """Fire-and-forget :func:`publish` from any thread.
 
@@ -414,7 +415,26 @@ def publish_soon(
     loop at all — a bare sync context such as a unit test — a throwaway thread
     with its own), exactly like ``EventBus._dispatch_hooks``.
     """
-    coro = publish(cfg, title=title, message=message, priority=priority, tags=tags)
+    dispatch(
+        publish(
+            cfg,
+            title=title,
+            message=message,
+            priority=priority,
+            tags=tags,
+            click=click,
+        )
+    )
+
+
+def dispatch(coro) -> None:
+    """Run a push coroutine on the server loop from any thread, and never raise.
+
+    The trampoline behind :func:`publish_soon` — split out because it is also
+    what :mod:`backend.web.core.mobile_announce` needs: a sync caller (a
+    FastAPI route on a worker thread, a settings save) handing a whole
+    push *sequence* to the loop without waiting for it.
+    """
     try:
         try:
             running = asyncio.get_running_loop()

--- a/backend/web/core/restart.py
+++ b/backend/web/core/restart.py
@@ -1,0 +1,152 @@
+"""Re-exec the server in place, and the one case that does it by itself.
+
+``POST /api/server/restart`` (Settings → Mobile / Advanced) exists because the
+serve mode — which interface uvicorn binds — is fixed at process start, so
+flipping the Settings → Mobile toggle can only take effect on the next boot.
+Re-execing is safe: the actual work lives outside this process (agent sessions
+are tmux sessions, ingestion is its own process, state is on disk), and every
+client already retries until the server answers again.
+
+:func:`auto_restart_for_tailscale` is that same re-exec, self-service: when the
+persisted mode says *tailscale* but this process is bound to 127.0.0.1, the
+setting is simply not in effect, and the fix is entirely mechanical. So we do
+it instead of asking. The one thing it must not do is loop — a restart that
+doesn't change the outcome would restart forever — so attempts are capped at
+:data:`MAX_TAILSCALE_ATTEMPTS`, counted **in the environment**: each attempt is
+a new process image, so an in-memory counter would reset every time and never
+reach its own limit. ``execv`` keeps the environment, so the count survives
+exactly as far as the chain of restarts it is meant to bound, and a genuinely
+fresh start (or an explicit user toggle, via :func:`reset_tailscale_attempts`)
+begins from zero.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+
+from backend import log
+from backend.web.core.mobile_access import _local_only_mode
+
+#: Mode words the launcher accepts positionally (``mindflock serve local``).
+#: Stripped from argv on re-exec so the fresh process falls through to the
+#: *persisted* general.serve_mode instead of resurrecting the mode this process
+#: happened to boot with.
+_MODE_TOKENS = ("local", "localhost", "tailscale", "ts", "all")
+
+#: How many times a boot may re-exec itself chasing tailscale mode before it
+#: gives up and stays local. Three: enough to ride out a transient failure
+#: (a port still in TIME_WAIT), few enough that a permanent one costs seconds.
+MAX_TAILSCALE_ATTEMPTS = 3
+
+#: Where the attempt count rides across ``execv``.
+_ATTEMPT_ENV = "MINDFLOCK_TAILSCALE_RESTARTS"
+
+#: Set by ``run.py`` immediately before it hands control to uvicorn — the one
+#: place that knows this process exists to *serve*. The automatic restart
+#: refuses to act without it: importing the app (a test, a tool, a REPL) must
+#: never end with that process replaced by a server.
+_SERVING = False
+
+
+def mark_serving() -> None:
+    """Declare this process the real server (called by ``run.main``)."""
+    global _SERVING
+    _SERVING = True
+
+
+def _under_pytest() -> bool:
+    """True inside a test run. ``execv`` there would replace the test runner
+    with a server — a guard worth having in front of every call, because the
+    blast radius is the whole suite rather than one failed assertion."""
+    return "pytest" in sys.modules
+
+
+def reexec_soon(delay: float = 0.5) -> None:
+    """Re-exec this process after ``delay`` seconds (never returns to caller).
+
+    The delay lets the HTTP response that asked for the restart flush to the
+    client first — without it the caller sees a dropped connection instead of
+    the ``{"ok": true}`` that tells it to start polling for the server's return.
+    """
+    if _under_pytest():
+        return
+    os.environ.pop("CS_WEB_MODE", None)
+    argv = [a for a in sys.argv if a.strip().lower() not in _MODE_TOKENS]
+
+    def _reexec() -> None:
+        time.sleep(delay)
+        os.execv(sys.executable, [sys.executable] + argv)
+
+    threading.Thread(target=_reexec, daemon=True).start()
+
+
+def reset_tailscale_attempts() -> None:
+    """Forget previous auto-restart attempts.
+
+    Called when the user turns tailscale mode on by hand: an explicit choice is
+    a fresh intent, and shouldn't inherit the budget a previous one spent.
+    """
+    os.environ.pop(_ATTEMPT_ENV, None)
+
+
+def _serve_mode_setting() -> str:
+    """The persisted Settings → Mobile mode, normalized. Never raises."""
+    try:
+        from backend.config.settings import load_settings
+
+        return (load_settings().general.serve_mode or "").strip().lower()
+    except Exception:  # noqa: BLE001 — an unreadable store means "don't act"
+        return ""
+
+
+def auto_restart_for_tailscale(delay: float = 1.0) -> bool:
+    """Re-exec when tailscale mode is on but this process is bound locally.
+
+    Returns whether a restart was scheduled — False covers every ordinary case
+    (mode already in effect, mode not requested, budget spent), so callers can
+    use it to decide whether the process has a future worth doing more work in.
+    ``delay`` is the same "let the response out first" grace :func:`reexec_soon`
+    takes; the default suits the startup path, where nobody is waiting on a
+    response but the server has just begun serving.
+
+    Only fires when we *know* the bind is local *and* that this process is the
+    server: ``_local_only_mode`` reads the mode the launcher resolved and
+    exported, and :func:`mark_serving` is set by ``run.main`` alone. Anything
+    else that merely imported the app — a test client, a script — is left
+    running rather than replaced on a guess about how it was launched.
+    """
+    if not _SERVING or _under_pytest():
+        return False
+    if _serve_mode_setting() != "tailscale" or not _local_only_mode():
+        return False
+    raw = os.environ.get(_ATTEMPT_ENV, "")
+    attempts = int(raw) if raw.isdigit() else 0
+    if attempts >= MAX_TAILSCALE_ATTEMPTS:
+        _say(
+            "Tailscale mode is on but this server is still bound to 127.0.0.1 "
+            "after %d restart attempts — staying local. Start it with "
+            "`mindflock serve tailscale` to see why." % attempts
+        )
+        return False
+    os.environ[_ATTEMPT_ENV] = str(attempts + 1)
+    _say(
+        "Tailscale mode is on but this server is bound to 127.0.0.1 — "
+        "restarting to apply it (attempt %d of %d)."
+        % (attempts + 1, MAX_TAILSCALE_ATTEMPTS)
+    )
+    reexec_soon(delay=delay)
+    return True
+
+
+def _say(msg: str) -> None:
+    """Console + log. The console is where someone watching a `serve` run finds
+    out why it just restarted itself; the log is where they find out later."""
+    print("  " + msg, flush=True)
+    if log.ErrorLog is not None:
+        try:
+            log.ErrorLog.Printf("%s", msg)
+        except Exception:  # noqa: BLE001
+            pass

--- a/backend/web/run.py
+++ b/backend/web/run.py
@@ -251,6 +251,18 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     threading.Thread(target=_fast_preflight, daemon=True).start()
 
+    # This process is now the server, and nothing else is: the only place that
+    # can honestly say so is right here, one line before uvicorn takes over.
+    # core.restart requires it before it will re-exec the process by itself
+    # (chasing a tailscale mode that isn't in effect) — importing the app must
+    # never be enough to get yourself replaced by a server.
+    try:
+        from backend.web.core import restart as _restart
+
+        _restart.mark_serving()
+    except Exception:  # noqa: BLE001 — never block the boot on a marker
+        pass
+
     # Never open a browser: the desktop app (Electron) is the client, and it
     # auto-starts/connects to this server itself. (The retired CS_WEB_OPEN
     # browser auto-open left with browser mode.)

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -238,6 +238,8 @@ from backend.web.core.engine import (
     _reload_loop,
     _sync_external_instances,
 )
+from backend.web.core import mobile_announce
+from backend.web.core import restart as _restart
 from backend.web.core.mobile_access import (
     _local_only_mode,
     _mobile_banner,
@@ -413,6 +415,13 @@ async def lifespan(app: FastAPI):
     # Tailscale banner probe alone can hang for seconds on a machine without
     # tailscale).
     async def _startup_warmups() -> None:
+        # Tailscale mode is on but this process came up bound to 127.0.0.1 (a
+        # `serve local` that predates the toggle, or a CS_WEB_MODE inherited
+        # from somewhere): the setting isn't in effect, and the fix is a
+        # restart — so take it, up to core.restart's attempt cap. Everything
+        # below would be work done by a process on its way out.
+        if await asyncio.to_thread(_restart.auto_restart_for_tailscale):
+            return
         # Apply the persisted terminal scroll speed to already-running sessions.
         try:
             await asyncio.to_thread(apply_scroll_speed)
@@ -441,6 +450,10 @@ async def lifespan(app: FastAPI):
                     pass
         except Exception:  # noqa: BLE001
             pass
+        # Same URL, second channel: if ntfy is configured and Tailscale is up,
+        # the phone gets the /m URL as a push (without the token) so reaching
+        # the mobile view doesn't require being at this console to read it.
+        await mobile_announce.announce(mobile_announce.REASON_STARTUP)
 
     _register_task(_startup_warmups())
     # Addon startup hooks (e.g. the Assistant seeds its working dir here).
@@ -1170,11 +1183,125 @@ def _drain_one_queue(title: str) -> None:
     _send_queued_item(title, name, nxt, rec, now)
 
 
+# --- Usage-limit watch: sessions parked on the limit screen with no queue --- #
+# The drain above resumes a limited session that has something QUEUED. A session
+# that simply ran out mid-task has an empty queue, so nothing was watching it —
+# it sat on the limit screen until a human came back hours later, long after the
+# window reopened. This watcher covers exactly that gap, and pays for itself:
+# the candidate list comes from the snapshot the /api/events tick already keeps
+# (a dict read), so a flock with nothing limited does no work at all.
+_LIMIT_RESUME_PROMPT = "continue"
+
+#: "Usage is back" is one fact about the account, not one per session — several
+#: sessions typically unblock in the same pass. Announce it once per window.
+_LIMIT_RESTORE_QUIET = 300.0
+_LAST_RESTORE_EMIT = 0.0
+
+
+def _resume_on_usage_reset() -> bool:
+    """Whether to nudge a limited session once its window reopens
+    (``general.resume_on_usage_reset``; unset = on). Never raises."""
+    try:
+        from backend.config import settings as _settings
+
+        return _settings.load_settings().general.resume_on_usage_reset is not False
+    except Exception:  # noqa: BLE001 — an unreadable store keeps the default
+        return True
+
+
+def _limited_titles() -> list:
+    """Sessions whose last observed activity was ``limit``, from the event
+    snapshot — free (no probes), and refreshed every ~4s by the state tick."""
+    with _EVENT_SNAPSHOT_LOCK:
+        return [
+            t for t, snap in _EVENT_SNAPSHOT.items() if snap.get("activity") == "limit"
+        ]
+
+
+def _watch_one_limited(title: str) -> None:
+    """One usage-limit decision for a session sitting on the limit screen.
+
+    Runs only while the session's *observed* activity is ``limit``, so the pane
+    capture in :func:`_refresh_limit_state` happens for genuinely stuck sessions
+    only. Never raises."""
+    global _LAST_RESTORE_EMIT
+    st = _prompt_queue.get_state(title)
+    if st["enabled"] and st["items"]:
+        return  # the drain owns this one — it has a prompt to send on reopening
+    inst = ENGINE.instances.get(title)
+    if inst is None:
+        return
+    try:
+        if not inst.Started() or inst.Status == session.Paused:
+            return
+    except Exception:  # noqa: BLE001
+        return
+    name, err = _ensure_agent_session(inst, title)
+    if err is not None:
+        return
+    now = time.time()
+    if _refresh_limit_state(inst, title, name) > now:
+        return  # still limited — the UI shows the countdown
+    # The window reopened. Reuse the drain's per-session send bookkeeping so the
+    # nudge obeys the same "once, then wait to see it picked up" rule: an Esc +
+    # prompt that doesn't take (a menu that needs a second key, a meter that
+    # lags the real reset) retries after _QUEUE_REARM_IDLE instead of every 5s.
+    rec = _QUEUE_STATE.setdefault(
+        title,
+        {"armed": True, "sent_at": 0.0, "rebooted_at": 0.0, "idle_since": None},
+    )
+    if (
+        not rec.get("armed", True)
+        and now - rec.get("sent_at", 0.0) >= _QUEUE_REARM_IDLE
+    ):
+        rec["armed"] = True
+    if (
+        not rec.get("armed", True)
+        or now - rec.get("sent_at", 0.0) < _QUEUE_SEND_COOLDOWN
+    ):
+        return
+    resume = _resume_on_usage_reset()
+    if resume:
+        _send_escape_to_agent(name)  # drop the lingering limit menu
+        time.sleep(0.15)  # let the CLI redraw its prompt before we type
+        if _send_to_agent(name, _LIMIT_RESUME_PROMPT, submit=True):
+            rec["armed"] = False
+            rec["sent_at"] = now
+            if log.ErrorLog is not None:
+                try:
+                    log.ErrorLog.Printf(
+                        "[MONITORING] usage window reopened — resumed %s", title
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+        else:
+            return  # tmux gone: no resume, and no "usage is back" to announce
+    # Announce the reopening whether or not we acted on it — "your usage is
+    # back" is worth knowing even with auto-resume off, and it can only fire for
+    # a session that had actually run out (that is what put it on this list).
+    if now - _LAST_RESTORE_EMIT >= _LIMIT_RESTORE_QUIET:
+        _LAST_RESTORE_EMIT = now
+        _events.BUS.emit(
+            "session.usage_restored", session=title, data={"resumed": resume}
+        )
+
+
+def _watch_limited_sessions() -> None:
+    """One pass over every session parked on a usage-limit screen."""
+    for title in _limited_titles():
+        try:
+            _watch_one_limited(title)
+        except Exception:  # noqa: BLE001 — one bad session can't stop the pass
+            pass
+
+
 def _drain_prompt_queues() -> None:
-    """One pass over every session with a queue. Runs in a worker thread (it
-    shells out to tmux) so it never blocks the event loop."""
+    """One pass over every session with a queue, plus every session parked on a
+    usage-limit screen. Runs in a worker thread (it shells out to tmux) so it
+    never blocks the event loop."""
     titles = _prompt_queue.all_titles()
     if not titles:
+        _watch_limited_sessions()
         return
     _prompt_queue.prune(list(ENGINE.instances.keys()))
     _ports.prune(list(ENGINE.instances.keys()))
@@ -1183,6 +1310,7 @@ def _drain_prompt_queues() -> None:
             _drain_one_queue(title)
         except Exception:  # noqa: BLE001 — one bad session can't stop the drain
             pass
+    _watch_limited_sessions()
     # Forget in-memory drain state for sessions that vanished.
     for gone in [t for t in _QUEUE_STATE if t not in ENGINE.instances]:
         _QUEUE_STATE.pop(gone, None)
@@ -1674,18 +1802,10 @@ def post_server_restart() -> JSONResponse:
     so the fresh process falls through to the *persisted* general.serve_mode
     instead of resurrecting the mode this process happened to boot with.
     """
-    os.environ.pop("CS_WEB_MODE", None)
-    argv = [
-        a
-        for a in sys.argv
-        if a.strip().lower() not in ("local", "localhost", "tailscale", "ts", "all")
-    ]
-
-    def _reexec() -> None:
-        time.sleep(0.5)  # let the HTTP response flush to the client first
-        os.execv(sys.executable, [sys.executable] + argv)
-
-    threading.Thread(target=_reexec, daemon=True).start()
+    # An explicit restart is a fresh intent: whatever the automatic
+    # tailscale-mode retries (core.restart) already spent, this one starts over.
+    _restart.reset_tailscale_attempts()
+    _restart.reexec_soon()
     return JSONResponse({"ok": True, "restarting": True})
 
 

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29195,9 +29195,35 @@ function General(_) {
         ]
       }
     ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(ResumeOnUsageResetRow, {}),
     /* @__PURE__ */ jsxRuntimeExports.jsx(ScrollSpeedRow, {}),
     /* @__PURE__ */ jsxRuntimeExports.jsx(ReduceMotionRow, {}),
     /* @__PURE__ */ jsxRuntimeExports.jsx(GettingStarted, {})
+  ] });
+}
+function ResumeOnUsageResetRow() {
+  const s = useSettings();
+  const stored = s.get("general", "resume_on_usage_reset");
+  const on = stored !== false && stored !== "false" && stored !== "0";
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row set-switch-row", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "notif-rule-text", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Resume sessions when usage comes back" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint notif-rule-desc", children: "When an agent runs out of usage it parks on its CLI's limit screen and stays there — even after the window resets. With this on, MindFlock watches those sessions and tells them to continue the moment usage returns, the same way the prompt queue already resumes sessions that have something queued. You get a notification either way (Settings → Notifications)." })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "checkbox",
+          checked: on,
+          onChange: (e) => {
+            s.saveField("general", "resume_on_usage_reset", e.target.checked);
+            toast(e.target.checked ? "Auto-resume on" : "Auto-resume off");
+          }
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
+    ] })
   ] });
 }
 function GettingStarted() {
@@ -29349,7 +29375,7 @@ function useServerRestart() {
     if (timer.current) clearInterval(timer.current);
     setRestarting(true);
     setTimedOut(false);
-    api("/api/server/restart", { method: "POST" }).catch(() => {
+    if (!(opts == null ? void 0 : opts.alreadyRequested)) api("/api/server/restart", { method: "POST" }).catch(() => {
     });
     const t0 = Date.now();
     const finish = (didTimeOut) => {
@@ -29398,12 +29424,17 @@ function Mobile(_) {
   }, [load2]);
   const setMode = async (on) => {
     setModeBusy(true);
+    let restarting2 = false;
     try {
-      await api("/api/settings", { json: { general: { serve_mode: on ? "tailscale" : "local" } } });
+      const res = await api("/api/settings", {
+        json: { general: { serve_mode: on ? "tailscale" : "local" } }
+      });
+      restarting2 = !!(res == null ? void 0 : res.restarting);
     } catch {
     }
     setModeBusy(false);
-    load2();
+    if (restarting2) restart({ alreadyRequested: true, onBack: load2 });
+    else load2();
   };
   const onRestart = () => restart({ onBack: load2 });
   const pending = !!((data == null ? void 0 : data.serve_mode) && data.serve_mode === "tailscale" === !!data.local_only);

--- a/backend/web/static/mobile.css
+++ b/backend/web/static/mobile.css
@@ -218,6 +218,85 @@ html, body {
 .xterm .xterm-viewport { scrollbar-width: none; }
 .xterm .xterm-viewport::-webkit-scrollbar { width: 0; height: 0; display: none; }
 
+/* --- diff panel (Diff tab): fills the same space as the terminal --- */
+#diff-wrap {
+  position: relative;   /* anchors #status when the toast moves in here */
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+#diff-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+.diff-btn {
+  flex: 0 0 auto;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 7px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  user-select: none;
+}
+.diff-btn:active { background: var(--border); }
+#diff-stat {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#diff-stat .add { color: #4ade80; }
+#diff-stat .del { color: #f87171; }
+/* The one scroller on this page: vertical for the diff, horizontal for long
+   lines (which are not wrapped — a wrapped diff line loses its shape). */
+#diff-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 6px 0 24px 0;
+}
+#diff-body .dl {
+  white-space: pre;
+  padding: 0 10px;
+  min-width: 100%;
+  width: max-content;
+}
+#diff-body .add { background: rgba(74, 222, 128, 0.12); color: #86efac; }
+#diff-body .del { background: rgba(248, 113, 113, 0.12); color: #fca5a5; }
+#diff-body .hunk { color: #38bdf8; }
+#diff-body .note { color: var(--muted); padding: 10px; white-space: normal; }
+/* File headers stick to the top while you scroll that file's hunks — on a
+   phone the filename otherwise scrolls away long before the hunks do. */
+#diff-body .file {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--panel-2);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-size: 12px;
+  padding: 7px 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 #empty, #status {
   position: absolute;
   left: 0; right: 0;

--- a/backend/web/static/mobile.html
+++ b/backend/web/static/mobile.html
@@ -28,6 +28,9 @@
       <div id="tabs">
         <button type="button" class="tab active" data-tab="agent">Agent</button>
         <button type="button" class="tab" data-tab="shell">Shell</button>
+        <!-- Read the work before you approve it: the same diff the desktop
+             pane's Diff tab shows, unified and colorized for a narrow screen. -->
+        <button type="button" class="tab" data-tab="diff">Diff</button>
       </div>
     </header>
 
@@ -46,6 +49,18 @@
       <div id="term"></div>
       <div id="empty" class="hidden">No sessions yet. Create one from the desktop view.</div>
       <div id="status" class="hidden"></div>
+    </div>
+
+    <!-- Diff panel: takes the terminal's place under the Diff tab (the PTY
+         stays connected behind it, so switching back is instant). Unified only
+         — a split view needs width a phone doesn't have. -->
+    <div id="diff-wrap" class="hidden">
+      <div id="diff-head">
+        <button type="button" id="diff-base" class="diff-btn">All changes</button>
+        <span id="diff-stat"></span>
+        <button type="button" id="diff-refresh" class="diff-btn">Refresh</button>
+      </div>
+      <div id="diff-body"></div>
     </div>
 
     <!-- Native compose box: type/paste/autocorrect like any phone text field,

--- a/backend/web/static/mobile.js
+++ b/backend/web/static/mobile.js
@@ -35,6 +35,7 @@
 
   var pickerEl = document.getElementById("picker");
   var dotEl = document.getElementById("dot");
+  var termWrap = document.getElementById("term-wrap");
   var termHost = document.getElementById("term");
   var emptyEl = document.getElementById("empty");
   var statusEl = document.getElementById("status");
@@ -42,12 +43,21 @@
   var actionsEl = document.getElementById("actions");
   var commitSheet = document.getElementById("commit-sheet");
   var commitText = document.getElementById("commit-text");
+  var diffWrap = document.getElementById("diff-wrap");
+  var diffBody = document.getElementById("diff-body");
+  var diffStat = document.getElementById("diff-stat");
+  var diffBaseBtn = document.getElementById("diff-base");
 
   var term = null;
   var fit = null;
   var ws = null;
   var closedByUs = false;       // true when we intentionally tear down a ws
   var current = null;           // selected session title
+  // Two different "which tab": `view` is what the screen shows (the Diff panel
+  // is a view with no PTY behind it), `tab` is which tmux session the terminal
+  // is attached to. Splitting them is what lets Diff overlay the terminal
+  // without tearing the websocket down and rebuilding it on the way back.
+  var view = "agent";           // "agent" | "shell" | "diff"
   var tab = "agent";            // "agent" | "shell"
   var ctrlActive = false;       // sticky Ctrl modifier
   var instances = [];
@@ -155,20 +165,39 @@
     fitSoon();
     connect();
     updateActions();
+    if (view === "diff") loadDiff();
   }
 
   function switchTab(next) {
-    if (next === tab) return;
-    tab = next;
+    if (next === view) return;
+    view = next;
     document.querySelectorAll(".tab").forEach(function (b) {
       b.classList.toggle("active", b.dataset.tab === next);
     });
+    // The Diff panel takes the terminal's place; the compose box and key bar go
+    // with it (there is nothing to type at) but the git action bar stays — the
+    // whole point of reading the diff on a phone is deciding whether to push it.
+    var isDiff = next === "diff";
+    diffWrap.classList.toggle("hidden", !isDiff);
+    termWrap.classList.toggle("hidden", isDiff);
+    document.getElementById("composer").classList.toggle("hidden", isDiff);
+    document.getElementById("keys").classList.toggle("hidden", isDiff);
+    if (isDiff) { loadDiff(); return; }
+    // Coming back from Diff to the PTY the terminal is already attached to:
+    // nothing to rebuild, just re-fit into the space it got back.
+    if (next === tab) { fitSoon(); return; }
+    tab = next;
     // Rebuild the terminal against the other tmux session of the same instance.
     var t = current; current = null; select(t);
   }
 
   function setStatus(msg) {
     if (!msg) { statusEl.classList.add("hidden"); statusEl.textContent = ""; return; }
+    // The toast lives inside whichever panel is on screen — parked in the
+    // terminal wrap it would be display:none along with it under the Diff tab,
+    // which is exactly where "pushed" / "merge failed" needs to be readable.
+    var host = view === "diff" ? diffWrap : termWrap;
+    if (statusEl.parentNode !== host) host.appendChild(statusEl);
     statusEl.textContent = msg;
     statusEl.classList.remove("hidden");
   }
@@ -372,6 +401,119 @@
       .then(function () { flashStatus("commit started — watch the shell"); setTimeout(poll, 800); })
       .catch(function (err) { flashStatus("commit failed: " + err.message); });
   }
+
+  // --- diff panel ------------------------------------------------------------
+  // The desktop Diff tab, narrowed to what a phone can show: unified only (a
+  // split view needs width that isn't there) and colorized the same way
+  // (lib/diff.ts parseUnifiedDiff — "@@" cyan, "+" green, "-" red). Same
+  // endpoint and same two baselines the desktop offers, so the numbers here
+  // match the badge over there:
+  //   base=fork  everything vs the branch's fork point (committed + not)
+  //   base=head  uncommitted only
+  var DIFF_MAX_LINES = 4000;   // a phone renders (and scrolls) no more usefully
+  var diffBase = "fork";
+  // Same localStorage key as the desktop's diff base (lib/diff.ts) — a phone is
+  // a different browser, so this is just one name for one preference.
+  try { diffBase = localStorage.getItem("mf_diffbase") === "head" ? "head" : "fork"; } catch (e) {}
+  var diffSeq = 0;             // guards against a slow load overwriting a newer one
+
+  // Diff text is repo content: build every line with textContent, never HTML.
+  function diffNode(cls, text) {
+    var d = document.createElement("div");
+    d.className = cls;
+    d.textContent = text;
+    return d;
+  }
+
+  function diffNote(msg) {
+    diffBody.innerHTML = "";
+    diffBody.appendChild(diffNode("note", msg));
+  }
+
+  function setDiffStat(added, removed) {
+    diffStat.innerHTML = "";
+    var a = diffNode("add", "+" + (added || 0));
+    var d = diffNode("del", "−" + (removed || 0));
+    a.style.display = d.style.display = "inline";
+    diffStat.appendChild(a);
+    diffStat.appendChild(document.createTextNode("  "));
+    diffStat.appendChild(d);
+  }
+
+  // Header lines git emits that a phone has no room for: the filename pulled
+  // out of "diff --git" already says all of it, in a header that stays put.
+  var DIFF_NOISE = /^(index |--- |\+\+\+ |new file mode|deleted file mode|old mode|new mode|similarity index|dissimilarity index|rename |copy )/;
+
+  function renderDiff(content) {
+    var frag = document.createDocumentFragment();
+    var lines = content.split("\n");
+    // A trailing newline yields one empty last element — not a diff line.
+    if (lines.length && lines[lines.length - 1] === "") lines.pop();
+    var shown = 0;
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      if (line.indexOf("diff --git ") === 0) {
+        var m = line.match(/ b\/(.+)$/);
+        frag.appendChild(diffNode("file", m ? m[1] : line.slice(11)));
+        continue;
+      }
+      if (DIFF_NOISE.test(line)) continue;
+      if (shown >= DIFF_MAX_LINES) {
+        frag.appendChild(diffNode(
+          "note",
+          "… truncated at " + DIFF_MAX_LINES + " lines — open this session on " +
+          "the desktop to read the rest."));
+        break;
+      }
+      var c = line.charAt(0);
+      var cls = line.indexOf("@@") === 0 ? "hunk"
+              : c === "+" ? "add"
+              : c === "-" ? "del" : "";
+      // An empty context line still needs a box to occupy, hence the space.
+      frag.appendChild(diffNode("dl " + cls, line || " "));
+      shown++;
+    }
+    diffBody.innerHTML = "";
+    diffBody.appendChild(frag);
+    diffBody.scrollTop = 0;
+  }
+
+  function loadDiff() {
+    if (view !== "diff") return;
+    if (!current) { diffStat.textContent = ""; diffNote("No session selected."); return; }
+    var seq = ++diffSeq;
+    var title = current;
+    diffStat.textContent = "loading…";
+    fetch("/api/instances/" + encodeURIComponent(title) + "/diff?base=" + diffBase)
+      .then(function (r) {
+        return r.json().catch(function () { return {}; }).then(function (j) {
+          if (!r.ok) throw new Error((j && j.error) || "diff failed (" + r.status + ")");
+          return j;
+        });
+      })
+      .then(function (j) {
+        if (seq !== diffSeq) return;   // a newer load (or session) won
+        if (j.error) { diffStat.textContent = ""; diffNote(j.error); return; }
+        setDiffStat(j.added, j.removed);
+        if (!(j.content || "").trim()) {
+          diffNote(diffBase === "head"
+            ? "No uncommitted changes."
+            : "No changes on this branch yet.");
+          return;
+        }
+        renderDiff(j.content);
+      })
+      .catch(function (err) {
+        if (seq !== diffSeq) return;
+        diffStat.textContent = "";
+        diffNote((err && err.message) || "could not load the diff");
+      });
+  }
+
+  function setDiffBaseLabel() {
+    diffBaseBtn.textContent = diffBase === "head" ? "Uncommitted" : "All changes";
+  }
+  setDiffBaseLabel();
 
   // O1: attention rank (lower = more urgent) + its picker marker. Mirrors the
   // desktop inbox priorities (app.js attentionItems).
@@ -597,6 +739,17 @@
       }
     });
   });
+  // Diff panel controls: flip the baseline (persisted), or re-read the diff.
+  diffBaseBtn.addEventListener("click", function () {
+    diffBase = diffBase === "head" ? "fork" : "head";
+    try { localStorage.setItem("mf_diffbase", diffBase); } catch (e) {}
+    setDiffBaseLabel();
+    loadDiff();
+  });
+  document.getElementById("diff-refresh").addEventListener("click", function () {
+    loadDiff();
+  });
+
   document.getElementById("commit-ok").addEventListener("click", submitCommit);
   document.getElementById("commit-cancel").addEventListener("click", closeCommitSheet);
   // Tap the dimmed backdrop (outside the sheet box) to dismiss.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -44,6 +44,7 @@ Core vocabulary (emitted by the server):
 | `session.budget_exceeded` | Estimated cost first crosses `general.session_budget_usd` | `data: {cost, budget}` |
 | `session.prompt_sent` | The queue drain loop auto-sends a prompt | `data: {text, remaining, loop}` |
 | `session.queue_changed` | Any prompt-queue edit | `data: {pending, enabled, loop}` |
+| `session.usage_restored` | A provider window reopened for a session that had run out | `data: {resumed}` |
 
 Addon-originated events (see `AppContext.emit`) live under the `addon.`
 namespace, e.g. `addon.notify.ping`. Notable transitions:
@@ -51,6 +52,11 @@ namespace, e.g. `addon.notify.ping`. Notable transitions:
 - **agent needs you**: `session.activity_changed` with `new == "clarify"`
 - **PR merged/closed**: `session.stage_changed` with `old == "pr"` (an open PR
   is stage `pr`; merging or closing it moves the stage off `pr`)
+- **out of usage**: `session.activity_changed` with `new == "limit"` — the pane
+  is showing the CLI's usage-limit screen. There is no separate "ran out" event;
+  the counterpart `session.usage_restored` is emitted once per reopening (not
+  once per session) by the watcher that resumes such sessions, so it can only
+  fire after a real outage — never on a window that merely rolled over
 
 The last ~100 envelopes are kept in a ring buffer for replay; `seq` survives the
 buffer rolling over (it keeps counting), but not a server restart.

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -324,14 +324,21 @@ Live stream of the server-side session event bus (see
 
 Events: `session.created|create_failed|deleted|paused|resumed|status_changed|
 activity_changed|stage_changed|setup_started|setup_finished|check_started|
-check_finished|budget_exceeded|budget_raised|prompt_sent|queue_changed`
+check_finished|budget_exceeded|budget_raised|prompt_sent|queue_changed|
+usage_restored`
 (plus addon-originated `addon.*`). `session.budget_exceeded` (J5) fires when a
 session's estimated cost first crosses the configured
 `general.session_budget_usd` — `data: {"cost": <float>, "budget": <float>}` —
 once per session until the server restarts or the budget is changed.
 `session.prompt_sent` fires when the drain loop auto-sends a queued prompt
 (`data: {"text", "remaining", "loop"}`); `session.queue_changed` fires on any
-queue edit (`data: {"pending", "enabled", "loop"}`). The notification-center
+queue edit (`data: {"pending", "enabled", "loop"}`). `session.usage_restored`
+fires once per reopening of a provider's usage window — emitted by the same
+drain-loop pass that nudges sessions parked on a limit screen to carry on
+(`data: {"resumed": <bool>}`, false when `general.resume_on_usage_reset` is
+off). It only ever fires for sessions that had actually run out, so it is the
+"your usage is back" signal; running *out* is `session.activity_changed` with
+`new == "limit"`. The notification-center
 bell (frontend) curates these into a "what happened while I was away" feed.
 
 On connect the server sends a **hello frame first** (L4): `seq: 0, event:

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -193,6 +193,20 @@ carries **no usable reset time** (a null/absent/past reset) holds on a bounded
 fallback instead of sending. A meter that reads *open* — or is *unavailable* —
 leaves the queue free to send, so healthy sessions are never over-held.
 
+**A session that ran out with nothing queued** used to fall outside all of that:
+an empty queue meant nothing was watching, so it sat on the CLI's limit screen
+until a human came back, often hours after the window reopened. The same drain
+pass now also walks the sessions whose activity is `limit` (a free read of the
+state snapshot — no probes when nothing has run out), waits out the window with
+the same meter/banner logic, then sends **Esc + `continue`** so the agent picks
+its task back up. Settings → General's **Resume sessions when usage comes back**
+turns the nudge off (default on); either way the reopening emits
+`session.usage_restored` once, which is what the "Usage comes back" notification
+rule rides on. Sessions with a queued prompt are left to the drain — its prompt
+is the better thing to send — and the nudge obeys the drain's own
+send-once-then-wait rule, so a menu that doesn't clear gets a bounded retry
+rather than one every five seconds.
+
 The command palette has **Send message…** and **Queue prompt…** for the focused
 session (keyboard-only via a prompt).
 
@@ -207,8 +221,19 @@ focuses that session.
 
 **One rule list, two delivery channels.** Settings → Notifications is split that
 way on purpose: *What triggers a notification* (needs-input, PR merged/closed,
-budget exceeded, pre-commit failed — plus the noisy opt-ins) governs **both**
-channels, and each channel decides only where an alert lands.
+budget exceeded, pre-commit failed, ran out of usage / usage came back — plus
+the noisy opt-ins) governs **both** channels, and each channel decides only
+where an alert lands.
+
+The two usage rules are a pair: **"A session runs out of usage"** fires on the
+activity flip to `limit` (the agent is parked on its CLI's usage-limit screen),
+and **"Usage comes back after running out"** fires on `session.usage_restored`,
+which is emitted once per reopening by the watcher that resumes those
+sessions — so it cannot fire for a window that merely rolled over while nothing
+was blocked, and several sessions unblocking together still make one
+notification. Whether those sessions are actually nudged to carry on is
+Settings → General's **Resume sessions when usage comes back**; the
+notification fires either way.
 
 - **Browser / desktop** — the notify addon's `Notification` popup. Needs a tab
   open on a secure origin (HTTPS or localhost), so it is silent on a plain-http
@@ -223,14 +248,25 @@ channels, and each channel decides only where an alert lands.
   protected — **Clear** beside it removes a saved one, since blanking the field
   means "keep" and a *wrong* token is worse than none (ntfy 401s a bad
   credential on a topic that needed no credential at all).
-  *Tapping opens* is an optional URL the notification opens — paste
-  your phone URL from Settings → Mobile; MindFlock strips an `?token=` from it,
-  since that URL is stored on the ntfy server.
+  *Tapping opens* is an optional URL the notification opens. You usually do not
+  need it: when Tailscale is up every push already carries this machine's
+  tailnet `/m` URL — in the message text and as the tap target — deep-linked to
+  the session the alert is about (`/m?s=<title>`), so a tap lands on that
+  session's terminal. Set the field only to send taps somewhere else; MindFlock
+  strips an `?token=` from whatever you paste, since that URL is stored on the
+  ntfy server. (The automatic URL is bare for the same reason.)
 
   Priority is per rule: "needs your input", "budget exceeded" and "pre-commit
   failed" go out at ntfy priority 4 (buzzes through most do-not-disturb
-  setups), PR merged/closed at 3, and the ambient opt-ins (idle, pre-commit
-  running) at 2 so they arrive quietly.
+  setups), PR merged/closed and the two usage rules at 3, and the ambient
+  opt-ins (idle, pre-commit running) at 2 so they arrive quietly.
+
+  You also get one push carrying the phone URL whenever it becomes newly
+  reachable — at server start, when you switch this channel on, and when you
+  turn on tailscale mode — so a phone that has never heard from this machine
+  learns where it is without a QR scan at the desk. It is deduplicated (turning
+  on push and tailscale mode back to back is one intent), and a URL that is not
+  live until the server restarts says so.
 
   On the **public ntfy.sh server the topic name is the credential** — anyone who
   knows it can read your session titles or send you fakes — so keep the
@@ -455,6 +491,13 @@ default); submitting calls `submitMakePr` → `POST /api/instances/{title}/make-
   the app. Takes effect the next time the ingestion pipeline starts; it is the
   same switch as `[mindflock].enabled` in `config.toml` and overrides that file
   (see [configuration.md](configuration.md)).
+- **General → Resume sessions when usage comes back**
+  (`general.resume_on_usage_reset`, **default on**) — whether a session parked
+  on its CLI's usage-limit screen with an empty queue is told to `continue` once
+  the provider's window reopens (see
+  [Send a message / prompt queue](#send-a-message--prompt-queue--per-pane) for
+  the gate it shares with `wait_for_limit`). Off leaves it parked; the "Usage comes back"
+  notification fires either way.
 - **General → Onboarding** — the master **getting-started hints** switch and a
   **Replay tour** button (see [First-run onboarding](#first-run-onboarding)).
 - **Agent CLI → scheduled window refresh** — a keepalive that periodically
@@ -475,10 +518,21 @@ default); submitting calls `submitMakePr` → `POST /api/instances/{title}/make-
   **launch flags** (`[launch] args`). The per-provider **default launch flags**
   (`coding_cli.default_launch_args`) that pre-fill the New-session dialog are
   also edited here.
-- **Mobile** — the `/m` URLs and QR code (`GET /api/mobile`). The tailnet URL here
-  is also the natural paste target for *Tapping opens* on the
-  [Notifications](#notifications-) screen, so a phone push lands in the mobile UI
-  — with one wrinkle worth knowing before you blame the link. The URL is offered
+- **Mobile** — the `/m` URLs and QR code (`GET /api/mobile`), plus the
+  **tailscale mode** toggle. Which interface uvicorn binds is fixed at process
+  start, so that toggle only means something after a restart — and turning it
+  **on** now takes that restart itself: `POST /api/settings` answers
+  `{"restarting": true}`, the screen waits for the server to come back and
+  refreshes the URLs/QR in place. It gives up after three attempts (counted in
+  the environment, since each attempt is a new process image) and leaves the
+  manual **Restart server to apply** button, rather than restart-looping a
+  server that isn't going to come up on the tailnet. The same check runs at
+  every boot, so a server started in local mode while the setting says tailscale
+  corrects itself. The tailnet URL here is also the natural paste target for
+  *Tapping opens* on the [Notifications](#notifications-) screen — though pushes
+  now carry it automatically, so that field is only needed to send taps
+  somewhere else. One wrinkle is worth knowing before you blame the link: the
+  URL is offered
   with `?token=…` baked in so a scan lands signed in, and MindFlock **strips that
   token** when saving it as an ntfy click URL (it would otherwise be stored on the
   ntfy server). A tap therefore only lands signed in if that device already holds
@@ -593,6 +647,23 @@ Shift+Enter inserts a newline in the draft, an empty Send just presses Enter
 (confirming TUI prompts), and the field keeps focus after sending so the
 keyboard stays up. The soft-key bar still acts on the PTY directly while
 composing — arrows and sticky ctrl work mid-draft.
+
+**Diff tab** — a third tab beside Agent/Shell showing the session's diff, so a
+phone can *approve* work and not just unblock it. It reads the same
+`GET /api/instances/<title>/diff` the desktop Diff tab does, with the same two
+baselines behind one button: **All changes** (`base=fork` — everything vs the
+branch's fork point, matching the header badge) and **Uncommitted**
+(`base=head`), persisted per browser under the same `mf_diffbase` key. Unified
+only — a split view needs width a phone hasn't got — colorized like the desktop
+(`@@` cyan, `+` green, `-` red), with each file's name lifted out of its
+`diff --git` line into a header that sticks while its hunks scroll past. Long
+lines scroll sideways inside the panel rather than wrapping (a wrapped diff line
+loses its shape) and the page itself never scrolls horizontally. Very large
+diffs are truncated with a note pointing at the desktop. The Diff panel is a
+*view*, not another terminal: the PTY stays attached behind it, so switching
+back is instant, and the git action bar stays visible (with its status toast
+following you into the tab) because reading the diff is exactly when you decide
+to push.
 
 **Git workflow action bar** — a **Commit / Push / PR / Merge** button row that
 brings the desktop pane header's guided flow to a phone, so the whole git

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/frontend/src/components/settings/screens/General.tsx
+++ b/frontend/src/components/settings/screens/General.tsx
@@ -6,7 +6,7 @@ import { api } from "../../../api/client";
 import { setWheelDamping } from "../../../lib/terminals";
 import { toast } from "../../../lib/toast";
 import { useUi } from "../../../state/store";
-import { SettingField } from "../useSettings";
+import { SettingField, useSettings } from "../useSettings";
 import type { ScreenProps } from "../SettingsDialog";
 
 export function General(_: ScreenProps) {
@@ -34,10 +34,49 @@ export function General(_: ScreenProps) {
           this. Not billed dollars.
         </span>
       </label>
+      <ResumeOnUsageResetRow />
       <ScrollSpeedRow />
       <ReduceMotionRow />
       <GettingStarted />
     </>
+  );
+}
+
+/** Auto-resume after a usage limit: nudge a session that ran out mid-task to
+ * carry on once the provider's window reopens. The prompt queue has always done
+ * this for sessions with something queued; this covers the ones with an empty
+ * queue, which otherwise sit on the CLI's limit screen until someone comes
+ * back. Unset reads as on (see settings.GeneralSettings). */
+function ResumeOnUsageResetRow() {
+  const s = useSettings();
+  const stored = s.get("general", "resume_on_usage_reset");
+  const on = stored !== false && stored !== "false" && stored !== "0";
+  return (
+    <div className="set-row set-switch-row">
+      <span className="notif-rule-text">
+        <span className="set-label">Resume sessions when usage comes back</span>
+        <span className="set-hint notif-rule-desc">
+          When an agent runs out of usage it parks on its CLI's limit screen and
+          stays there — even after the window resets. With this on, MindFlock
+          watches those sessions and tells them to continue the moment usage
+          returns, the same way the prompt queue already resumes sessions that
+          have something queued. You get a notification either way (Settings →
+          Notifications).
+        </span>
+      </span>
+      {/* label wraps only the switch, so clicking the row text no longer flips it */}
+      <label className="ca-switch">
+        <input
+          type="checkbox"
+          checked={on}
+          onChange={(e) => {
+            s.saveField("general", "resume_on_usage_reset", e.target.checked);
+            toast(e.target.checked ? "Auto-resume on" : "Auto-resume off");
+          }}
+        />
+        <span className="ca-slider" />
+      </label>
+    </div>
   );
 }
 

--- a/frontend/src/components/settings/screens/Mobile.tsx
+++ b/frontend/src/components/settings/screens/Mobile.tsx
@@ -40,13 +40,22 @@ export function Mobile(_: ScreenProps) {
 
   const setMode = async (on: boolean) => {
     setModeBusy(true);
+    let restarting = false;
     try {
-      await api("/api/settings", { json: { general: { serve_mode: on ? "tailscale" : "local" } } });
+      const res = await api<{ restarting?: boolean }>("/api/settings", {
+        json: { general: { serve_mode: on ? "tailscale" : "local" } },
+      });
+      restarting = !!res?.restarting;
     } catch {
       /* revert via reload */
     }
     setModeBusy(false);
-    load();
+    // Turning tailscale mode on restarts the server by itself (which interface
+    // uvicorn binds is fixed at boot). It's already going down — wait it out
+    // and refresh the URLs/QR, rather than letting the reload below fail
+    // against a port that is mid-re-exec.
+    if (restarting) restart({ alreadyRequested: true, onBack: load });
+    else load();
   };
 
   // Refresh the QR/URLs in place once the server is back — the new serve mode

--- a/frontend/src/components/settings/useServerRestart.ts
+++ b/frontend/src/components/settings/useServerRestart.ts
@@ -27,6 +27,13 @@ export interface RestartOptions {
   /** Runs once the server answers again. Skipped when `reload` wins, since
    * the page is on its way out. */
   onBack?(): void;
+  /** The server is *already* on its way down — just wait for it.
+   *
+   * Turning tailscale mode on restarts the server by itself (the bind is fixed
+   * at boot), and `POST /api/settings` says so with `restarting: true`. Asking
+   * for a second restart there would either race the re-exec or fire at the
+   * fresh process a moment after it came up. */
+  alreadyRequested?: boolean;
 }
 
 export interface ServerRestart {
@@ -55,7 +62,7 @@ export function useServerRestart(): ServerRestart {
     setTimedOut(false);
     // Fire-and-forget: the response races the re-exec, so a transport error
     // here means nothing. The poll below is what actually reports the outcome.
-    api("/api/server/restart", { method: "POST" }).catch(() => {});
+    if (!opts?.alreadyRequested) api("/api/server/restart", { method: "POST" }).catch(() => {});
     const t0 = Date.now();
     const finish = (didTimeOut: boolean) => {
       if (timer.current) clearInterval(timer.current);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.6"
+version = "0.1.7"
 description = "MindFlock — run a flock of AI coding agents, each in its own git worktree; started by your ticket queue (Jira, Linear, GitHub Issues, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,33 @@ def _redirect_tempfiles(tmp_path, monkeypatch):
         pass
 
 
+@pytest.fixture(autouse=True)
+def _no_tailnet_side_effects(monkeypatch):
+    """No test machine has a tailnet, and no test fires a phone-URL push.
+
+    Two escapes this closes, both introduced by the "here's your phone URL"
+    notification (backend.web.core.mobile_announce):
+
+    * the probes shell out to ``tailscale``, so on a developer's own machine the
+      suite would pick up their real tailnet name — and take seconds doing it;
+    * ``announce_soon`` is fire-and-forget on a thread of its own, so a test that
+      merely enables ntfy could outlive its own monkeypatches and land a *real*
+      push (or a stray call into the next test's fake transport).
+
+    Tests that exercise either path re-patch these themselves — see
+    tests/unit/test_mobile_announce.py.
+    """
+    from backend.web import server
+    from backend.web.core import mobile_announce
+
+    monkeypatch.setattr(server, "_tailscale_info", lambda: (None, None))
+    monkeypatch.setattr(server, "_tailscale_serves_port", lambda port: False)
+    monkeypatch.setattr(mobile_announce, "announce_soon", lambda reason: None)
+    monkeypatch.setattr(mobile_announce, "_refresh_cache_soon", lambda: None)
+    monkeypatch.setattr(mobile_announce, "_CACHED_URL", None)
+    monkeypatch.setattr(mobile_announce, "_CACHED_AT", 0.0)
+
+
 @pytest.fixture
 def isolate_settings_store(tmp_path, monkeypatch):
     """Point the user settings store at a flat per-test ``settings.json`` and

--- a/tests/unit/test_auto_restart.py
+++ b/tests/unit/test_auto_restart.py
@@ -1,0 +1,218 @@
+"""Restarting the server to make tailscale mode real — and knowing when to stop.
+
+Which interface uvicorn binds is decided once, at boot, so the Settings → Mobile
+toggle is inert until the process restarts. :mod:`backend.web.core.restart` does
+that restart itself rather than leaving a button to press, which makes two things
+load-bearing:
+
+* it must **never** fire in a process that merely imported the app (a test run
+  replaced mid-suite by a web server is not a failure anyone can debug), and
+* it must stop. A restart that doesn't change the outcome would otherwise
+  restart forever, so the attempt count rides across ``execv`` in the
+  environment — the only place an in-memory counter couldn't survive to reach
+  its own limit.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from backend.config import settings as S
+from backend.web import server
+from backend.web.core import restart
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store(isolate_settings_store):
+    """Delegate to the shared settings-store isolation (tests/conftest.py)."""
+
+
+@pytest.fixture(autouse=True)
+def _no_execv(monkeypatch):
+    """Record re-exec requests instead of performing them, and start every test
+    with a clean attempt budget."""
+    calls: list = []
+    monkeypatch.setattr(restart, "reexec_soon", lambda delay=0.5: calls.append(delay))
+    monkeypatch.delenv(restart._ATTEMPT_ENV, raising=False)
+    return calls
+
+
+@pytest.fixture
+def execs(_no_execv):
+    return _no_execv
+
+
+@pytest.fixture
+def armed(monkeypatch):
+    """The conditions under which the auto-restart is *supposed* to fire: this
+    process is the server, tailscale mode is on, and the bind is still local."""
+    monkeypatch.setattr(restart, "_SERVING", True)
+    monkeypatch.setattr(restart, "_under_pytest", lambda: False)
+    monkeypatch.setenv("CS_WEB_MODE", "local")
+    S.update_settings(general={"serve_mode": "tailscale"})
+
+
+# --------------------------------------------------------------------------- #
+# The guards: who is allowed to replace this process
+# --------------------------------------------------------------------------- #
+def test_a_test_run_is_never_re_execed(monkeypatch, execs):
+    """The default state of this very suite: every precondition met except the
+    one that matters."""
+    monkeypatch.setattr(restart, "_SERVING", True)
+    monkeypatch.setenv("CS_WEB_MODE", "local")
+    S.update_settings(general={"serve_mode": "tailscale"})
+    assert restart.auto_restart_for_tailscale() is False
+    assert execs == []
+
+
+def test_an_imported_app_is_never_re_execed(monkeypatch, execs):
+    """Without run.main's marker this process is a script, a REPL or a test —
+    none of which asked to become a server."""
+    monkeypatch.setattr(restart, "_under_pytest", lambda: False)
+    monkeypatch.setattr(restart, "_SERVING", False)
+    monkeypatch.setenv("CS_WEB_MODE", "local")
+    S.update_settings(general={"serve_mode": "tailscale"})
+    assert restart.auto_restart_for_tailscale() is False
+    assert execs == []
+
+
+def test_reexec_soon_is_inert_under_pytest(monkeypatch):
+    """The guard sits in the low-level call too — one missed caller shouldn't be
+    able to take the suite down with it."""
+    spawned: list = []
+    monkeypatch.setattr(
+        restart.threading, "Thread", lambda *a, **kw: spawned.append(kw) or _Dummy()
+    )
+    restart.reexec_soon()
+    assert spawned == []
+
+
+class _Dummy:
+    def start(self):  # pragma: no cover — never reached
+        raise AssertionError("a re-exec thread was started under pytest")
+
+
+# --------------------------------------------------------------------------- #
+# The conditions
+# --------------------------------------------------------------------------- #
+def test_no_restart_when_tailscale_mode_is_off(armed, execs):
+    S.update_settings(general={"serve_mode": "local"})
+    assert restart.auto_restart_for_tailscale() is False
+    assert execs == []
+
+
+def test_no_restart_when_the_mode_is_already_in_effect(monkeypatch, armed, execs):
+    """Bound to 0.0.0.0 already — there is nothing to apply."""
+    monkeypatch.setenv("CS_WEB_MODE", "tailscale")
+    assert restart.auto_restart_for_tailscale() is False
+    assert execs == []
+
+
+def test_no_restart_when_the_bind_is_unknown(monkeypatch, armed, execs):
+    """A bare uvicorn leaves CS_WEB_MODE unset; guessing it is local and
+    re-execing would be acting on nothing."""
+    monkeypatch.delenv("CS_WEB_MODE", raising=False)
+    assert restart.auto_restart_for_tailscale() is False
+    assert execs == []
+
+
+def test_restarts_when_the_setting_is_not_in_effect(armed, execs):
+    assert restart.auto_restart_for_tailscale() is True
+    assert execs == [1.0]
+
+
+def test_the_caller_can_shorten_the_grace_period(armed, execs):
+    """The settings route has a client waiting on a response, not a fresh
+    server finding its feet."""
+    assert restart.auto_restart_for_tailscale(delay=0.5) is True
+    assert execs == [0.5]
+
+
+# --------------------------------------------------------------------------- #
+# The budget
+# --------------------------------------------------------------------------- #
+def test_attempts_are_counted_in_the_environment(armed, execs):
+    """execv keeps the environment, so this is the counter that survives the
+    restart it is counting."""
+    restart.auto_restart_for_tailscale()
+    import os
+
+    assert os.environ[restart._ATTEMPT_ENV] == "1"
+
+
+def test_it_gives_up_after_three_attempts(armed, execs):
+    for expected in range(1, restart.MAX_TAILSCALE_ATTEMPTS + 1):
+        assert restart.auto_restart_for_tailscale() is True
+        assert len(execs) == expected
+    assert restart.auto_restart_for_tailscale() is False
+    assert len(execs) == restart.MAX_TAILSCALE_ATTEMPTS
+
+
+def test_a_spent_budget_stays_spent(armed, execs, monkeypatch):
+    monkeypatch.setenv(restart._ATTEMPT_ENV, str(restart.MAX_TAILSCALE_ATTEMPTS))
+    assert restart.auto_restart_for_tailscale() is False
+    assert execs == []
+
+
+def test_a_garbled_counter_is_treated_as_zero(armed, execs, monkeypatch):
+    monkeypatch.setenv(restart._ATTEMPT_ENV, "not-a-number")
+    assert restart.auto_restart_for_tailscale() is True
+
+
+def test_resetting_hands_the_budget_back(armed, execs):
+    """What an explicit user action (the toggle, a manual restart) does: this
+    intent is new, and shouldn't inherit the last one's give-up."""
+    for _ in range(restart.MAX_TAILSCALE_ATTEMPTS):
+        restart.auto_restart_for_tailscale()
+    assert restart.auto_restart_for_tailscale() is False
+    restart.reset_tailscale_attempts()
+    assert restart.auto_restart_for_tailscale() is True
+
+
+# --------------------------------------------------------------------------- #
+# The routes that drive it
+# --------------------------------------------------------------------------- #
+# Loopback base URL: these tests run with CS_WEB_MODE=local, where the
+# DNS-rebinding guard (auth.host_ok) refuses any Host that isn't loopback —
+# including TestClient's default "testserver".
+client = TestClient(server.app, base_url="http://127.0.0.1")
+
+
+def test_the_toggle_restarts_and_says_so(armed, execs):
+    """Settings → Mobile flips the switch; the server takes the restart itself
+    and tells the client to wait for it rather than report the dropped
+    connection as a failure."""
+    S.update_settings(general={"serve_mode": "local"})
+    r = client.post("/api/settings", json={"general": {"serve_mode": "tailscale"}})
+    assert r.status_code == 200
+    assert r.json()["restarting"] is True
+    assert execs == [0.5]
+
+
+def test_turning_the_toggle_off_restarts_nothing(armed, execs):
+    r = client.post("/api/settings", json={"general": {"serve_mode": "local"}})
+    assert r.status_code == 200
+    assert "restarting" not in r.json()
+    assert execs == []
+
+
+def test_the_toggle_hands_back_a_spent_budget(armed, execs, monkeypatch):
+    """A user who flips the switch after the automatic retries gave up gets a
+    restart, not silence."""
+    S.update_settings(general={"serve_mode": "local"})
+    monkeypatch.setenv(restart._ATTEMPT_ENV, str(restart.MAX_TAILSCALE_ATTEMPTS))
+    r = client.post("/api/settings", json={"general": {"serve_mode": "tailscale"}})
+    assert r.json()["restarting"] is True
+    assert execs == [0.5]
+
+
+def test_the_manual_restart_endpoint_still_re_execs(execs, monkeypatch):
+    monkeypatch.setenv(restart._ATTEMPT_ENV, "2")
+    r = client.post("/api/server/restart")
+    assert r.status_code == 200 and r.json()["restarting"] is True
+    assert execs == [0.5]
+    # Explicit intent: the automatic retries start over after it.
+    import os
+
+    assert restart._ATTEMPT_ENV not in os.environ

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -99,6 +99,7 @@ def test_event_names_vocabulary_is_complete():
         "session.budget_exceeded",
         "session.prompt_sent",
         "session.queue_changed",
+        "session.usage_restored",
     }
 
 

--- a/tests/unit/test_frontend_mobile.py
+++ b/tests/unit/test_frontend_mobile.py
@@ -313,3 +313,107 @@ def test_mobile_js_postaction_contract():
         in js
     )
     assert "return j;" in js
+
+
+# --------------------------------------------------------------------------- #
+# /m mobile view — the Diff tab
+#
+# Reading the diff is what turns the phone from "unblock the agent" into
+# "approve the work", so it sits next to Agent/Shell rather than behind a menu.
+# Unified only (a split view needs width a phone hasn't got), same endpoint and
+# same two baselines as the desktop Diff tab.
+# --------------------------------------------------------------------------- #
+def test_mobile_html_has_the_diff_tab():
+    html = client.get("/m").text
+    assert 'data-tab="diff"' in html
+    for el in (
+        'id="diff-wrap"',
+        'id="diff-head"',
+        'id="diff-body"',
+        'id="diff-base"',
+        'id="diff-refresh"',
+        'id="diff-stat"',
+    ):
+        assert el in html, el
+    # Hidden until the tab is chosen — the terminal owns that space by default.
+    assert 'id="diff-wrap" class="hidden"' in html
+
+
+def test_mobile_css_diff_rules():
+    css = client.get("/mobile.css").text
+    for sel in ("#diff-wrap", "#diff-head", "#diff-body", ".diff-btn"):
+        assert sel in css, sel
+    # Diff lines are not wrapped (a wrapped diff line loses its shape), so the
+    # panel scrolls in both directions instead.
+    body = css.split("#diff-body {")[1].split("}")[0]
+    assert "overflow: auto" in body
+    assert "white-space: pre" in css.split("#diff-body .dl {")[1].split("}")[0]
+    # The colors carry the same meaning as the desktop diff.
+    for rule in ("#diff-body .add", "#diff-body .del", "#diff-body .hunk"):
+        assert rule in css, rule
+    # The filename stays visible while its hunks scroll past.
+    assert "position: sticky" in css.split("#diff-body .file {")[1].split("}")[0]
+
+
+def test_mobile_js_diff_fetches_the_same_endpoint_as_the_desktop():
+    js = client.get("/mobile.js").text
+    assert (
+        '"/api/instances/" + encodeURIComponent(title) + "/diff?base=" + diffBase' in js
+    )
+    # Both baselines the desktop offers, persisted under the same key.
+    assert 'localStorage.getItem("mf_diffbase") === "head" ? "head" : "fork"' in js
+    assert 'localStorage.setItem("mf_diffbase", diffBase)' in js
+
+
+def test_mobile_js_diff_is_built_without_html():
+    """Diff text is repo content — it reaches the DOM as text, never markup."""
+    js = client.get("/mobile.js").text
+    diff_fns = js.split("function diffNode(")[1].split("function loadDiff(")[0]
+    assert "d.textContent = text;" in js
+    assert "innerHTML = " not in diff_fns.replace('innerHTML = ""', "")
+
+
+def test_mobile_js_diff_classifies_lines_like_the_desktop():
+    js = client.get("/mobile.js").text
+    # Same classification as lib/diff.ts parseUnifiedDiff.
+    assert 'var cls = line.indexOf("@@") === 0 ? "hunk"' in js
+    assert 'c === "+" ? "add"' in js
+    assert 'c === "-" ? "del" : "";' in js
+    # The filename is lifted out of the "diff --git" line into a header.
+    assert 'if (line.indexOf("diff --git ") === 0)' in js
+    assert "DIFF_NOISE.test(line)" in js
+    # A phone can't usefully render an unbounded diff.
+    assert "shown >= DIFF_MAX_LINES" in js
+
+
+def test_mobile_js_diff_load_is_race_safe():
+    js = client.get("/mobile.js").text
+    # A slow load must not overwrite the result of a newer one (switching
+    # sessions or baselines mid-flight).
+    assert "var seq = ++diffSeq;" in js
+    assert "if (seq !== diffSeq) return;" in js
+
+
+def test_mobile_js_diff_tab_keeps_the_pty_attached():
+    js = client.get("/mobile.js").text
+    # The Diff panel is a *view*, not another PTY: `tab` (which tmux session the
+    # terminal holds) only changes for agent/shell, so coming back from Diff
+    # doesn't tear down and rebuild the websocket.
+    assert 'var view = "agent";' in js
+    assert "if (isDiff) { loadDiff(); return; }" in js
+    assert "if (next === tab) { fitSoon(); return; }" in js
+    # The compose box and key bar go with the terminal; the git action bar stays.
+    assert (
+        'document.getElementById("composer").classList.toggle("hidden", isDiff);' in js
+    )
+    assert 'document.getElementById("keys").classList.toggle("hidden", isDiff);' in js
+    # Switching sessions while the Diff tab is up re-reads the diff.
+    assert 'if (view === "diff") loadDiff();' in js
+
+
+def test_mobile_js_status_toast_follows_the_visible_panel():
+    """Push/merge feedback has to be readable from the Diff tab — that's where
+    the decision to push is made."""
+    js = client.get("/mobile.js").text
+    assert 'var host = view === "diff" ? diffWrap : termWrap;' in js
+    assert "if (statusEl.parentNode !== host) host.appendChild(statusEl);" in js

--- a/tests/unit/test_mobile_announce.py
+++ b/tests/unit/test_mobile_announce.py
@@ -1,0 +1,467 @@
+"""The "here's your phone URL" push: which URL, when, and what it must not say.
+
+Two halves have to line up for this feature to exist at all — Tailscale gives
+the URL, ntfy gives somewhere to send it — so most of these tests are about
+staying *silent* when one half is missing. The rest pin the two things that
+would be bugs with consequences rather than annoyances: the access token must
+never ride along to a third-party server, and a URL that isn't live yet must
+say so instead of pretending.
+
+Covers :func:`mobile_access.tailnet_url`, :mod:`backend.web.core.mobile_announce`
+and the three moments that fire it (server startup, the ntfy channel coming on,
+Settings → Mobile's tailscale toggle).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from starlette.testclient import TestClient
+
+from backend.config import settings as S
+from backend.web import server
+from backend.web.addons import notify as notify_addon
+from backend.web.core import mobile_access, mobile_announce, ntfy
+
+client = TestClient(server.app)
+
+#: The real fire-and-forget entry point, captured before tests/conftest.py's
+#: suite-wide stub replaces it (this module is the one that tests that path).
+_REAL_ANNOUNCE_SOON = mobile_announce.announce_soon
+_REAL_REFRESH = mobile_announce._refresh_cache_soon
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store(isolate_settings_store):
+    """Delegate to the shared settings-store isolation (tests/conftest.py)."""
+
+
+@pytest.fixture
+def real_announce_soon(monkeypatch):
+    """Undo conftest's stub: these tests are *about* the background push."""
+    monkeypatch.setattr(mobile_announce, "announce_soon", _REAL_ANNOUNCE_SOON)
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    """Clear the dedupe memory and the ntfy env overrides between tests."""
+    mobile_announce._SEEN.clear()
+    mobile_announce.remember_url(None)
+    monkeypatch.setattr(mobile_announce, "_CACHED_AT", 0.0)
+    for name in (
+        "MINDFLOCK_NTFY_ENABLED",
+        "MINDFLOCK_NTFY_SERVER",
+        "MINDFLOCK_NTFY_TOPIC",
+        "MINDFLOCK_NTFY_TOKEN",
+        "MINDFLOCK_NTFY_CLICK_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    mobile_announce._SEEN.clear()
+
+
+@pytest.fixture
+def tailnet(monkeypatch):
+    """A tailnet that exists: MagicDNS name + IP, no `tailscale serve`, and a
+    non-local bind — i.e. the plain "phone can reach this" case."""
+    monkeypatch.setenv("CS_WEB_MODE", "tailscale")
+    # A non-local bind auto-arms the auth gate, which would 401 the API calls
+    # below. The gate is not what these tests are about (test_auth.py owns it),
+    # and the one test that cares patches auth_enabled directly.
+    monkeypatch.setenv("MINDFLOCK_AUTH", "0")
+    monkeypatch.setenv("UVICORN_PORT", "8765")
+    monkeypatch.setattr(
+        server, "_tailscale_info", lambda: ("box.tail.net", "100.1.2.3")
+    )
+    monkeypatch.setattr(server, "_tailscale_serves_port", lambda port: False)
+
+
+@pytest.fixture
+def no_tailnet(monkeypatch):
+    monkeypatch.setattr(server, "_tailscale_info", lambda: (None, None))
+    monkeypatch.setattr(server, "_tailscale_serves_port", lambda port: False)
+
+
+@pytest.fixture
+def pushes(monkeypatch):
+    """Capture what would be published, without a transport."""
+    sent: list = []
+
+    async def _publish(cfg, **kw):
+        sent.append({"cfg": cfg, **kw})
+        return True, ""
+
+    monkeypatch.setattr(ntfy, "publish", _publish)
+    return sent
+
+
+def _ntfy_on(topic="t1"):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": topic})
+
+
+def _wait(pred, timeout: float = 5.0) -> bool:
+    """Poll until true — announce_soon lands on a thread or a loop of its own."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(0.01)
+    return pred()
+
+
+# --------------------------------------------------------------------------- #
+# tailnet_url: which URL a phone gets
+# --------------------------------------------------------------------------- #
+def test_tailnet_url_prefers_the_serve_proxy(monkeypatch):
+    """`tailscale serve` fronts localhost with HTTPS, so that URL works even
+    while uvicorn is bound to 127.0.0.1 — local mode is not a caveat here."""
+    monkeypatch.setenv("CS_WEB_MODE", "local")
+    monkeypatch.setattr(
+        server, "_tailscale_info", lambda: ("box.tail.net", "100.1.2.3")
+    )
+    monkeypatch.setattr(server, "_tailscale_serves_port", lambda port: True)
+    assert mobile_access.tailnet_url() == ("https://box.tail.net/m", True)
+
+
+def test_tailnet_url_uses_the_magicdns_name_and_port(tailnet):
+    assert mobile_access.tailnet_url() == ("http://box.tail.net:8765/m", True)
+
+
+def test_tailnet_url_falls_back_to_the_ip(monkeypatch, tailnet):
+    monkeypatch.setattr(server, "_tailscale_info", lambda: (None, "100.1.2.3"))
+    assert mobile_access.tailnet_url() == ("http://100.1.2.3:8765/m", True)
+
+
+def test_tailnet_url_is_not_live_while_bound_locally(monkeypatch, tailnet):
+    """The address is right, but nothing answers on it until the server is
+    restarted in tailscale mode — the caller has to be able to tell."""
+    monkeypatch.setenv("CS_WEB_MODE", "local")
+    assert mobile_access.tailnet_url() == ("http://box.tail.net:8765/m", False)
+
+
+def test_tailnet_url_is_none_without_tailscale(no_tailnet):
+    assert mobile_access.tailnet_url() == (None, False)
+
+
+# --------------------------------------------------------------------------- #
+# announce: when it stays quiet
+# --------------------------------------------------------------------------- #
+async def test_silent_when_ntfy_is_off(tailnet, pushes):
+    assert await mobile_announce.announce("startup") is False
+    assert pushes == []
+
+
+async def test_silent_when_ntfy_has_no_topic(tailnet, pushes):
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": ""})
+    assert await mobile_announce.announce("startup") is False
+    assert pushes == []
+
+
+async def test_silent_without_tailscale(no_tailnet, pushes):
+    """No tailnet, no URL — and a made-up one would be worse than silence."""
+    _ntfy_on()
+    assert await mobile_announce.announce("startup") is False
+    assert pushes == []
+
+
+async def test_never_raises_when_the_push_blows_up(monkeypatch, tailnet):
+    _ntfy_on()
+
+    async def _boom(cfg, **kw):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(ntfy, "publish", _boom)
+    assert await mobile_announce.announce("startup") is False  # no exception
+
+
+# --------------------------------------------------------------------------- #
+# announce: what it says
+# --------------------------------------------------------------------------- #
+async def test_push_carries_the_url_and_opens_it_on_tap(tailnet, pushes):
+    _ntfy_on()
+    assert await mobile_announce.announce(mobile_announce.REASON_STARTUP) is True
+    (push,) = pushes
+    assert "http://box.tail.net:8765/m" in push["message"]
+    assert push["click"] == "http://box.tail.net:8765/m"
+    assert push["cfg"].topic == "t1"
+    assert "just started" in push["message"]
+
+
+async def test_each_reason_says_why_the_phone_is_buzzing(tailnet, pushes):
+    _ntfy_on()
+    for reason in (
+        mobile_announce.REASON_STARTUP,
+        mobile_announce.REASON_NTFY,
+        mobile_announce.REASON_MOBILE,
+    ):
+        mobile_announce._SEEN.clear()
+        assert await mobile_announce.announce(reason) is True
+    assert [p["message"].split("\n")[0] for p in pushes] == [
+        mobile_announce._LINES[mobile_announce.REASON_STARTUP],
+        mobile_announce._LINES[mobile_announce.REASON_NTFY],
+        mobile_announce._LINES[mobile_announce.REASON_MOBILE],
+    ]
+
+
+async def test_the_access_token_never_travels_to_ntfy(monkeypatch, tailnet, pushes):
+    """The push is stored on a third-party server. The QR may bake ?token= in;
+    this must not — same call ntfy.strip_token_param makes for the click URL."""
+    monkeypatch.setattr(server._auth, "auth_enabled", lambda: True)
+    monkeypatch.setattr(server._auth, "get_token", lambda: "s3cret-token")
+    _ntfy_on()
+    assert await mobile_announce.announce("startup") is True
+    (push,) = pushes
+    blob = "%s %s %s" % (push["title"], push["message"], push.get("click"))
+    assert "s3cret-token" not in blob
+    assert "token=" not in blob
+    # It does say a token will be wanted — a sign-in page with no warning is
+    # how "the URL doesn't work" reports get written.
+    assert "access token" in push["message"].lower()
+
+
+async def test_a_url_that_is_not_live_yet_says_so(monkeypatch, tailnet, pushes):
+    monkeypatch.setenv("CS_WEB_MODE", "local")
+    _ntfy_on()
+    assert await mobile_announce.announce(mobile_announce.REASON_MOBILE) is True
+    (push,) = pushes
+    assert "restart" in push["message"].lower()
+
+
+async def test_a_live_url_carries_no_restart_caveat(tailnet, pushes):
+    _ntfy_on()
+    await mobile_announce.announce(mobile_announce.REASON_MOBILE)
+    assert "restart" not in pushes[0]["message"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# announce: saying it once
+# --------------------------------------------------------------------------- #
+async def test_the_same_url_is_not_announced_twice(tailnet, pushes):
+    """Turning on ntfy and tailscale mode back to back is one intent."""
+    _ntfy_on()
+    assert await mobile_announce.announce(mobile_announce.REASON_NTFY) is True
+    assert await mobile_announce.announce(mobile_announce.REASON_MOBILE) is False
+    assert len(pushes) == 1
+
+
+async def test_a_url_going_live_is_worth_saying_again(monkeypatch, tailnet, pushes):
+    """The "restart to apply" push and the "it works now" push are different
+    news — the second is the one the user is actually waiting for."""
+    monkeypatch.setenv("CS_WEB_MODE", "local")
+    _ntfy_on()
+    assert await mobile_announce.announce(mobile_announce.REASON_MOBILE) is True
+    monkeypatch.setenv("CS_WEB_MODE", "tailscale")
+    assert await mobile_announce.announce(mobile_announce.REASON_STARTUP) is True
+    assert len(pushes) == 2
+
+
+async def test_the_dedupe_window_expires(monkeypatch, tailnet, pushes):
+    _ntfy_on()
+    assert await mobile_announce.announce("startup") is True
+    for key in list(mobile_announce._SEEN):  # age every entry past the window
+        mobile_announce._SEEN[key] -= mobile_announce._DEDUPE_SECONDS + 1
+    assert await mobile_announce.announce("startup") is True
+    assert len(pushes) == 2
+
+
+# --------------------------------------------------------------------------- #
+# The three moments that fire it
+# --------------------------------------------------------------------------- #
+def test_turning_ntfy_on_announces_the_url(tailnet, pushes, real_announce_soon):
+    S.update_settings(notifications={"ntfy_topic": "t1"})
+    r = client.post("/api/notify/ntfy", json={"enabled": True, "topic": "t1"})
+    assert r.status_code == 200
+    assert _wait(lambda: len(pushes) == 1)
+    assert "box.tail.net" in pushes[0]["message"]
+
+
+def test_saving_an_already_on_channel_does_not_re_announce(
+    tailnet, pushes, real_announce_soon
+):
+    _ntfy_on()
+    client.post("/api/notify/ntfy", json={"enabled": True, "topic": "t1"})
+    time.sleep(0.2)
+    assert pushes == []
+
+
+def test_turning_tailscale_mode_on_announces_the_url(
+    tailnet, pushes, real_announce_soon
+):
+    """No restart is scheduled here (the server is already on the tailnet), so
+    the announce is this process's job."""
+    _ntfy_on()
+    r = client.post("/api/settings", json={"general": {"serve_mode": "tailscale"}})
+    assert r.status_code == 200
+    assert r.json().get("restarting") is None
+    assert _wait(lambda: len(pushes) == 1)
+
+
+def test_an_unrelated_settings_save_announces_nothing(
+    tailnet, pushes, real_announce_soon
+):
+    _ntfy_on()
+    client.post("/api/settings", json={"ui": {"accent": "macaw"}})
+    time.sleep(0.2)
+    assert pushes == []
+
+
+def test_server_startup_announces_the_url(tailnet, monkeypatch):
+    """The lifespan warmup fires it, so a phone learns the URL from a restart
+    it wasn't present for."""
+    seen: list = []
+
+    async def _announce(reason):
+        seen.append(reason)
+        return True
+
+    monkeypatch.setattr(mobile_announce, "announce", _announce)
+    with TestClient(server.app):
+        assert _wait(lambda: mobile_announce.REASON_STARTUP in seen)
+
+
+def test_announce_soon_delivers_without_a_running_loop(
+    tailnet, pushes, real_announce_soon
+):
+    """The settings routes are sync handlers on a worker thread — the push has
+    to find its own way onto a loop."""
+    _ntfy_on()
+    mobile_announce.announce_soon(mobile_announce.REASON_NTFY)
+    assert _wait(lambda: len(pushes) == 1)
+
+
+def test_announce_soon_never_raises_at_the_caller(
+    monkeypatch, tailnet, real_announce_soon
+):
+    _ntfy_on()
+    monkeypatch.setattr(
+        ntfy.threading,
+        "Thread",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("cannot spawn")),
+    )
+    mobile_announce.announce_soon("startup")  # no exception
+
+
+# --------------------------------------------------------------------------- #
+# click_for: the URL that rides along on every other push
+# --------------------------------------------------------------------------- #
+def test_click_for_deep_links_to_the_session():
+    mobile_announce.remember_url("http://box.tail.net:8765/m")
+    assert mobile_announce.click_for("alpha") == "http://box.tail.net:8765/m?s=alpha"
+
+
+def test_click_for_escapes_the_session_title():
+    """Session titles are free text; a raw one would break the query string."""
+    mobile_announce.remember_url("http://box.tail.net:8765/m")
+    assert mobile_announce.click_for("fix a&b") == (
+        "http://box.tail.net:8765/m?s=fix%20a%26b"
+    )
+
+
+def test_click_for_without_a_session_is_the_bare_url():
+    mobile_announce.remember_url("https://box.tail.net/m")
+    assert mobile_announce.click_for() == "https://box.tail.net/m"
+
+
+def test_click_for_is_empty_when_there_is_no_tailnet():
+    """No URL is not an error — publish() falls back to the user's own click
+    URL, and the push still goes out."""
+    mobile_announce.remember_url(None)
+    assert mobile_announce.click_for("alpha") == ""
+
+
+def test_click_for_never_probes_on_the_callers_thread(monkeypatch):
+    """It runs inside an event-bus emit; `tailscale status` can take seconds."""
+    monkeypatch.setattr(
+        mobile_access,
+        "tailnet_url",
+        lambda: pytest.fail("click_for probed on the calling thread"),
+    )
+    monkeypatch.setattr(mobile_announce, "_refresh_cache_soon", lambda: None)
+    assert mobile_announce.click_for("alpha") == ""
+
+
+def test_a_stale_cache_refreshes_in_the_background(monkeypatch, tailnet):
+    """The first push after Tailscale comes up may have no link; the next one
+    does."""
+    monkeypatch.setattr(mobile_announce, "_refresh_cache_soon", _REAL_REFRESH)
+    assert mobile_announce.click_for("alpha") == ""  # nothing cached yet
+    assert _wait(lambda: mobile_announce.click_for("alpha").startswith("http"))
+    assert mobile_announce.click_for("alpha") == ("http://box.tail.net:8765/m?s=alpha")
+
+
+def test_session_pushes_carry_the_url(monkeypatch, tailnet):
+    """Every rule push taps through to the session it is about — both as the
+    click action and as a line in the message."""
+    sent: list = []
+    monkeypatch.setattr(ntfy, "publish_soon", lambda cfg, **kw: sent.append(kw))
+    mobile_announce.remember_url("http://box.tail.net:8765/m")
+    _ntfy_on()
+    notify_addon.NotifyAddon()._on_event(
+        {
+            "event": "session.activity_changed",
+            "session": "alpha",
+            "old": "working",
+            "new": "clarify",
+        }
+    )
+    (push,) = sent
+    assert push["click"] == "http://box.tail.net:8765/m?s=alpha"
+    assert push["message"].endswith("http://box.tail.net:8765/m?s=alpha")
+    # The rule's own text is still the first thing you read.
+    assert push["message"].startswith("The agent is waiting on a clarification.")
+
+
+def test_session_pushes_without_a_tailnet_are_unchanged(monkeypatch):
+    """No URL to add, so nothing is added — and publish() still falls back to
+    the user's configured click URL."""
+    sent: list = []
+    monkeypatch.setattr(ntfy, "publish_soon", lambda cfg, **kw: sent.append(kw))
+    mobile_announce.remember_url(None)
+    _ntfy_on()
+    notify_addon.NotifyAddon()._on_event(
+        {
+            "event": "session.activity_changed",
+            "session": "alpha",
+            "old": "working",
+            "new": "clarify",
+        }
+    )
+    (push,) = sent
+    assert push["click"] is None
+    assert push["message"] == "The agent is waiting on a clarification."
+
+
+def test_the_test_push_shows_the_url_too(tailnet, pushes):
+    """The first push anyone sees demonstrates what the real ones will do."""
+    _ntfy_on()
+    r = client.post("/api/notify/ntfy/test", json={})
+    assert r.status_code == 200 and r.json()["ok"] is True
+    (push,) = pushes
+    assert push["click"] == "http://box.tail.net:8765/m"
+    assert "http://box.tail.net:8765/m" in push["message"]
+
+
+async def test_publish_soon_forwards_a_click_url(monkeypatch):
+    """The click passthrough mobile_announce relies on, checked at the seam."""
+    seen: list = []
+
+    async def _publish(cfg, **kw):
+        seen.append(kw)
+        return True, ""
+
+    monkeypatch.setattr(ntfy, "publish", _publish)
+    ntfy.set_loop(asyncio.get_running_loop())
+    ntfy.publish_soon(
+        ntfy.NtfyConfig(enabled=True, topic="t1"),
+        title="T",
+        message="M",
+        click="https://box.tail.net/m",
+    )
+    for _ in range(200):
+        if seen:
+            break
+        await asyncio.sleep(0.01)
+    assert seen and seen[0]["click"] == "https://box.tail.net/m"
+    ntfy.set_loop(None)

--- a/tests/unit/test_server_reexports.py
+++ b/tests/unit/test_server_reexports.py
@@ -24,6 +24,21 @@ import pytest
 from backend.web import server
 
 
+@pytest.fixture(autouse=True)
+def _unstub_tailnet_probes(monkeypatch):
+    """Put the real Tailscale probes back on the server facade.
+
+    tests/conftest.py stubs them there suite-wide (no test machine has a
+    tailnet, and probing shells out). This module asserts the facade holds the
+    *same object* as ``core`` — a stub is exactly the shadowing redefinition it
+    exists to catch, so here the real bindings have to be in place.
+    """
+    from backend.web.core import mobile_access
+
+    for _name in ("_tailscale_info", "_tailscale_serves_port"):
+        monkeypatch.setattr(server, _name, getattr(mobile_access, _name))
+
+
 def _iter_module_level(nodes):
     """Walk statements without descending into function/class bodies, so only
     imports bound at module import time are seen (a ``from core import _x``

--- a/tests/unit/test_usage_resume.py
+++ b/tests/unit/test_usage_resume.py
@@ -1,0 +1,239 @@
+"""Sessions that ran out of usage with nothing queued (server._watch_*).
+
+The prompt queue has always ridden out a usage limit for sessions with a prompt
+waiting. A session that simply ran out mid-task has an empty queue, so nothing
+was watching it: it sat on its CLI's limit screen long after the window
+reopened, until a human noticed. This is the watcher that covers that gap, plus
+the one event it emits so "your usage is back" can reach a phone.
+
+The three things worth pinning: it acts only when the window has actually
+reopened, it never fights the queue drain for the same session, and it announces
+the reopening once — not once per limited session, and never at all for a window
+that merely rolled over while everything was fine.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from backend.config import settings as S
+from backend.web import server
+from backend.web.core import events, prompt_queue as _pq
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store(isolate_settings_store):
+    """Delegate to the shared settings-store isolation (tests/conftest.py)."""
+
+
+@pytest.fixture
+def watch(monkeypatch):
+    """A single live session parked on the usage-limit screen, with every
+    shell-out replaced. Returns a handle whose ``limited_until`` decides what
+    the limit gate reports and whose ``sent`` records what reached the agent."""
+    h = types.SimpleNamespace(
+        limited_until=0.0, sent=[], escapes=[], events=[], now=10_000.0
+    )
+    inst = types.SimpleNamespace(
+        Program="claude",
+        Started=lambda: True,
+        Status="running",
+    )
+    monkeypatch.setattr(server.time, "time", lambda: h.now)
+    monkeypatch.setattr(server.time, "sleep", lambda s: None)
+    monkeypatch.setattr(server.ENGINE, "instances", {"alpha": inst})
+    monkeypatch.setattr(server, "_ensure_agent_session", lambda i, t: ("sess", None))
+    monkeypatch.setattr(server, "_refresh_limit_state", lambda i, t, n: h.limited_until)
+    monkeypatch.setattr(
+        server, "_send_escape_to_agent", lambda n: h.escapes.append(n) or True
+    )
+    monkeypatch.setattr(
+        server,
+        "_send_to_agent",
+        lambda n, text, submit=True: h.sent.append(text) is None,
+    )
+    monkeypatch.setattr(
+        events.BUS,
+        "emit",
+        lambda name, **kw: h.events.append((name, kw)),
+    )
+    # The watcher's candidate list is the event snapshot the state tick keeps.
+    monkeypatch.setattr(
+        server, "_EVENT_SNAPSHOT", {"alpha": {"activity": "limit"}}, raising=False
+    )
+    server._QUEUE_STATE.pop("alpha", None)
+    monkeypatch.setattr(server, "_LAST_RESTORE_EMIT", 0.0, raising=False)
+    _pq.clear("alpha")
+    yield h
+    server._QUEUE_STATE.pop("alpha", None)
+    _pq.clear("alpha")
+
+
+def _restored(h):
+    return [kw for name, kw in h.events if name == "session.usage_restored"]
+
+
+# --------------------------------------------------------------------------- #
+# Acting only when the window has actually reopened
+# --------------------------------------------------------------------------- #
+def test_still_limited_is_left_alone(watch):
+    watch.limited_until = watch.now + 3600
+    server._watch_limited_sessions()
+    assert watch.sent == [] and watch.escapes == []
+    assert _restored(watch) == []
+
+
+def test_reopened_window_resumes_the_session(watch):
+    server._watch_limited_sessions()
+    # Esc first (the CLI leaves its limit menu up until a key is pressed), then
+    # the nudge — the same order the queue drain uses.
+    assert watch.escapes == ["sess"]
+    assert watch.sent == [server._LIMIT_RESUME_PROMPT]
+    assert _restored(watch) == [{"session": "alpha", "data": {"resumed": True}}]
+
+
+def test_a_session_with_no_limit_screen_is_not_watched(watch, monkeypatch):
+    """The whole pass costs one dict read when nothing has run out."""
+    monkeypatch.setattr(server, "_EVENT_SNAPSHOT", {"alpha": {"activity": "idle"}})
+    server._watch_limited_sessions()
+    assert watch.sent == [] and _restored(watch) == []
+
+
+def test_a_paused_session_is_not_resumed(watch, monkeypatch):
+    monkeypatch.setattr(
+        server.ENGINE,
+        "instances",
+        {
+            "alpha": types.SimpleNamespace(
+                Program="claude", Started=lambda: True, Status=server.session.Paused
+            )
+        },
+    )
+    server._watch_limited_sessions()
+    assert watch.sent == [] and _restored(watch) == []
+
+
+def test_a_dead_tmux_session_announces_nothing(watch, monkeypatch):
+    """The send is how we know the resume landed; without it there is nothing
+    to tell the user about."""
+    monkeypatch.setattr(server, "_send_to_agent", lambda n, text, submit=True: False)
+    server._watch_limited_sessions()
+    assert _restored(watch) == []
+
+
+# --------------------------------------------------------------------------- #
+# Not fighting the queue drain
+# --------------------------------------------------------------------------- #
+def test_a_session_with_a_queued_prompt_is_left_to_the_drain(watch):
+    """Both would send on the same tick; the drain's prompt is the better one."""
+    _pq.enqueue("alpha", "do the thing")
+    server._watch_limited_sessions()
+    assert watch.sent == [] and watch.escapes == []
+
+
+def test_a_disabled_queue_is_still_watched(watch):
+    """Auto-run off means the drain will never send — so this session IS stuck,
+    and the watcher is the only thing that will get it moving again."""
+    _pq.enqueue("alpha", "do the thing")
+    _pq.set_flags("alpha", enabled=False)
+    server._watch_limited_sessions()
+    assert watch.sent == [server._LIMIT_RESUME_PROMPT]
+
+
+def test_the_nudge_is_sent_once_not_every_tick(watch):
+    """Armed-gating, exactly like the drain: a nudge that doesn't take retries
+    after the re-arm window rather than every five seconds."""
+    server._watch_limited_sessions()
+    watch.now += server._QUEUE_SEND_COOLDOWN + 1
+    server._watch_limited_sessions()
+    assert watch.sent == [server._LIMIT_RESUME_PROMPT]
+    # ...but a stuck session does get a bounded retry.
+    watch.now += server._QUEUE_REARM_IDLE + 1
+    server._watch_limited_sessions()
+    assert len(watch.sent) == 2
+
+
+# --------------------------------------------------------------------------- #
+# The announcement
+# --------------------------------------------------------------------------- #
+def test_usage_restored_is_announced_once_per_window(watch, monkeypatch):
+    """Several sessions unblock in the same pass; "usage is back" is one fact
+    about the account, not one per session."""
+    inst = server.ENGINE.instances["alpha"]
+    monkeypatch.setattr(
+        server.ENGINE, "instances", {"alpha": inst, "beta": inst, "gamma": inst}
+    )
+    monkeypatch.setattr(
+        server,
+        "_EVENT_SNAPSHOT",
+        {t: {"activity": "limit"} for t in ("alpha", "beta", "gamma")},
+    )
+    server._watch_limited_sessions()
+    assert len(watch.sent) == 3  # every stuck session is resumed
+    assert len(_restored(watch)) == 1  # but the news is announced once
+    for t in ("beta", "gamma"):
+        server._QUEUE_STATE.pop(t, None)
+
+
+def test_a_later_window_announces_again(watch):
+    server._watch_limited_sessions()
+    watch.now += server._LIMIT_RESTORE_QUIET + 1
+    server._QUEUE_STATE["alpha"]["armed"] = True
+    server._watch_limited_sessions()
+    assert len(_restored(watch)) == 2
+
+
+# --------------------------------------------------------------------------- #
+# The setting
+# --------------------------------------------------------------------------- #
+def test_auto_resume_off_still_announces(watch):
+    """Knowing your usage is back is useful even when you want to restart the
+    work yourself."""
+    S.update_settings(general={"resume_on_usage_reset": False})
+    server._watch_limited_sessions()
+    assert watch.sent == []
+    assert _restored(watch) == [{"session": "alpha", "data": {"resumed": False}}]
+
+
+def test_auto_resume_defaults_to_on():
+    """Unset reads as on — running out is temporary, and the point of the limit
+    gate is that MindFlock picks the work back up."""
+    assert S.load_settings().general.resume_on_usage_reset is None
+    assert server._resume_on_usage_reset() is True
+
+
+def test_auto_resume_survives_a_settings_round_trip():
+    S.update_settings(general={"resume_on_usage_reset": False})
+    S.invalidate()
+    assert S.load_settings().general.resume_on_usage_reset is False
+    assert server._resume_on_usage_reset() is False
+    S.update_settings(general={"resume_on_usage_reset": True})
+    assert server._resume_on_usage_reset() is True
+
+
+# --------------------------------------------------------------------------- #
+# The rules that carry it to a phone
+# --------------------------------------------------------------------------- #
+def test_both_usage_rules_exist_and_are_on_by_default():
+    from backend.web.addons import notify
+
+    by_id = {r["id"]: r for r in notify.NOTIFY_RULES}
+    out, back = by_id["usage_limit"], by_id["usage_restored"]
+    # Running out is just the activity transition — no bespoke event needed.
+    assert out["event"] == "session.activity_changed" and out["new"] == "limit"
+    # Coming back is the watcher's event, which only fires for a session that
+    # had run out — so it can't fire on an ordinary window rollover.
+    assert back["event"] == "session.usage_restored"
+    assert out["default_enabled"] and back["default_enabled"]
+
+
+def test_the_usage_rules_can_be_muted():
+    from starlette.testclient import TestClient
+
+    client = TestClient(server.app)
+    for rule_id in ("usage_limit", "usage_restored"):
+        r = client.post("/api/notify/rules/%s" % rule_id, json={"enabled": False})
+        assert r.status_code == 200
+        assert {x["id"]: x["enabled"] for x in r.json()["rules"]}[rule_id] is False

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Four features that all come back to the same complaint: MindFlock knew something
you needed to know, and you had to be at the desk to find out. Plus the version
bump — this is the release PR for **0.1.7**.

## Your phone URL travels with the notifications

Every ntfy push now carries this machine's tailnet `/m` URL, both in the message
text and as the tap target, deep-linked to the session it is about
(`/m?s=<title>`) — so a notification is one tap from the thing it's telling you
about instead of the start of a hunt for the URL. On top of that, one push
announces the URL whenever it becomes *newly reachable*: at server start, when
the ntfy channel is switched on, and when tailscale mode is turned on
(deduplicated, so flipping two switches back to back is one notification).

The access token is deliberately not included — the message is stored on a
third-party server — but the message says a new device will meet the sign-in
page. `Tapping opens` stays available for sending taps somewhere else.

New `backend/web/core/mobile_announce.py`; `mobile_access.tailnet_url()` is the
one place that decides which URL a phone gets, and whether it is live yet.

## A Diff tab in the phone UI

`/m` gains a third tab beside Agent and Shell, so a phone can *approve* work and
not just unblock it. Same `GET /api/instances/<title>/diff` and the same two
baselines as the desktop Diff tab (**All changes** / **Uncommitted**, persisted
under the shared `mf_diffbase` key), unified and colorized, with each file's
name lifted out of its `diff --git` line into a header that sticks while its
hunks scroll past. Long lines scroll sideways *inside* the panel; the page never
scrolls horizontally. The PTY stays attached behind the panel, so switching back
is instant, and the git action bar — with its status toast — stays on screen,
because reading the diff is exactly when you decide to push.

## Tailscale mode applies itself

Which interface uvicorn binds is fixed at process start, so the Settings →
Mobile toggle only ever meant something after a restart. Turning it on now takes
that restart: `POST /api/settings` answers `{"restarting": true}` and the screen
waits for the server to come back, refreshing the URLs/QR in place. Bounded at
three attempts — counted in the *environment*, because each attempt is a new
process image and an in-memory counter could never reach its own limit — before
it gives up and leaves the manual button. The same check runs at every boot, so
a server started in local mode while the setting says tailscale corrects itself.

New `backend/web/core/restart.py`, which also owns the existing
`POST /api/server/restart` re-exec. It refuses to fire in a test process or in
anything that merely imported the app.

## Sessions that run out of usage get picked back up

The prompt queue has always ridden out a usage limit for sessions with something
queued. A session that simply ran out mid-task has an empty queue, so nothing was
watching it — it sat on its CLI's limit screen until a human came back, often
hours after the window reopened. The drain pass now also walks the sessions whose
activity is `limit` (a free read of the state snapshot the events tick already
keeps — no probes when nothing has run out), waits the window out with the same
meter/banner logic the queue uses, and sends Esc + `continue`.

New setting `general.resume_on_usage_reset` (Settings → General, default on) and
two default-on notification rules: **"A session runs out of usage"** and
**"Usage comes back after running out"**. The second rides a new
`session.usage_restored` event emitted once per *reopening* — so it cannot fire
for a window that merely rolled over while nothing was blocked, and several
sessions unblocking together still make one notification.

## Verification

Beyond the suite (3561 backend / 148 frontend, black + tsc clean, bundle
rebuilt), the two features that only exist at runtime were exercised for real on
an isolated server and port:

* toggled tailscale mode → log shows `restarting to apply it (attempt 1 of 3)`
  → came back as `mode: tailscale, bind: 0.0.0.0`, and the startup push landed
  on a stand-in ntfy server carrying the tailnet URL as message and `click`;
  the "Send a test" and channel-on pushes carried it too;
* the Diff tab screenshotted at 390×844 against a real session — sticky headers,
  no page-level horizontal scroll, no console errors.

Three new test files cover the parts that would be bugs with consequences: no
push ever carries the access token, no auto-restart can fire from a test process
or a bare import, and the usage watcher never fights the drain for the same
session. `tests/conftest.py` gains a suite-wide stub so no test can shell out to
the developer's real `tailscale` or fire a background push.

Docs: README, `docs/web-ui.md`, `docs/web-api.md`, `docs/extensions.md`.
