### PR TITLE
Release 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-08-03
+
 ### Added
 
 - **Ingestion runs any agent CLI, not just Claude Code.** MindFlock has always
@@ -611,7 +613,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.8
 [0.1.7]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.7
 [0.1.6]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.6
 [0.1.5]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.5

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.7"
+version = "0.1.8"
 description = "MindFlock — run a flock of AI coding agents, each in its own git worktree; started by your ticket queue (Jira, Linear, GitHub Issues, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump + CHANGELOG roll for 0.1.8: multi-CLI ingestion, the local-model path, and GitHub Issues as the zero-config on-ramp (#30).

Manifests written by `scripts/bump-version.py`: `pyproject.toml`, `electron/package.json`, `frontend/package.json`, `uv.lock`.

Merging this and tagging `v0.1.8` publishes the wheel/sdist and the desktop installers as release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)