### PR TITLE
Let the sidebar be the width you need, and keep the pill a pill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🐦‍⬛ MindFlock
 
-**Run a flock of AI coding agents — started by your ticket queue, merged by you.**
+**A private flock of AI coding agents — started by your ticket queue, merged by you.**
 
 [![CI](https://github.com/MindFlock/MindFlock/actions/workflows/ci.yml/badge.svg)](https://github.com/MindFlock/MindFlock/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/MindFlock/MindFlock?include_prereleases)](https://github.com/MindFlock/MindFlock/releases)
@@ -12,6 +12,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md)
 
 [What is it?](#what-is-mindflock) •
+[Where your code goes](#where-your-code-goes) •
 [Does it actually work?](#what-it-looks-like-in-use) •
 [How is this different?](#how-is-this-different) •
 [Quick Start](#quick-start) •
@@ -35,16 +36,18 @@ diffs and terminal output are sample data.</sub>
 ## What is MindFlock?
 
 Work assigned to you in **GitHub Issues, Jira, Linear, Shortcut, or Asana**
-becomes an isolated AI coding session: its own **git worktree** on its own
-`feature/<ticket>/<slug>` branch, dependencies installed, and an agent already
-seeded with the ticket's title, description, acceptance criteria and comments.
-Nothing typed.
+becomes an isolated AI coding session **on your own machine**: its own **git
+worktree** on its own `feature/<ticket>/<slug>` branch, dependencies installed,
+and an agent already seeded with the ticket's title, description, acceptance
+criteria and comments. Nothing typed. No vendor sandbox, no account, no copy of
+your repository anywhere but your disk — and with a local model, no network
+either.
 
-<sub>Two caveats worth knowing before you read further: dependency install is
+<sub>One caveat worth knowing before you read further: dependency install is
 auto-detected for Python/uv repos (`uv sync --all-groups`, `pre-commit install`)
-and every other stack declares its own `setup_commands`; and *provisioned*
-sessions — the ones ingestion creates — launch **Claude Code**. Any agent CLI can
-drive sessions you start yourself.</sub>
+and every other stack declares its own `setup_commands`. Any agent CLI can drive
+any session — including the *provisioned* ones ingestion creates, which each
+ticketing source picks its own agent for.</sub>
 
 You come in at the end that needs a human: **read the diff**, then drive it home
 with one click each — commit (in your terminal, so you watch the hooks), push,
@@ -69,6 +72,55 @@ in from your commits. It never writes to your tracker — no comments, no status
 transitions. It polls (every 20 s) rather than listening for
 webhooks, works one ticket at a time, and only picks up review comments on *your
 own* PRs.
+
+## Where your code goes
+
+Nowhere new. **MindFlock is not a service.** There is no MindFlock cloud, no
+account to create, no sandbox that gets a copy of your repository. The engine is
+a process on your laptop bound to `127.0.0.1` by default; the agents are the same
+CLIs you already run in a terminal, launched into a git worktree on your own
+disk, on your own subscription.
+
+That is the whole difference from the cloud ticket-to-PR tools. Devin, Google
+Jules, GitHub Copilot's coding agent, Cursor's background agents and Atlassian
+Rovo Dev take the same input — a ticket assigned to you — and clone your
+repository into a VM the vendor operates. MindFlock takes the same input and
+never moves the code.
+
+Everything MindFlock itself talks to over the network, in full:
+
+| It calls | When | What it sends |
+|---|---|---|
+| Your tracker's API (GitHub Issues · Jira · Linear · Shortcut · Asana) | every ~20 s while ingestion is on | nothing — **read-only**. It never comments and never moves a status |
+| your local model server, if you configure one | every turn of a session on a local model | your prompt and code — to `127.0.0.1` (or whatever host you pointed it at). Never leaves your machine unless you aim it off-box |
+| `api.github.com` | polling *your own* PRs for review comments; the **Make PR** / **Merge** buttons | what `gh` would send if you ran it by hand |
+| `aipricing.guru` | at most once a day, for the model price table behind the cost display | nothing. Falls back to a built-in table offline |
+| your git remote | only when *you* click push | your commits, over the remote your repo already has |
+| `ntfy.sh`, or your own instance | only if you switch phone push on | the notification text |
+| GitHub Releases | the desktop app's update check | nothing |
+
+No analytics, no telemetry, no crash reporting, no license check, no phone-home
+of any kind — the tree is public, so grep it. Tracker tokens live in
+`~/.mindflock/settings.json` at mode `0600` and are sent to the tracker they
+belong to and nowhere else. `mindflock serve` refuses the network until you
+explicitly ask for `tailscale` mode, and even then it's your tailnet behind an
+auth token, never the public internet.
+
+**The honest boundary, because it's the first thing a security review will
+ask:** your *agent* still talks to its own vendor. `claude` sends code to
+Anthropic and `codex` sends it to OpenAI, exactly as they do when you run them
+yourself in that repo — MindFlock adds no hop and introduces no third party, but
+by default it does not remove that one either.
+
+**If that call is the one you can't make, close it.** Settings → **Local model**
+points the session's CLI at a model you serve yourself — Ollama, LM Studio, or
+any OpenAI-compatible server — and then there is no code egress at all: no
+subscription, no API key, and nothing you type or edit crosses the network.
+Supported by `codex`, `aider` and `goose`, each of which has native local-model
+support, and it applies to *ingested* sessions too, so a ticket can go from
+assigned to committed without leaving the machine. `claude` speaks only the
+Anthropic API, so it has no local route — the screen and `mindflock doctor` both
+say so rather than letting a session quietly keep using it.
 
 ## What it looks like in use
 
@@ -165,9 +217,28 @@ PR-session count a floor.</sub>
 
 ## How is this different?
 
-Every tool below is a good way to *start* an AI coding session, and MindFlock is
-a good way to start one too — `+ New`, a repo, an agent, a prompt. The difference
-is that in MindFlock you don't *have* to: your tracker can do it for you.
+Two different families of tools each do half of what MindFlock does, and they
+sit on opposite sides of it.
+
+**The ticket-to-PR tools run in someone else's cloud.** Assigning an issue and
+getting a pull request back is no longer rare — it's a first-party feature at
+GitHub, Google, Atlassian and Linear. What every one of them has in common is
+that your repository is checked out on a machine you don't own.
+
+| | ticket → PR | where the agent runs | your repo is cloned to |
+|---|---|---|---|
+| **MindFlock** | **yes** | **your machine** | **nowhere — it's already there** |
+| Devin (Cognition) | yes | vendor sandbox | Cognition |
+| Google Jules | yes | vendor VM | Google |
+| GitHub Copilot coding agent | yes | GitHub Actions runner | GitHub |
+| Cursor background agents | yes | vendor sandbox | Cursor |
+| Atlassian Rovo Dev | yes | remote sandbox | Atlassian |
+
+**The local orchestrators make you start every session yourself.** Each one below
+is a good way to *start* an AI coding session, and MindFlock is a good way to
+start one too — `+ New`, a repo, an agent, a prompt. The difference is that in
+MindFlock you don't *have* to: your tracker can do it for you, and it still
+happens on your hardware.
 
 | | **MindFlock** | **Claude Squad** | **Conductor** | **Claude Code Agent Teams** |
 |---|---|---|---|---|
@@ -182,10 +253,17 @@ is that in MindFlock you don't *have* to: your tracker can do it for you.
 | Platforms | Linux, macOS, Windows (WSL2) | macOS, Linux | macOS only | Anywhere Claude Code runs |
 | Remote / phone control | **tailnet + QR, full action bar** | — | — | — |
 
-<sub>Comparison as of July 2026; these tools move fast. If a cell is out of date, please [open an issue or PR](CONTRIBUTING.md) and we'll correct it.</sub>
+<sub>Both comparisons are as of July 2026; these tools move fast. If a cell is out of date, please [open an issue or PR](CONTRIBUTING.md) and we'll correct it.</sub>
 
-The top two rows are the ones that matter. Everything else is a feature race;
-those two change what your day looks like:
+**Nothing in either table sits where MindFlock does** — the queue starts the
+session *and* the session runs on your hardware. Seven local orchestrators were
+checked for a personal assigned-ticket poller and none of them has one: the
+closest, Conductor, can open a workspace from a GitHub or Linear issue but needs
+a click per issue. That is a narrow claim about a fast-moving space rather than a
+moat, and it's exactly the kind of cell worth correcting if you find one.
+
+The top two rows of the second table are the ones that matter. Everything else is
+a feature race; those two change what your day looks like:
 
 - **Work comes to the agents.** MindFlock polls your tracker for tickets
   assigned to you and GitHub for your PRs that came back with review comments,
@@ -217,6 +295,10 @@ those two change what your day looks like:
 - **[Claude Squad](https://github.com/smtg-ai/claude-squad)** is a mature
   multi-agent TUI that also drives several CLIs. If you'd rather stay in the
   terminal than run a desktop app, it's the closer fit.
+- **The cloud tools, if you actually want the cloud.** Work continuing while
+  your laptop is shut, a fleet running against one backlog, someone else's
+  compute paying for the tokens — those are real advantages and MindFlock has
+  none of them. It trades all three for the repository never leaving your disk.
 
 ## Features
 
@@ -229,6 +311,13 @@ those two change what your day looks like:
   moves a ticket's status. **GitHub Issues needs no configuration at all** — the
   token comes from your existing `gh auth login` and the repo from this
   checkout's `origin`.
+- 🔒 **No cloud in the middle** — there is no MindFlock service, no account and
+  no vendor sandbox holding a copy of your repo. The engine binds `127.0.0.1`
+  unless you ask for tailnet mode, ships no analytics or telemetry of any kind,
+  and keeps tracker tokens at mode `0600` on your own disk. The one code egress
+  is your agent CLI's own call to its vendor — the one you were already making,
+  and one you can close entirely by pointing it at a local model.
+  [The full network inventory is above](#where-your-code-goes).
 - 🔀 **Guided git workflow** — one-click commit → push → PR → merge, with live
   workflow-stage badges
   (provisioning → agent → pre-commit → committed → pushed → PR open). The

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
-"""MindFlock — run a flock of AI coding agents, started by your ticket queue.
+"""MindFlock — a private flock of AI coding agents, started by your ticket queue.
 
 The version is single-sourced from ``pyproject.toml`` (the uv_build backend
 does not support dynamic metadata, so the static ``[project] version`` there

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -57,7 +57,10 @@ _NEW_POLL_S = 1.0
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="mindflock",
-        description="MindFlock — run a flock of AI coding agents, started by your ticket queue.",
+        description=(
+            "MindFlock — a private flock of AI coding agents, started by your "
+            "ticket queue, merged by you."
+        ),
     )
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"

--- a/backend/web/core/agent_state.py
+++ b/backend/web/core/agent_state.py
@@ -825,7 +825,13 @@ def _failed_precommit_step(title: str) -> Optional[str]:
     try:
         name = _server()._shell_tmux_name(title)
         cp = subprocess.run(
-            ["tmux", "capture-pane", "-p", "-S", "-400", "-t", name],
+            # -J joins tmux's wrapped lines. Without it a long error is captured
+            # as one line per PANE ROW, so the generic fallback below — which
+            # takes the LAST error-looking line — surfaced the tail of a wrapped
+            # line and the badge read as a mid-word fragment ("ffic-reduction'."
+            # out of "…'traffic-reduction'."). tmux.py and server.py already
+            # capture with -J for the same reason.
+            ["tmux", "capture-pane", "-p", "-J", "-S", "-400", "-t", name],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=10,

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22379,6 +22379,13 @@ function orderedSections(order) {
 function orderedBars(order) {
   return orderedSections(order).map((key) => BY_KEY.get(key)).filter((b) => !!b);
 }
+const SIDEBAR_MIN_W = 260;
+const SIDEBAR_MAX_W = 560;
+const SIDEBAR_DEFAULT_W = 260;
+function clampSidebarWidth(px) {
+  if (!isFinite(px)) return SIDEBAR_DEFAULT_W;
+  return Math.round(Math.min(SIDEBAR_MAX_W, Math.max(SIDEBAR_MIN_W, px)));
+}
 function load(key, fallback, parse = true) {
   try {
     const raw = localStorage.getItem(key);
@@ -22406,6 +22413,7 @@ const useUi = create((set, get) => ({
   viewMode: load("cs_viewmode", "auto", false),
   gridRows: load("cs_gridrows", []),
   sidebarHidden: load("cs_sidebar", "", false) === "hidden",
+  sidebarWidth: clampSidebarWidth(load("mf_sidebar_w", SIDEBAR_DEFAULT_W)),
   order: load("cs_order", []),
   mru: load("cs_mru", []),
   filter: "",
@@ -22451,6 +22459,12 @@ const useUi = create((set, get) => ({
     const hidden = !get().sidebarHidden;
     save("cs_sidebar", hidden ? "hidden" : "", false);
     set({ sidebarHidden: hidden });
+  },
+  setSidebarWidth: (px) => {
+    const w = clampSidebarWidth(px);
+    if (w === get().sidebarWidth) return;
+    save("mf_sidebar_w", w);
+    set({ sidebarWidth: w });
   },
   setOrder: (order) => {
     save("cs_order", order);
@@ -22876,6 +22890,10 @@ async function cleanupMissing(title) {
   toast("Session removed");
   await refreshInstances();
 }
+function clearStaleAlias(title) {
+  const ui = useUi.getState();
+  if (title && ui.aliases[title]) ui.setAlias(title, "");
+}
 function addPendingSession(base) {
   const taken = new Set(instances$1().map((i) => i.title));
   let title = base;
@@ -22884,6 +22902,7 @@ function addPendingSession(base) {
     while (taken.has(base + "-" + i)) i++;
     title = base + "-" + i;
   }
+  clearStaleAlias(title);
   const pending = { title, status: "loading", pending_create: true };
   queryClient.setQueryData(["instances"], (prev) => [...prev || [], pending]);
   return title;
@@ -22901,6 +22920,7 @@ async function copySession(title) {
   const guess = addPendingSession(title + "-copy");
   try {
     const inst = await instApi(title, "/copy", { method: "POST" });
+    if (inst == null ? void 0 : inst.title) clearStaleAlias(inst.title);
     await refreshInstances();
     if (inst == null ? void 0 : inst.title) selectSession(inst.title);
   } catch (err) {
@@ -23006,6 +23026,7 @@ async function resumeSession(title) {
   }
   await refreshInstances();
 }
+const STEP_BADGE_MAX = 24;
 const STAGE_META = {
   provisioning: { label: "provisioning" },
   agent: { label: "agent" },
@@ -23106,9 +23127,10 @@ function chipState(inst) {
   if (stage === "agent")
     return act === "offline" ? { label: "offline", cls: "s-offline", title: "Agent offline" } : { label: "idle", cls: "s-idle", title: "Agent is idle — waiting for input" };
   if (stage === "interrupt") {
-    const step = inst.failed_step;
+    const step = (inst.failed_step || "").trim();
+    const badgeable = !!step && step.length <= STEP_BADGE_MAX;
     return {
-      label: step ? "✗ " + step : "pre-commit ✗",
+      label: badgeable ? "✗ " + step : "pre-commit ✗",
       cls: "s-interrupt",
       title: step ? "Pre-commit failed at: " + step : "Pre-commit failed"
     };
@@ -24543,7 +24565,6 @@ function VoiceInput() {
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "mic-caption", className: caption == null ? "hidden" : "", children: caption || "" })
   ] });
 }
-const MAX_NAME = 20;
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -24555,16 +24576,13 @@ function branchTail(branch) {
   const parts = branch.split("/").filter(Boolean);
   return parts.length ? parts[parts.length - 1] : "";
 }
-function clip(name) {
-  return name.length > MAX_NAME ? name.slice(0, MAX_NAME - 1) + "…" : name;
-}
 function splitKind(title) {
   if (title.startsWith("pr-")) return { kind: "pr", slug: title.slice(3) };
   if (title.startsWith("issue-")) return { kind: "iss", slug: title.slice(6) };
   return null;
 }
 function sessionLabel(title, branch) {
-  const plain = { text: title, full: title, kind: "", name: "", slug: title };
+  const plain = { text: title, kind: "", name: "", slug: title };
   if (!title) return plain;
   const split = splitKind(title);
   const ticketName = split ? "" : featureBranchName(branch, title);
@@ -24575,8 +24593,7 @@ function sessionLabel(title, branch) {
   const name = split ? featureBranchName(branch, title) || branchTail(branch) : ticketName;
   const useName = name && name !== slug && name !== title ? name : "";
   return {
-    text: useName ? `(${kind}) ${clip(useName)}/${slug}` : `(${kind}) ${slug}`,
-    full: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
+    text: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
     kind,
     name: useName,
     slug
@@ -24758,7 +24775,7 @@ const SidebarRow = reactExports.memo(function SidebarRow2({
                 {
                   className: "title" + (alias ? " aliased" : ""),
                   title: [
-                    alias ? `${alias}  ·  ${label.full}` : label.full,
+                    alias ? `${alias}  ·  ${label.text}` : label.text,
                     // The real title is the identity behind a reformatted label —
                     // it's what every API path and `tmux attach` is keyed by.
                     label.kind ? `session: ${displayTitle(inst)}` : "",
@@ -24968,6 +24985,64 @@ function SessionFilter() {
       }
     )
   ] });
+}
+const STEP = 16;
+function SidebarResizer() {
+  const width = useUi((s) => s.sidebarWidth);
+  const setSidebarWidth = useUi((s) => s.setSidebarWidth);
+  const startX = reactExports.useRef(0);
+  const startW = reactExports.useRef(width);
+  const liveW = reactExports.useRef(width);
+  const paint = reactExports.useCallback((px) => {
+    liveW.current = px;
+    document.body.style.setProperty("--sidebar-w", px + "px");
+  }, []);
+  reactExports.useEffect(() => () => document.body.classList.remove("sidebar-resizing"), []);
+  const onPointerDown = (ev) => {
+    if (ev.button !== 0) return;
+    ev.preventDefault();
+    startX.current = ev.clientX;
+    startW.current = width;
+    liveW.current = width;
+    ev.currentTarget.setPointerCapture(ev.pointerId);
+    document.body.classList.add("sidebar-resizing");
+  };
+  const onPointerMove = (ev) => {
+    if (!ev.currentTarget.hasPointerCapture(ev.pointerId)) return;
+    paint(clampSidebarWidth(startW.current + (ev.clientX - startX.current)));
+  };
+  const endDrag = (ev) => {
+    if (!ev.currentTarget.hasPointerCapture(ev.pointerId)) return;
+    ev.currentTarget.releasePointerCapture(ev.pointerId);
+    document.body.classList.remove("sidebar-resizing");
+    setSidebarWidth(liveW.current);
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "div",
+    {
+      className: "sidebar-resizer",
+      role: "separator",
+      "aria-orientation": "vertical",
+      "aria-label": "Resize sidebar",
+      "aria-valuenow": width,
+      "aria-valuemin": SIDEBAR_MIN_W,
+      "aria-valuemax": SIDEBAR_MAX_W,
+      tabIndex: 0,
+      title: "Drag to resize · double-click to reset",
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: endDrag,
+      onPointerCancel: endDrag,
+      onDoubleClick: () => setSidebarWidth(SIDEBAR_DEFAULT_W),
+      onKeyDown: (ev) => {
+        if (ev.key === "ArrowLeft") setSidebarWidth(width - STEP);
+        else if (ev.key === "ArrowRight") setSidebarWidth(width + STEP);
+        else if (ev.key === "Home") setSidebarWidth(SIDEBAR_DEFAULT_W);
+        else return;
+        ev.preventDefault();
+      }
+    }
+  );
 }
 function BulkBar() {
   const { data: instances2 = [] } = useInstances();
@@ -26353,6 +26428,7 @@ function Sidebar({ onOpenChat, onOpenTodo }) {
   const countHead = isFinite(cap) && shownCount > cap ? `${cap} of ${shownCount} shown` : `${instances2.length} session${instances2.length === 1 ? "" : "s"}`;
   const searchVisible = instances2.length >= SEARCH_MIN || !!ui.filter;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { id: "sidebar", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SidebarResizer, {}),
     doctorWarn.failing && !doctorWarn.dismissed && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "doctor-warn", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "dw-text", children: "⚠ setup issues —" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -28603,6 +28679,7 @@ function NewSessionDialog() {
     closeDialog();
     try {
       const inst = await api("/api/instances", { json: body });
+      clearStaleAlias(inst.title);
       await refreshInstances();
       selectSession(inst.title);
     } catch (err) {
@@ -33530,7 +33607,7 @@ const SLIDES = [
     logo: true,
     title: "Welcome to MindFlock",
     body: /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-      "MindFlock runs a flock of AI coding agents, each in its own git worktree. Start one yourself with any agent CLI — or let a ticket assigned to you in Jira, Linear, GitHub Issues, Shortcut or Asana start it for you, with the ticket already seeded. Either way you review the diff and merge. This tour covers the basics and then walks you through connecting your accounts. You can skip it any time and replay it later from ",
+      "MindFlock runs a private flock of AI coding agents, each in its own git worktree, all of them on this machine — there is no MindFlock cloud and no account. Start one yourself with any agent CLI — or let a ticket assigned to you in Jira, Linear, GitHub Issues, Shortcut or Asana start it for you, with the ticket already seeded. Either way you review the diff and merge. This tour covers the basics and then walks you through connecting your accounts. You can skip it any time and replay it later from ",
       /* @__PURE__ */ jsxRuntimeExports.jsx("b", { children: "Settings → General" }),
       "."
     ] })
@@ -33832,6 +33909,9 @@ function App() {
     const t = setTimeout(() => window.dispatchEvent(new Event("resize")), 60);
     return () => clearTimeout(t);
   }, [ui.sidebarHidden]);
+  reactExports.useEffect(() => {
+    document.body.style.setProperty("--sidebar-w", ui.sidebarWidth + "px");
+  }, [ui.sidebarWidth]);
   reactExports.useEffect(() => {
     for (const inst of instances2 || []) noteActivity(inst);
   }, [instances2]);

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -635,7 +635,9 @@ body {
 
 body {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  /* --sidebar-w is written by App.tsx from the UI store (the sidebar's right
+     edge is draggable); the literal is the fallback before the first paint. */
+  grid-template-columns: var(--sidebar-w, 260px) 1fr;
   grid-template-rows: 1fr;
   height: 100vh;
   /* Reserve the top-bar strip; the fixed #topbar sits in this band, so the
@@ -965,6 +967,48 @@ body #mf-winctl {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Anchors .sidebar-resizer on the right edge. */
+  position: relative;
+}
+
+/* Resize handle on the sidebar's right edge. It overhangs into the grid's 10px
+   padding rather than sitting inside the sidebar, so it never steals clicks
+   from #instance-list's scrollbar; z-index lifts it over #grid, which is a
+   later sibling and would otherwise paint on top. */
+.sidebar-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 100%;
+  width: 8px;
+  margin-left: -2px;
+  z-index: 40;
+  cursor: col-resize;
+  /* The strip is invisible until hovered — the accent line is painted by the
+     :hover / :focus-visible rule below. */
+  background: transparent;
+  touch-action: none;
+}
+
+.sidebar-resizer:hover,
+.sidebar-resizer:focus-visible,
+body.sidebar-resizing .sidebar-resizer {
+  background: linear-gradient(
+    to right,
+    transparent 2px,
+    var(--accent) 2px,
+    var(--accent) 4px,
+    transparent 4px
+  );
+  outline: none;
+}
+
+/* While dragging, the cursor must not flicker back to a text caret as the
+   pointer crosses terminals, and nothing on the page should select. */
+body.sidebar-resizing,
+body.sidebar-resizing * {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 
 #sidebar header {
@@ -1017,6 +1061,12 @@ body.sidebar-collapsed {
 }
 
 body.sidebar-collapsed #sidebar {
+  display: none;
+}
+
+/* Nothing to resize when the column is gone (the handle would float over the
+   grid's left edge with no sidebar behind it). */
+body.sidebar-collapsed .sidebar-resizer {
   display: none;
 }
 
@@ -2855,24 +2905,43 @@ p.set-hint {
 .inst-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 9px 10px;
+  gap: 5px;
+  /* Left padding is the grip's lane: the grip is absolutely positioned (see
+     .inst .grip) so it costs the row no width, and this keeps it from landing
+     on top of the Alt+N number when it fades in. */
+  padding: 9px 8px 9px 12px;
   border-radius: 8px;
   cursor: pointer;
+  /* Anchors the grip to THIS row rather than to .inst, which also contains the
+     expanded actions menu (the grip would stretch down the whole card). */
+  position: relative;
 }
 
 .inst-row:hover {
   background: var(--panel-2);
 }
 
-/* Drag-to-reorder grip (sidebar) — appears on hover to keep the row clean. */
+/* Drag-to-reorder grip (sidebar) — the SAME affordance the movable bars use
+   (.bar-grip in toolbars.css): pinned to the hard left edge, out of flow so it
+   costs the row no width, invisible until the row is hovered.
+   Nothing is lost by hiding it: the whole <li> is draggable, so the grip is
+   pure signposting, and the row it signposts is the thing under the cursor. */
 .inst .grip {
-  flex: none;
+  position: absolute;
+  left: 1px;
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 10px;
+  overflow: hidden;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 10px;
   line-height: 1;
   cursor: grab;
-  opacity: 0.35;
+  opacity: 0;
   transition: opacity 0.12s ease;
   user-select: none;
   letter-spacing: -1px;
@@ -2882,6 +2951,10 @@ p.set-hint {
   opacity: 0.85;
 }
 
+.inst .grip:active {
+  cursor: grabbing;
+}
+
 .inst.dragging .grip {
   cursor: grabbing;
 }
@@ -2889,7 +2962,7 @@ p.set-hint {
 /* Alt+N number badge (first 9 rows). */
 .inst .idx {
   flex: none;
-  width: 13px;
+  width: 11px;
   text-align: center;
   font-size: 10px;
   color: var(--muted);
@@ -2956,13 +3029,28 @@ p.set-hint {
    illegible sliver while the title ellipsized even when space existed); the
    branch is capped at 40% of the row with its own ellipsis. */
 .inst .title {
-  font-size: 13px;
+  /* 12px, not the 13px body size: the row has to fit a grip, a number, a
+     status dot, a chevron, the stage chip and the ✕ alongside the name, and
+     ellipsizing the name is the thing that actually costs the user. */
+  font-size: 12px;
   font-weight: 600;
   flex: 1 1 auto;
   min-width: 34px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Sidebar chips size to their CONTENT rather than to the base 96px cap, so a
+   pill is never cut while the row still has room. They stay shrinkable as a
+   last resort, which is what keeps the row from ever overflowing: flex shrink
+   is proportional to base size, so the title (much wider) gives way first and
+   only stops at its min-width floor — by which point the pills have already
+   been shown in full. Below that the pills ellipsize too, but with a real "…". */
+.inst .stagechip {
+  max-width: none;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 /* A force-start the server accepted but hasn't turned into a session yet: it
@@ -2980,7 +3068,8 @@ p.set-hint {
   padding: 0 2px;
   margin: -1px 0;
   font-family: inherit;
-  font-size: 13px;
+  /* Matches .inst .title exactly, or the row height jumps on rename. */
+  font-size: 12px;
   font-weight: 600;
   color: var(--text);
   background: var(--bg);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,6 +61,13 @@ export default function App() {
     return () => clearTimeout(t);
   }, [ui.sidebarHidden]);
 
+  // Sidebar width (dragged from its right edge) drives the body grid column.
+  // SidebarResizer writes the var directly while dragging; this is what makes
+  // the committed width survive a reload.
+  useEffect(() => {
+    document.body.style.setProperty("--sidebar-w", ui.sidebarWidth + "px");
+  }, [ui.sidebarWidth]);
+
   // Feed the activity debounce on every poll.
   useEffect(() => {
     for (const inst of instances || []) noteActivity(inst);

--- a/frontend/src/__tests__/sessionLabel.test.ts
+++ b/frontend/src/__tests__/sessionLabel.test.ts
@@ -35,11 +35,14 @@ describe("sessionLabel", () => {
     expect(sessionLabel("pr-app-42", "pr-app-42").text).toBe("(pr) app-42");
   });
 
-  it("clips a long feature name in the row but not in the tooltip", () => {
+  it("never clips a long feature name — CSS ellipsis owns that call", () => {
     const long = "rework-the-entire-billing-pipeline";
     const l = sessionLabel("sc-9", `feature/sc-9/${long}`);
-    expect(l.text).toBe("(tix) rework-the-entire-b…/sc-9");
-    expect(l.full).toBe(`(tix) ${long}/sc-9`);
+    // A JS character budget can't know how wide the sidebar is right now, so it
+    // put a "…" in names that had room to spare. The row ellipsizes instead.
+    expect(l.text).toBe(`(tix) ${long}/sc-9`);
+    expect(l.text).not.toContain("…");
+    expect(l.name).toBe(long);
   });
 
   it("survives regex-special characters in a title", () => {

--- a/frontend/src/__tests__/sidebar.test.ts
+++ b/frontend/src/__tests__/sidebar.test.ts
@@ -1,0 +1,86 @@
+/** Sidebar width clamping (the draggable right edge) and the alias reset that
+ * keeps a newly created session from wearing a closed one's rename. */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  SIDEBAR_DEFAULT_W,
+  SIDEBAR_MAX_W,
+  SIDEBAR_MIN_W,
+  clampSidebarWidth,
+  useUi,
+} from "../state/store";
+import { addPendingSession } from "../lib/sessionActions";
+import { queryClient } from "../state/queries";
+import type { Instance } from "../api/types";
+
+describe("clampSidebarWidth", () => {
+  it("keeps a width inside the bounds untouched (rounded to whole px)", () => {
+    expect(clampSidebarWidth(320)).toBe(320);
+    expect(clampSidebarWidth(320.4)).toBe(320);
+  });
+
+  it("clamps a drag past either bound", () => {
+    expect(clampSidebarWidth(10)).toBe(SIDEBAR_MIN_W);
+    expect(clampSidebarWidth(4000)).toBe(SIDEBAR_MAX_W);
+  });
+
+  it("floors at the default, so dragging can only widen the sidebar", () => {
+    // Narrower than 260 spills the stage chip and ✕ past the sidebar's edge and
+    // crushes the name to a couple of characters.
+    expect(SIDEBAR_MIN_W).toBe(SIDEBAR_DEFAULT_W);
+    expect(clampSidebarWidth(200)).toBe(SIDEBAR_DEFAULT_W);
+    // A width persisted under an older, lower floor is raised on load.
+    expect(clampSidebarWidth(259)).toBe(SIDEBAR_DEFAULT_W);
+  });
+
+  it("falls back to the default for a non-finite width (corrupt storage)", () => {
+    // No drag can produce these — only a hand-edited/corrupt mf_sidebar_w — so
+    // they reset rather than pinning the column to a bound.
+    expect(clampSidebarWidth(NaN)).toBe(SIDEBAR_DEFAULT_W);
+    expect(clampSidebarWidth(Infinity)).toBe(SIDEBAR_DEFAULT_W);
+    expect(clampSidebarWidth(-Infinity)).toBe(SIDEBAR_DEFAULT_W);
+  });
+});
+
+describe("setSidebarWidth", () => {
+  it("stores the clamped value", () => {
+    useUi.getState().setSidebarWidth(9999);
+    expect(useUi.getState().sidebarWidth).toBe(SIDEBAR_MAX_W);
+    useUi.getState().setSidebarWidth(300);
+    expect(useUi.getState().sidebarWidth).toBe(300);
+  });
+});
+
+describe("addPendingSession", () => {
+  const rows = (titles: string[]) =>
+    queryClient.setQueryData<Instance[]>(
+      ["instances"],
+      titles.map((t) => ({ title: t }) as unknown as Instance)
+    );
+
+  beforeEach(() => {
+    rows([]);
+    for (const t of Object.keys(useUi.getState().aliases))
+      useUi.getState().setAlias(t, "");
+  });
+
+  it("numbers around titles already taken (mirrors the server)", () => {
+    rows(["foo-copy", "foo-copy-2"]);
+    expect(addPendingSession("foo-copy")).toBe("foo-copy-3");
+  });
+
+  it("drops a stale alias so a reused title is not named after a dead session", () => {
+    // The user duplicated `foo` before, renamed the copy, then closed it. The
+    // alias survives (a reopened session keeps its name) — but the NEXT
+    // `foo-copy` is a different session and must read as itself.
+    useUi.getState().setAlias("foo-copy", "Belisa's old scratch window");
+    expect(addPendingSession("foo-copy")).toBe("foo-copy");
+    expect(useUi.getState().aliases["foo-copy"]).toBeUndefined();
+  });
+
+  it("leaves aliases for other titles alone", () => {
+    useUi.getState().setAlias("bar", "keep me");
+    addPendingSession("foo-copy");
+    expect(useUi.getState().aliases["bar"]).toBe("keep me");
+  });
+});

--- a/frontend/src/__tests__/stage.test.ts
+++ b/frontend/src/__tests__/stage.test.ts
@@ -53,6 +53,24 @@ describe("chipState (persistent status chip)", () => {
       "✗ typecheck"
     );
   });
+
+  it("badges a hook NAME but keeps a line of hook output in the tooltip", () => {
+    // The server's generic fallback can return a whole output line (up to 80
+    // chars). Pills are never truncated, so a sentence has to stay out of one.
+    const line =
+      "branch 'feature/sc-20834/token-saving-and-traffic-reduction' set up to track ...";
+    const c = chipState(
+      inst({ title: "a7", stage: "interrupt", activity: "idle", failed_step: line })
+    );
+    expect(c.label).toBe("pre-commit ✗");
+    expect(c.title).toContain(line);
+
+    // "Run Tests (+3)" is a name, spaces and all — it still gets badged.
+    expect(
+      chipState(inst({ title: "a8", stage: "interrupt", activity: "idle", failed_step: "Run Tests (+3)" }))
+        .label
+    ).toBe("✗ Run Tests (+3)");
+  });
 });
 
 describe("checkChip (verification gate)", () => {

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -11,6 +11,7 @@ import { useUi } from "../../state/store";
 import { toast } from "../../lib/toast";
 import {
   addPendingSession,
+  clearStaleAlias,
   failPendingSession,
   selectSession,
 } from "../../lib/sessionActions";
@@ -179,6 +180,9 @@ export function NewSessionDialog() {
     closeDialog();
     try {
       const inst = await api<Instance>("/api/instances", { json: body });
+      // Same reason as the guess in addPendingSession: the server's real title
+      // must not arrive wearing a closed session's rename.
+      clearStaleAlias(inst.title);
       await refreshInstances();
       selectSession(inst.title);
     } catch (err) {

--- a/frontend/src/components/onboarding/WelcomeTour.tsx
+++ b/frontend/src/components/onboarding/WelcomeTour.tsx
@@ -28,10 +28,12 @@ const SLIDES: Slide[] = [
     title: "Welcome to MindFlock",
     body: (
       <>
-        MindFlock runs a flock of AI coding agents, each in its own git worktree.
-        Start one yourself with any agent CLI — or let a ticket assigned to you in
-        Jira, Linear, GitHub Issues, Shortcut or Asana start it for you, with the
-        ticket already seeded. Either way you review the diff and merge. This tour
+        MindFlock runs a private flock of AI coding agents, each in its own git
+        worktree, all of them on this machine — there is no MindFlock cloud and no
+        account. Start one yourself with any agent CLI — or let a ticket assigned
+        to you in Jira, Linear, GitHub Issues, Shortcut or Asana start it for you,
+        with the ticket already seeded. Either way you review the diff and merge.
+        This tour
         covers the basics and then walks you through connecting your accounts. You
         can skip it any time and replay it later from <b>Settings → General</b>.
       </>

--- a/frontend/src/components/sidebar/Sidebar.css
+++ b/frontend/src/components/sidebar/Sidebar.css
@@ -9,6 +9,48 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Anchors .sidebar-resizer on the right edge. */
+  position: relative;
+}
+
+/* Resize handle on the sidebar's right edge. It overhangs into the grid's 10px
+   padding rather than sitting inside the sidebar, so it never steals clicks
+   from #instance-list's scrollbar; z-index lifts it over #grid, which is a
+   later sibling and would otherwise paint on top. */
+.sidebar-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 100%;
+  width: 8px;
+  margin-left: -2px;
+  z-index: 40;
+  cursor: col-resize;
+  /* The strip is invisible until hovered — the accent line is painted by the
+     :hover / :focus-visible rule below. */
+  background: transparent;
+  touch-action: none;
+}
+
+.sidebar-resizer:hover,
+.sidebar-resizer:focus-visible,
+body.sidebar-resizing .sidebar-resizer {
+  background: linear-gradient(
+    to right,
+    transparent 2px,
+    var(--accent) 2px,
+    var(--accent) 4px,
+    transparent 4px
+  );
+  outline: none;
+}
+
+/* While dragging, the cursor must not flicker back to a text caret as the
+   pointer crosses terminals, and nothing on the page should select. */
+body.sidebar-resizing,
+body.sidebar-resizing * {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 
 #sidebar header {
@@ -61,6 +103,12 @@ body.sidebar-collapsed {
 }
 
 body.sidebar-collapsed #sidebar {
+  display: none;
+}
+
+/* Nothing to resize when the column is gone (the handle would float over the
+   grid's left edge with no sidebar behind it). */
+body.sidebar-collapsed .sidebar-resizer {
   display: none;
 }
 

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import { toast } from "../../lib/toast";
 import { viewCap } from "../grid/layout";
 import { SidebarRow } from "./SidebarRow";
 import { SessionFilter } from "./SessionFilter";
+import { SidebarResizer } from "./SidebarResizer";
 import { BulkBar } from "./BulkBar";
 import { BarSlot, barContent, SECTION_MIME } from "./SidebarBars";
 import { orderedSections, SESSIONS_KEY } from "./barDefs";
@@ -177,6 +178,7 @@ export function Sidebar({ onOpenChat, onOpenTodo }: Props) {
 
   return (
     <aside id="sidebar">
+      <SidebarResizer />
       {doctorWarn.failing && !doctorWarn.dismissed && (
         <div id="doctor-warn">
           <span className="dw-text">⚠ setup issues —</span>

--- a/frontend/src/components/sidebar/SidebarResizer.tsx
+++ b/frontend/src/components/sidebar/SidebarResizer.tsx
@@ -1,0 +1,92 @@
+/** Drag handle on the sidebar's right edge.
+ *
+ * The sidebar was a fixed 260px, which made long session labels ellipsize while
+ * the agent panes had width to spare (or the other way round on a big screen).
+ * The width lives in the UI store, so it persists across reloads; the panes
+ * refit their terminals on their own (Pane's ResizeObserver), so nothing here
+ * has to know about xterm.
+ *
+ * During the drag the CSS var is written DIRECTLY and the store is left alone —
+ * committing on every pointermove would mean a synchronous localStorage write
+ * per frame. The store is updated once on release, which re-asserts the var
+ * through App's effect. */
+
+import { useCallback, useEffect, useRef } from "react";
+import {
+  SIDEBAR_DEFAULT_W,
+  SIDEBAR_MAX_W,
+  SIDEBAR_MIN_W,
+  clampSidebarWidth,
+  useUi,
+} from "../../state/store";
+
+/** How far one arrow-key press moves the edge. */
+const STEP = 16;
+
+export function SidebarResizer() {
+  const width = useUi((s) => s.sidebarWidth);
+  const setSidebarWidth = useUi((s) => s.setSidebarWidth);
+  // Drag origin (pointer x + width at pointerdown) and the width the pointer is
+  // currently over — read on release, so a drag that ends outside the window
+  // still commits the last width the user actually saw.
+  const startX = useRef(0);
+  const startW = useRef(width);
+  const liveW = useRef(width);
+
+  const paint = useCallback((px: number) => {
+    liveW.current = px;
+    document.body.style.setProperty("--sidebar-w", px + "px");
+  }, []);
+
+  // Body class drives the global col-resize cursor + selection lock; make sure
+  // an unmount mid-drag can't leave the page stuck in it.
+  useEffect(() => () => document.body.classList.remove("sidebar-resizing"), []);
+
+  const onPointerDown = (ev: React.PointerEvent<HTMLDivElement>) => {
+    if (ev.button !== 0) return;
+    ev.preventDefault();
+    startX.current = ev.clientX;
+    startW.current = width;
+    liveW.current = width;
+    ev.currentTarget.setPointerCapture(ev.pointerId);
+    document.body.classList.add("sidebar-resizing");
+  };
+
+  const onPointerMove = (ev: React.PointerEvent<HTMLDivElement>) => {
+    if (!ev.currentTarget.hasPointerCapture(ev.pointerId)) return;
+    paint(clampSidebarWidth(startW.current + (ev.clientX - startX.current)));
+  };
+
+  const endDrag = (ev: React.PointerEvent<HTMLDivElement>) => {
+    if (!ev.currentTarget.hasPointerCapture(ev.pointerId)) return;
+    ev.currentTarget.releasePointerCapture(ev.pointerId);
+    document.body.classList.remove("sidebar-resizing");
+    setSidebarWidth(liveW.current);
+  };
+
+  return (
+    <div
+      className="sidebar-resizer"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      aria-valuenow={width}
+      aria-valuemin={SIDEBAR_MIN_W}
+      aria-valuemax={SIDEBAR_MAX_W}
+      tabIndex={0}
+      title="Drag to resize · double-click to reset"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onDoubleClick={() => setSidebarWidth(SIDEBAR_DEFAULT_W)}
+      onKeyDown={(ev) => {
+        if (ev.key === "ArrowLeft") setSidebarWidth(width - STEP);
+        else if (ev.key === "ArrowRight") setSidebarWidth(width + STEP);
+        else if (ev.key === "Home") setSidebarWidth(SIDEBAR_DEFAULT_W);
+        else return;
+        ev.preventDefault();
+      }}
+    />
+  );
+}

--- a/frontend/src/components/sidebar/SidebarRow.css
+++ b/frontend/src/components/sidebar/SidebarRow.css
@@ -38,24 +38,43 @@
 .inst-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 9px 10px;
+  gap: 5px;
+  /* Left padding is the grip's lane: the grip is absolutely positioned (see
+     .inst .grip) so it costs the row no width, and this keeps it from landing
+     on top of the Alt+N number when it fades in. */
+  padding: 9px 8px 9px 12px;
   border-radius: 8px;
   cursor: pointer;
+  /* Anchors the grip to THIS row rather than to .inst, which also contains the
+     expanded actions menu (the grip would stretch down the whole card). */
+  position: relative;
 }
 
 .inst-row:hover {
   background: var(--panel-2);
 }
 
-/* Drag-to-reorder grip (sidebar) — appears on hover to keep the row clean. */
+/* Drag-to-reorder grip (sidebar) — the SAME affordance the movable bars use
+   (.bar-grip in toolbars.css): pinned to the hard left edge, out of flow so it
+   costs the row no width, invisible until the row is hovered.
+   Nothing is lost by hiding it: the whole <li> is draggable, so the grip is
+   pure signposting, and the row it signposts is the thing under the cursor. */
 .inst .grip {
-  flex: none;
+  position: absolute;
+  left: 1px;
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 10px;
+  overflow: hidden;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 10px;
   line-height: 1;
   cursor: grab;
-  opacity: 0.35;
+  opacity: 0;
   transition: opacity 0.12s ease;
   user-select: none;
   letter-spacing: -1px;
@@ -65,6 +84,10 @@
   opacity: 0.85;
 }
 
+.inst .grip:active {
+  cursor: grabbing;
+}
+
 .inst.dragging .grip {
   cursor: grabbing;
 }
@@ -72,7 +95,7 @@
 /* Alt+N number badge (first 9 rows). */
 .inst .idx {
   flex: none;
-  width: 13px;
+  width: 11px;
   text-align: center;
   font-size: 10px;
   color: var(--muted);
@@ -139,13 +162,28 @@
    illegible sliver while the title ellipsized even when space existed); the
    branch is capped at 40% of the row with its own ellipsis. */
 .inst .title {
-  font-size: 13px;
+  /* 12px, not the 13px body size: the row has to fit a grip, a number, a
+     status dot, a chevron, the stage chip and the ✕ alongside the name, and
+     ellipsizing the name is the thing that actually costs the user. */
+  font-size: 12px;
   font-weight: 600;
   flex: 1 1 auto;
   min-width: 34px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Sidebar chips size to their CONTENT rather than to the base 96px cap, so a
+   pill is never cut while the row still has room. They stay shrinkable as a
+   last resort, which is what keeps the row from ever overflowing: flex shrink
+   is proportional to base size, so the title (much wider) gives way first and
+   only stops at its min-width floor — by which point the pills have already
+   been shown in full. Below that the pills ellipsize too, but with a real "…". */
+.inst .stagechip {
+  max-width: none;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 /* A force-start the server accepted but hasn't turned into a session yet: it
@@ -163,7 +201,8 @@
   padding: 0 2px;
   margin: -1px 0;
   font-family: inherit;
-  font-size: 13px;
+  /* Matches .inst .title exactly, or the row height jumps on rename. */
+  font-size: 12px;
   font-weight: 600;
   color: var(--text);
   background: var(--bg);

--- a/frontend/src/components/sidebar/SidebarRow.tsx
+++ b/frontend/src/components/sidebar/SidebarRow.tsx
@@ -256,7 +256,7 @@ export const SidebarRow = memo(function SidebarRow({
             <span
               className={"title" + (alias ? " aliased" : "")}
               title={[
-                alias ? `${alias}  ·  ${label.full}` : label.full,
+                alias ? `${alias}  ·  ${label.text}` : label.text,
                 // The real title is the identity behind a reformatted label —
                 // it's what every API path and `tmux attach` is keyed by.
                 label.kind ? `session: ${displayTitle(inst)}` : "",

--- a/frontend/src/lib/sessionActions.ts
+++ b/frontend/src/lib/sessionActions.ts
@@ -239,6 +239,20 @@ export async function cleanupMissing(title: string) {
   await refreshInstances();
 }
 
+/** A brand-new session must not wear a dead one's name.
+ *
+ * Renames are client-side aliases keyed by title, and they deliberately OUTLIVE
+ * the session — a closed session can be reopened (Ctrl+Shift+T) and should come
+ * back with the name the user gave it. The cost is that a REUSED title inherits
+ * the alias: duplicating hit this every time, because the second `foo-copy`
+ * picked up whatever the first `foo-copy` had been renamed to, and the new row
+ * read as some unrelated session from last week. So creating a title drops any
+ * alias left over for it. */
+export function clearStaleAlias(title: string) {
+  const ui = useUi.getState();
+  if (title && ui.aliases[title]) ui.setAlias(title, "");
+}
+
 /** Optimistic "provisioning" row for create/duplicate (mirrors the server's
  * _unique_title numbering; a mismatch resolves on the next poll). */
 export function addPendingSession(base: string): string {
@@ -249,6 +263,7 @@ export function addPendingSession(base: string): string {
     while (taken.has(base + "-" + i)) i++;
     title = base + "-" + i;
   }
+  clearStaleAlias(title);
   const pending = { title, status: "loading", pending_create: true } as unknown as Instance;
   queryClient.setQueryData<Instance[]>(["instances"], (prev) => [...(prev || []), pending]);
   return title;
@@ -268,6 +283,9 @@ export async function copySession(title: string) {
   const guess = addPendingSession(title + "-copy");
   try {
     const inst = await instApi<Instance>(title, "/copy", { method: "POST" });
+    // The server picks the real title (its own -copy/-copy-2 numbering), which
+    // can differ from the optimistic guess — so clear that one's alias too.
+    if (inst?.title) clearStaleAlias(inst.title);
     await refreshInstances();
     if (inst?.title) selectSession(inst.title);
   } catch (err) {

--- a/frontend/src/lib/sessionLabel.ts
+++ b/frontend/src/lib/sessionLabel.ts
@@ -18,17 +18,12 @@
  * along in the row's tooltip.
  */
 
-/** How much of the feature name survives in the row text. The name is the
- * flexible part and the slug is the identifying part, so a long name is
- * clipped here rather than being allowed to push the slug into the row's
- * ellipsis. The tooltip always carries the full thing. */
-const MAX_NAME = 20;
-
 export interface SessionLabel {
-  /** "(tix) add-dark-mode/sc-12345", or the plain title when not a pipeline session. */
+  /** "(tix) add-dark-mode/sc-12345", or the plain title when not a pipeline
+   * session. Never truncated: how much fits is a question about the width of
+   * the sidebar right now, which only CSS knows, so the row ellipsizes this
+   * with `text-overflow` instead of a JS character budget guessing at it. */
   text: string;
-  /** Same as {@link text} but with the feature name never clipped — for tooltips. */
-  full: string;
   /** Kind tag without parens ("tix" | "pr" | "iss"), or "" for plain sessions. */
   kind: string;
   /** Feature name, un-clipped ("add-dark-mode"), or "" when none was derivable. */
@@ -54,10 +49,6 @@ function branchTail(branch: string): string {
   return parts.length ? parts[parts.length - 1] : "";
 }
 
-function clip(name: string): string {
-  return name.length > MAX_NAME ? name.slice(0, MAX_NAME - 1) + "…" : name;
-}
-
 /** Split a session title into its kind tag and identifying slug. */
 function splitKind(title: string): { kind: string; slug: string } | null {
   if (title.startsWith("pr-")) return { kind: "pr", slug: title.slice(3) };
@@ -71,7 +62,7 @@ function splitKind(title: string): { kind: string; slug: string } | null {
  * @param branch The session's branch, which is where the feature name lives.
  */
 export function sessionLabel(title: string, branch: string): SessionLabel {
-  const plain: SessionLabel = { text: title, full: title, kind: "", name: "", slug: title };
+  const plain: SessionLabel = { text: title, kind: "", name: "", slug: title };
   if (!title) return plain;
 
   const split = splitKind(title);
@@ -91,8 +82,7 @@ export function sessionLabel(title: string, branch: string): SessionLabel {
   const useName = name && name !== slug && name !== title ? name : "";
 
   return {
-    text: useName ? `(${kind}) ${clip(useName)}/${slug}` : `(${kind}) ${slug}`,
-    full: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
+    text: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
     kind,
     name: useName,
     slug,

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -15,6 +15,10 @@ import {
   pushSession,
 } from "./sessionActions";
 
+/** Longest `failed_step` that still reads as a hook NAME rather than a line of
+ * output, and so still belongs in the stage pill. "Run Tests (+3)" is 14. */
+const STEP_BADGE_MAX = 24;
+
 const STAGE_META: Record<string, { label: string }> = {
   provisioning: { label: "provisioning" },
   agent: { label: "agent" },
@@ -162,9 +166,16 @@ export function chipState(inst: Partial<Instance>): ChipState {
       ? { label: "offline", cls: "s-offline", title: "Agent offline" }
       : { label: "idle", cls: "s-idle", title: "Agent is idle — waiting for input" };
   if (stage === "interrupt") {
-    const step = inst.failed_step;
+    const step = (inst.failed_step || "").trim();
+    // A pre-commit hook NAME is pill-sized ("ruff", "Run Tests (+3)"), and that
+    // is what the badge is for. The server's generic fallback can instead hand
+    // back a whole line of hook output (up to 80 chars) — real detail, but not a
+    // pill: badging it would either overflow the row or force the chip to be
+    // truncated, and a truncated pill is exactly what we don't want. So long
+    // details ride in the tooltip and the badge stays generic.
+    const badgeable = !!step && step.length <= STEP_BADGE_MAX;
     return {
-      label: step ? "✗ " + step : "pre-commit ✗",
+      label: badgeable ? "✗ " + step : "pre-commit ✗",
       cls: "s-interrupt",
       title: step ? "Pre-commit failed at: " + step : "Pre-commit failed",
     };

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -10,6 +10,26 @@ import { defaultHiddenBars } from "../components/sidebar/barDefs";
 
 export type ViewMode = "auto" | "2" | "4" | "9";
 
+/** Sidebar width bounds (px).
+ *
+ * The floor is the width the sidebar shipped at for its whole life, and it is a
+ * floor rather than a suggestion because narrower genuinely breaks the row: the
+ * intrinsic minimum of a row (number + dot + chevron + the title's 34px legible
+ * floor + a 96px stage chip + ✕) is ~240px, so below that the chip and the ✕
+ * spill past the sidebar's edge and the name collapses to two characters.
+ * Dragging can only make the sidebar WIDER — which is the direction anyone
+ * reaches for the handle to go anyway.
+ *
+ * The ceiling stops a drag from squeezing the agent panes it exists beside. */
+export const SIDEBAR_MIN_W = 260;
+export const SIDEBAR_MAX_W = 560;
+export const SIDEBAR_DEFAULT_W = 260;
+
+export function clampSidebarWidth(px: number): number {
+  if (!isFinite(px)) return SIDEBAR_DEFAULT_W;
+  return Math.round(Math.min(SIDEBAR_MAX_W, Math.max(SIDEBAR_MIN_W, px)));
+}
+
 function load<T>(key: string, fallback: T, parse = true): T {
   try {
     const raw = localStorage.getItem(key);
@@ -63,6 +83,8 @@ interface UiState {
   /** Persisted row layout: array of arrays of titles. */
   gridRows: string[][];
   sidebarHidden: boolean;
+  /** Sidebar column width in px (drag the right edge; SIDEBAR_MIN_W…MAX_W). */
+  sidebarWidth: number;
   /** User drag order of sidebar rows (stable; selection never reorders). */
   order: string[];
   /** Most-recently-used order (selection updates it; fills fixed views). */
@@ -109,6 +131,8 @@ interface UiState {
   setViewMode(v: ViewMode): void;
   setGridRows(rows: string[][]): void;
   toggleSidebar(): void;
+  /** Set the sidebar width (clamped + persisted). */
+  setSidebarWidth(px: number): void;
   setOrder(order: string[]): void;
   moveInOrder(title: string, before: string | null): void;
   setFilter(f: string): void;
@@ -140,6 +164,7 @@ export const useUi = create<UiState>((set, get) => ({
   viewMode: load<ViewMode>("cs_viewmode", "auto", false),
   gridRows: load<string[][]>("cs_gridrows", []),
   sidebarHidden: load<string>("cs_sidebar", "", false) === "hidden",
+  sidebarWidth: clampSidebarWidth(load<number>("mf_sidebar_w", SIDEBAR_DEFAULT_W)),
   order: load<string[]>("cs_order", []),
   mru: load<string[]>("cs_mru", []),
   filter: "",
@@ -186,6 +211,12 @@ export const useUi = create<UiState>((set, get) => ({
     const hidden = !get().sidebarHidden;
     save("cs_sidebar", hidden ? "hidden" : "", false);
     set({ sidebarHidden: hidden });
+  },
+  setSidebarWidth: (px) => {
+    const w = clampSidebarWidth(px);
+    if (w === get().sidebarWidth) return;
+    save("mf_sidebar_w", w);
+    set({ sidebarWidth: w });
   },
   setOrder: (order) => {
     save("cs_order", order);

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -15,7 +15,9 @@ body {
 
 body {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  /* --sidebar-w is written by App.tsx from the UI store (the sidebar's right
+     edge is draggable); the literal is the fallback before the first paint. */
+  grid-template-columns: var(--sidebar-w, 260px) 1fr;
   grid-template-rows: 1fr;
   height: 100vh;
   /* Reserve the top-bar strip; the fixed #topbar sits in this band, so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mindflock"
 version = "0.1.8"
-description = "MindFlock — run a flock of AI coding agents, each in its own git worktree; started by your ticket queue (Jira, Linear, GitHub Issues, Shortcut, Asana), merged by you"
+description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [

--- a/tests/unit/test_frontend_sidebar_resize.py
+++ b/tests/unit/test_frontend_sidebar_resize.py
@@ -1,0 +1,150 @@
+"""Resizable sidebar + tighter session rows: structural contract checks.
+
+Same style as test_frontend_wave4.py — the live UI is verified with
+screenshots/CDP; these pin the markup hooks, JS wiring, and CSS rules so a
+future refactor can't silently give the fixed-260px sidebar back.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.web import server
+
+client = TestClient(server.app)
+
+
+def _rule(css: str, selector: str) -> str:
+    """The declarations of `selector`'s block (the bundle is unminified).
+
+    Anchored at a line start so a short selector can't match the tail of a
+    longer one (plain "body" would otherwise land in ".pane-body").
+    """
+    start = css.index("\n" + selector + " {")
+    return css[start : css.index("}", start)]
+
+
+# --------------------------------------------------------------------------- #
+# The sidebar column is user-sized (Belisa: "allow me to resize this left bar")
+# --------------------------------------------------------------------------- #
+
+
+def test_body_grid_reads_the_sidebar_width_var():
+    """The column width is a CSS var, not the old hard-coded 260px. The literal
+    survives only as the pre-first-paint fallback."""
+    css = client.get("/style.css").text
+    assert "grid-template-columns: var(--sidebar-w, 260px) 1fr" in css
+    # The old fixed column is gone from the page skeleton.
+    assert "grid-template-columns: 260px 1fr" not in css
+
+
+def test_sidebar_has_a_resize_handle():
+    css = client.get("/style.css").text
+    # The handle is positioned against the sidebar, so the sidebar anchors it.
+    assert "position: relative" in _rule(css, "#sidebar")
+    handle = _rule(css, ".sidebar-resizer")
+    assert "cursor: col-resize" in handle
+    assert "position: absolute" in handle
+    # Overhangs into the grid's padding instead of covering the session list's
+    # scrollbar, and paints above #grid (a later sibling).
+    assert "left: 100%" in handle
+    assert "z-index: 40" in handle
+
+
+def test_resize_handle_is_wired_to_the_persisted_store():
+    js = client.get("/app.js").text
+    assert "sidebar-resizer" in js
+    assert "setSidebarWidth" in js
+    assert "mf_sidebar_w" in js  # survives a reload
+    assert "--sidebar-w" in js
+    # Keyboard-operable and announced, not mouse-only.
+    assert '"Resize sidebar"' in js
+    assert "aria-orientation" in js or "ariaOrientation" in js
+
+
+def test_collapsed_sidebar_hides_the_handle():
+    """Ctrl+B drops the whole column; a handle floating over the grid's left
+    edge with no sidebar behind it would resize nothing."""
+    css = client.get("/style.css").text
+    assert "display: none" in _rule(css, "body.sidebar-collapsed .sidebar-resizer")
+
+
+def test_drag_locks_the_cursor_and_selection():
+    css = client.get("/style.css").text
+    dragging = _rule(css, "body.sidebar-resizing,\nbody.sidebar-resizing *")
+    assert "cursor: col-resize !important" in dragging
+    assert "user-select: none !important" in dragging
+
+
+# --------------------------------------------------------------------------- #
+# Row density: more of the name fits on the line
+# --------------------------------------------------------------------------- #
+
+
+def test_row_title_is_smaller_than_body_text():
+    """13px → 12px: the row carries a grip, a number, a dot, a chevron, the
+    stage chip and ✕ alongside the name, and the name is what gets ellipsized."""
+    css = client.get("/style.css").text
+    assert "font-size: 12px" in _rule(css, ".inst .title")
+    # The inline rename input must match, or the row height jumps mid-edit.
+    assert "font-size: 12px" in _rule(css, ".inst input.title-edit")
+
+
+def test_row_grip_is_hover_only_and_out_of_flow():
+    """The row grip behaves exactly like the movable bars' .bar-grip: pinned to
+    the hard left edge, absolutely positioned so it costs the row no width, and
+    invisible until the row is hovered. The whole <li> is draggable, so hiding
+    the grip at rest costs no function."""
+    css = client.get("/style.css").text
+    grip = _rule(css, ".inst .grip")
+    assert "position: absolute" in grip
+    assert "left: 1px" in grip
+    assert "opacity: 0;" in grip  # not 0.35 — fully hidden at rest
+    assert "opacity: 0.85" in _rule(css, ".inst-row:hover .grip")
+    assert '"grip"' in client.get("/app.js").text
+
+
+def test_row_reserves_a_lane_for_the_grip():
+    """The grip fades in over the row's left padding, not over the Alt+N
+    number, and the row anchors it (not .inst, which also holds the expanded
+    actions menu)."""
+    row = _rule(client.get("/style.css").text, ".inst-row")
+    assert "padding: 9px 8px 9px 12px" in row
+    assert "position: relative" in row
+
+
+def test_sidebar_pills_size_to_content_not_a_fixed_cap():
+    """A pill is never cut while the row still has room: the sidebar chips drop
+    the base 96px cap and size to their content. They stay shrinkable, which is
+    what keeps the row from overflowing — the title (far wider, same shrink
+    factor) gives way first and stops at its floor."""
+    css = client.get("/style.css").text
+    chip = _rule(css, ".inst .stagechip")
+    assert "max-width: none" in chip
+    assert "flex: 0 1 auto" in chip
+    assert "min-width: 0" in chip
+    # The shared base still caps chips OUTSIDE the sidebar (pane headers).
+    assert "max-width: 96px" in _rule(css, ".stagechip")
+    # If a pill does have to shrink, it ellipsizes rather than hard-clipping.
+    base = _rule(css, ".stagechip")
+    assert "text-overflow: ellipsis" in base
+    assert "white-space: nowrap" in base
+
+
+def test_row_title_has_no_javascript_character_budget():
+    """sessionLabel used to clip the feature name at 20 chars, which put a "…"
+    in names that had room to spare once the sidebar could be widened. Only CSS
+    knows the current width, so only CSS truncates."""
+    js = client.get("/app.js").text
+    assert "MAX_NAME" not in js
+    title = _rule(client.get("/style.css").text, ".inst .title")
+    assert "text-overflow: ellipsis" in title
+    assert "overflow: hidden" in title
+
+
+def test_grip_matches_the_bar_grip_pattern():
+    """If the bars' grip stops being hover-only, the rows should follow — this
+    pins the two together so they can't drift apart visually."""
+    bar = _rule(client.get("/style.css").text, ".bar-grip")
+    assert "position: absolute" in bar
+    assert "opacity: 0;" in bar


### PR DESCRIPTION
Uncommitted work that was sitting in the working tree of the canonical clone —
now committed, rebased onto v0.1.8, and with the conflicts against that release
resolved.

## What it does

- **The sidebar is resizable.** It was a fixed 260px, so long session labels
  ellipsized while the agent panes had width to spare (or the reverse on a wide
  screen). Drag handle, width in the UI store so it survives a reload, arrow-key
  support, and the drag writes the CSS var directly — committing to the store per
  `pointermove` would mean a synchronous `localStorage` write every frame.
- **Session labels stop being truncated in JS.** The 20-character budget on the
  feature name was always a guess at how much fits — a CSS question, and one
  whose answer now changes as you drag. `text-overflow` handles it; the label's
  `full` field goes with the budget that needed it.
- **The pre-commit stage pill only badges a pill-sized `failed_step`.** The
  server's generic fallback can return a whole line of hook output (up to 80
  chars), which either overflowed the row or forced the chip itself to be
  truncated. Long details ride in the tooltip.
- **That fallback was also picking the wrong text.** `capture-pane` without `-J`
  returns one line per pane *row*, so a wrapped error was split and the "last
  error-looking line" was its tail — the badge read as a mid-word fragment
  (`ffic-reduction'.` out of `…'traffic-reduction'.`). Now captured with `-J`,
  matching what `tmux.py` and `server.py` already did.
- **Retitles the project as a _private_ flock, on your own machine** — README,
  package metadata and `mindflock --help` — plus a "Where your code goes" section
  with the full network inventory.

## Conflicts resolved against v0.1.8

- `pyproject.toml` — kept the 0.1.8 version with the new description.
- `README.md` — kept both sides: the privacy framing *and* the GitHub-Issues
  zero-config note. Tracker lists reordered to lead with GitHub Issues, matching
  the rest of 0.1.8's docs.
- `backend/web/static/app.js` / `style.css` — generated, so resolved by
  rebuilding from the merged `frontend/src`. Verified the bundle carries both
  feature sets (`localmodel`, `lm-runtime`, `tk-agent` **and** `SidebarResizer`,
  `sidebarWidth`, `sidebar-resizing`).

## Three claims in the new prose that 0.1.8 had just made false

The privacy section was written before the local-model path landed, so it
understated what now ships. Corrected rather than merged verbatim:

- The "two caveats" note said *provisioned sessions launch **Claude Code***.
  They no longer do — each ticketing source picks its own agent.
- The honest-boundary paragraph said a CLI against a local model was "a
  supported shape, but nobody has published one yet, so treat it as untested
  rather than as a feature." It is now a feature with a settings screen,
  verified per-CLI routing, a `doctor` check and 24 tests.
- The network inventory had no row for a local model server; added, and the
  "one code egress" line now says it can be closed entirely.

## Verification

`3658 passed` (python) and `157 passed` (frontend) on the merged branch. Working
tree clean after the rebuild, so the committed bundle is the build of its own
source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
