### PR TITLE
Make the provider you chose the provider that runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The default coding provider was ignored by everything that launches a
+  session.** Settings → Coding provider writes `coding_cli.default_provider`
+  into `settings.json`, but every launch path read `default_program` out of
+  `config.json` — a different store, seeded once on first run by a helper that
+  only ever hunts for `claude`, and which the UI never writes to. Nothing
+  bridged the two, so choosing a default changed the Providers screen badge and
+  `mindflock doctor` and nothing else: ingested tickets, PR-review sessions,
+  issue sessions and the New Session dialog all still launched Claude Code.
+
+  `backend.config.program.resolve_default_program` is now the single answer to
+  "which CLI, when nobody asked for a specific one" — the chosen provider, then
+  the engine config, then `claude` — and the engine bridge, the standalone tmux
+  launcher and the web layer all resolve through it. It is also read fresh
+  rather than from the config snapshot taken at server start, so changing the
+  default no longer needs a restart. An explicitly chosen agent (a ticketing
+  source's own, say) still outranks it.
+
+- **Two welcome-tour slides scrolled.** "Welcome to MindFlock" needed 327px and
+  "3. PR review" 394px inside a 320px content box, so both got a scrollbar and
+  the PR-review slide hid its own *Set up now* button. The card is now 520×490
+  with a 48ch body — widening did most of the work, taking that slide from 394px
+  to 350px — which fits all twelve with room to spare.
+
+### Added
+
+- **PR review, issue handling and the Assistant each pick their own agent CLI**
+  (`github.agent`, `github.issue_agent`, `coding_cli.assistant_provider`), the
+  way a ticketing source already could. Issue handling deliberately does *not*
+  inherit PR review's choice and vice versa: they are separately configured
+  features with separate repo lists and separate toggles, so inheriting would
+  surprise anyone who set one and not the other. Both fall back to
+  `[mindflock].agent`, then the resolved default.
+
+  The Assistant needed this most — it was hardcoded to `claude` in two places,
+  which made it unusable for anyone who had never set Claude up. Its picker
+  lives in the Agent file dialog next to the standing instructions.
+
+### Changed
+
+- **PR review, Git issues and Ticketing are one screen with different nouns.**
+  They had drifted into three dialects of the same layout, and every incidental
+  difference cost a reader a moment working out whether it meant something. All
+  three now read the same way top to bottom — switch, status line, what's
+  watched, agent CLI, open-work panel, Advanced — from shared pieces in
+  `settings/screens/automation.tsx`. Ticketing gains the status line it never
+  had (its toggle had no feedback at all) and its per-source field is relabelled
+  **Agent CLI** to match its neighbours.
+
+- **The agent picker is a top-level field, not an Advanced one**, on every
+  screen that has one. Which CLI does the work is not a tuning knob.
+
+- A collapsed ticketing source now always names the CLI it runs
+  (`Shortcut — Allure Security · claude (default)`). Naming it only when it was
+  overridden made "on the app default" indistinguishable from "this source has
+  no agent setting", which is what sent people hunting for the picker.
+
 ## [0.1.8] - 2026-08-03
 
 ### Added

--- a/backend/config/program.py
+++ b/backend/config/program.py
@@ -1,0 +1,51 @@
+"""Which agent CLI a launch should use when nothing more specific asked for one.
+
+This exists because the answer lives in **two** stores that used to disagree:
+
+* ``~/.mindflock/config.json``'s ``default_program`` — the engine config, seeded
+  once on first run by :func:`GetClaudeCommand`, which only ever hunts for
+  ``claude``.
+* ``~/.mindflock/settings.json``'s ``coding_cli.default_provider`` — what
+  Settings → Coding provider actually writes when you pick a default.
+
+Only the first was ever read at launch time, so picking a default in the UI
+changed the Providers screen badge and ``mindflock doctor`` and nothing else:
+every session — hand-started, ingested, PR-review, issue — still launched
+``claude``. :func:`resolve_default_program` is the single choke point that reads
+the user's *chosen* default first and falls back to the engine config, so the
+setting means what it says.
+
+Kept in its own module rather than in ``config.py`` because ``settings.py``
+imports ``config.py``; putting it there would close an import cycle.
+"""
+
+from __future__ import annotations
+
+from backend.config.config import DEFAULT_PROGRAM, LoadConfig
+from backend.config.settings import load_settings
+
+
+def resolve_default_program() -> str:
+    """The agent CLI to launch when the caller has no more specific choice.
+
+    Precedence: ``coding_cli.default_provider`` (Settings → Coding provider) →
+    ``config.json``'s ``default_program`` → :data:`DEFAULT_PROGRAM`. Each layer
+    is independently best-effort: a missing or unreadable store falls through
+    rather than raising, because every caller is on a launch path where the
+    honest fallback is better than an exception.
+    """
+    try:
+        chosen = (load_settings().coding_cli.default_provider or "").strip()
+        if chosen:
+            return chosen
+    except Exception:  # noqa: BLE001 — settings are optional
+        pass
+
+    try:
+        program = (LoadConfig().GetProgram() or "").strip()
+        if program:
+            return program
+    except Exception:  # noqa: BLE001 — config must never break a launch
+        pass
+
+    return DEFAULT_PROGRAM

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -85,7 +85,15 @@ _SETTINGS_MIGRATIONS: dict = {}
 @dataclass
 class CodingCliSettings:
     #: Preferred provider name for new sessions (e.g. "claude", "codex").
+    #: Read at launch time via :func:`backend.config.program.resolve_default_program`
+    #: — it outranks the engine config's ``default_program``, which is only a
+    #: first-run seed.
     default_provider: str = ""
+    #: Provider the built-in Assistant runs. Empty = the same default as
+    #: everything else. Its own field because the Assistant is a long-lived
+    #: chat rather than a coding session, so people pair it with a different
+    #: CLI than the one doing the work.
+    assistant_provider: str = ""
     #: provider-name -> absolute binary path override.
     binary_paths: Dict[str, str] = field(default_factory=dict)
     #: Default launch flags, keyed by PROVIDER NAME (e.g. "claude", "codex").
@@ -107,6 +115,8 @@ class CodingCliSettings:
         d: dict = {}
         if self.default_provider:
             d["default_provider"] = self.default_provider
+        if self.assistant_provider:
+            d["assistant_provider"] = self.assistant_provider
         if self.binary_paths:
             # Drop empty-string overrides so a cleared field falls through.
             paths = {k: v for k, v in self.binary_paths.items() if k and v}
@@ -147,6 +157,7 @@ class CodingCliSettings:
             launch_args = {}
         return cls(
             default_provider=default_provider,
+            assistant_provider=str(d.get("assistant_provider", "") or ""),
             binary_paths=paths,
             default_launch_args=launch_args,
         )
@@ -371,6 +382,14 @@ class GithubSettings:
     issue_min_age_minutes: Optional[int] = None
     issue_poll_interval_seconds: Optional[int] = None
     issue_skip_authors: List[str] = field(default_factory=list)
+    # Coding-CLI provider name PR-review sessions run ("claude", "codex", …).
+    # Empty = fall back to engine.agent, then the resolved default. Separate
+    # from ``issue_agent`` because reviewing your own PR and taking a fresh
+    # issue are different jobs people reasonably want different CLIs for.
+    agent: str = ""
+    #: Same, for issue-handling sessions. Independent of ``agent`` exactly as
+    #: ``issue_repos`` is independent of ``repos``.
+    issue_agent: str = ""
 
     def repo_list(self) -> List[str]:
         """Effective ``owner/name`` repos to watch (blanks stripped)."""
@@ -406,6 +425,10 @@ class GithubSettings:
             d["issue_poll_interval_seconds"] = self.issue_poll_interval_seconds
         if self.issue_skip_authors:
             d["issue_skip_authors"] = list(self.issue_skip_authors)
+        if self.agent:
+            d["agent"] = self.agent
+        if self.issue_agent:
+            d["issue_agent"] = self.issue_agent
         return d
 
     @classmethod
@@ -423,6 +446,8 @@ class GithubSettings:
             issue_min_age_minutes=_opt_int(d.get("issue_min_age_minutes")),
             issue_poll_interval_seconds=_opt_int(d.get("issue_poll_interval_seconds")),
             issue_skip_authors=_str_list(d.get("issue_skip_authors")),
+            agent=str(d.get("agent", "") or ""),
+            issue_agent=str(d.get("issue_agent", "") or ""),
         )
 
 

--- a/backend/ticket_ingestion/claude_runner.py
+++ b/backend/ticket_ingestion/claude_runner.py
@@ -39,18 +39,19 @@ logger = logging.getLogger(__name__)
 
 
 def default_agent() -> str:
-    """The engine's configured default agent program, or ``"claude"``.
+    """The user's configured default agent program, or ``"claude"``.
 
-    The last link in the ``ticket.agent -> [mindflock].agent -> engine default``
-    chain. Read lazily and defensively: the standalone launcher is exactly the
-    path that runs when the engine half of the package is unavailable, so a
-    missing :mod:`backend.config` must degrade to the historical default rather
-    than fail the launch.
+    The last link in the ``ticket.agent -> [mindflock].agent -> user default``
+    chain, where "user default" is Settings → Coding provider first and the
+    engine config second. Read lazily and defensively: the standalone launcher
+    is exactly the path that runs when the engine half of the package is
+    unavailable, so a missing :mod:`backend.config` must degrade to the
+    historical default rather than fail the launch.
     """
     try:
-        from backend import config as cs_config
+        from backend.config.program import resolve_default_program
 
-        return cs_config.LoadConfig().GetProgram() or "claude"
+        return resolve_default_program() or "claude"
     except Exception:  # noqa: BLE001
         return "claude"
 

--- a/backend/ticket_ingestion/config.py
+++ b/backend/ticket_ingestion/config.py
@@ -46,6 +46,11 @@ class GithubConfig:
     issue_min_age_minutes: int = 15
     issue_poll_interval_seconds: int = 60
     issue_skip_authors: list[str] = field(default_factory=list)
+    #: Coding CLI PR-review sessions run. Empty = ``[mindflock].agent``, then
+    #: the resolved default. Independent of ``issue_agent`` below.
+    agent: str = ""
+    #: Coding CLI issue-handling sessions run, same fallback chain.
+    issue_agent: str = ""
 
     def repo_list(self) -> list[str]:
         """The effective ``owner/name`` repos to watch (blanks stripped)."""
@@ -251,7 +256,35 @@ class PipelineConfig:
         for src in self.ticketing_sources or ():
             if source_id and (src.id or src.provider) == source_id and src.agent:
                 return src.agent
+        return self._pipeline_agent()
+
+    def _pipeline_agent(self) -> str:
+        """The ingestion-wide agent (``[mindflock].agent``), or ``""``."""
         return (self.engine.agent if self.engine else "") or ""
+
+    def pr_agent(self) -> str:
+        """The coding CLI a PR-review session should run, or ``""``.
+
+        Precedence: ``[github].agent`` → ``[mindflock].agent`` → ``""`` (the
+        resolved default). PR review has no ticketing source, so it never
+        consults the per-source chain.
+        """
+        return (
+            (self.github.agent if self.github else "") or ""
+        ) or self._pipeline_agent()
+
+    def issue_agent(self) -> str:
+        """The coding CLI an issue-handling session should run, or ``""``.
+
+        Precedence: ``[github].issue_agent`` → ``[mindflock].agent`` → ``""``.
+        Deliberately does NOT fall back to ``[github].agent``: issue handling
+        and PR review are separately configured features (separate repo lists,
+        separate toggles), so inheriting the review CLI would surprise anyone
+        who set one and not the other.
+        """
+        return (
+            (self.github.issue_agent if self.github else "") or ""
+        ) or self._pipeline_agent()
 
 
 def _assign_source_ids(sources: list[TicketProviderConfig]) -> None:
@@ -470,6 +503,12 @@ def _merge_layers(raw: dict) -> dict:
     # issue_repos (issue handling): its own list — settings overrides toml.
     if _gh.issue_repos:
         github["issue_repos"] = list(_gh.issue_repos)
+    # Per-surface agent CLI: settings override toml, blank falls through to the
+    # pipeline-wide chain rather than pinning anything.
+    if _gh.agent:
+        github["agent"] = _gh.agent
+    if _gh.issue_agent:
+        github["issue_agent"] = _gh.issue_agent
 
     # --- engine block (settings override the [mindflock] section) --------------
     eng_enabled = _s.resolve_bool(

--- a/backend/ticket_ingestion/orchestrator.py
+++ b/backend/ticket_ingestion/orchestrator.py
@@ -418,6 +418,11 @@ class PipelineOrchestrator:
             )
             return
         story = issue_to_ticket(issue, comments)
+        # An issue has no ticketing source to inherit an agent from, so stamp
+        # issue handling's own choice onto the ticket here — every downstream
+        # launch path already reads `story.agent` first. Blank leaves the
+        # existing fallback chain untouched.
+        story.agent = self.config.issue_agent()
         try:
             if self._cs_runner is not None:
                 await self._cs_runner.run(story)

--- a/backend/ticket_ingestion/session_runner.py
+++ b/backend/ticket_ingestion/session_runner.py
@@ -91,18 +91,15 @@ def _resolve_program(agent: str = "") -> str:
 
     ``agent`` is the ingestion pipeline's choice for this session (the ticket's
     source ``agent``, else ``[mindflock].agent``); empty falls through to the
-    engine's configured default program, and then to ``claude`` if the engine
-    config can't be loaded. Single source for both engine-launch paths so they
-    can't diverge.
+    user's configured default — Settings → Coding provider first, then the
+    engine config, then ``claude``. Single source for both engine-launch paths
+    so they can't diverge.
     """
     if agent:
         return agent
-    from backend import config as cs_config
+    from backend.config.program import resolve_default_program
 
-    try:
-        return cs_config.LoadConfig().GetProgram()
-    except Exception:  # noqa: BLE001
-        return "claude"
+    return resolve_default_program()
 
 
 class SessionRunner:
@@ -270,9 +267,9 @@ class SessionRunner:
     ):
         from backend import session as cs_session
 
-        # PR review has no ticketing source, so it runs the ingestion-wide
-        # default agent.
-        program = _resolve_program(self.config.agent_for())
+        # PR review has no ticketing source, so it runs its own configured
+        # agent ([github].agent) before falling back to the ingestion-wide one.
+        program = _resolve_program(self.config.pr_agent())
 
         # Adopt the already-provisioned PR workspace: clone-style worktree at the
         # exact directory, on the PR's existing head branch (verbatim, no fork).

--- a/backend/web/addons/assistant.py
+++ b/backend/web/addons/assistant.py
@@ -105,6 +105,30 @@ def _atomic_write(path: Path, text: str) -> None:
     tmp.replace(path)
 
 
+def _assistant_program() -> str:
+    """The CLI the Assistant runs.
+
+    ``coding_cli.assistant_provider`` (Settings → Agent) first, so the Assistant
+    can be a different CLI from the one doing the coding, then the same default
+    everything else resolves to. This was hardcoded to ``claude``, which made
+    the Assistant unusable for anyone who hadn't set Claude up.
+    """
+    try:
+        from backend.config.settings import load_settings
+
+        chosen = (load_settings().coding_cli.assistant_provider or "").strip()
+        if chosen:
+            return chosen
+    except Exception:  # noqa: BLE001 — settings are optional
+        pass
+    try:
+        from backend.config.program import resolve_default_program
+
+        return resolve_default_program() or "claude"
+    except Exception:  # noqa: BLE001 — never block the chat on config
+        return "claude"
+
+
 def _seed_assistant_dir() -> None:
     """Ensure the assistant's dir, the user-instructions file, CLAUDE.md and
     todos.json exist and are coherent.
@@ -161,11 +185,12 @@ def _ensure_assistant_session():
     if exists:
         return name, None
     _seed_assistant_dir()  # re-seed defensively in case the dir was wiped
-    provider = providers.resolve("claude")
+    program = _assistant_program()
+    provider = providers.resolve(program)
     # Natural quit -> fresh; unnatural death -> resume the conversation.
     resume = not provider.is_natural_exit(_read_exit_marker(name))
     cmd = provider.build_launch_command(
-        providers.LaunchContext(program="claude", resume=resume, session_name=name)
+        providers.LaunchContext(program=program, resume=resume, session_name=name)
     )
     _clear_exit_marker(name)
     wrapped = _wrap_launch_cmd(cmd, name)

--- a/backend/web/core/engine.py
+++ b/backend/web/core/engine.py
@@ -208,10 +208,18 @@ class Engine:
                 log.ErrorLog.Printf("failed to load instances: %v", err)
 
     def default_program(self) -> str:
-        try:
-            return self.cfg.GetProgram()
-        except Exception:  # noqa: BLE001
-            return "claude"
+        """The agent CLI new sessions launch with.
+
+        Deliberately NOT ``self.cfg.GetProgram()``: that reads only the engine
+        config, which ignores the default the user picked in Settings → Coding
+        provider (stored as ``coding_cli.default_provider``). Resolving through
+        the shared chain also means this is read fresh rather than from the
+        config snapshot taken at server start, so changing the default takes
+        effect without a restart.
+        """
+        from backend.config.program import resolve_default_program
+
+        return resolve_default_program()
 
     def save(self, exclude_titles=()) -> None:
         """Persist instances, merging in entries written by other processes.

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -30429,7 +30429,194 @@ function LocalModel(_) {
     ] })
   ] });
 }
-function IngestionToggle() {
+function ageText(iso) {
+  const t = Date.parse(iso || "");
+  if (!isFinite(t)) return "";
+  const mins = Math.max(0, Math.round((Date.now() - t) / 6e4));
+  if (mins < 60) return mins + "m old";
+  const h = Math.round(mins / 60);
+  if (h < 48) return h + "h old";
+  return Math.round(h / 24) + "d old";
+}
+function AutomationSwitch({
+  label,
+  title,
+  rowId,
+  inputId,
+  statusId,
+  checked,
+  onChange,
+  status,
+  tone
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row set-switch-row", id: rowId, title, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: label }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "input",
+          {
+            type: "checkbox",
+            id: inputId,
+            checked,
+            onChange: (e) => onChange(e.target.checked)
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: statusId, className: "pr-status" + (tone ? " " + tone : ""), children: status })
+  ] });
+}
+function RepoListField({
+  label,
+  repos,
+  onSave,
+  emptyText,
+  hint,
+  listId,
+  inputId,
+  addId
+}) {
+  const [draft, setDraft] = reactExports.useState("");
+  const add = () => {
+    const val = draft.trim();
+    if (!val) return;
+    if (!/^[^\s/]+\/[^\s/]+$/.test(val)) {
+      toast("Use owner/name, e.g. MindFlock/MindFlock");
+      return;
+    }
+    if (repos.some((r) => r.toLowerCase() === val.toLowerCase())) {
+      setDraft("");
+      toast(val + " is already in the list");
+      return;
+    }
+    setDraft("");
+    onSave([...repos, val], "Added " + val);
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: listId, className: "repo-list", children: !repos.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: emptyText }) : repos.map((repo) => /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "repo-chip", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "repo-chip-name", children: repo }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          className: "repo-chip-x",
+          title: "Remove " + repo,
+          "aria-label": "Remove " + repo,
+          onClick: () => onSave(
+            repos.filter((r) => r !== repo),
+            "Removed " + repo
+          ),
+          children: "✕"
+        }
+      )
+    ] }, repo)) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "repo-add-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "text",
+          id: inputId,
+          placeholder: "owner/name — e.g. mindflockai/MindFlock",
+          autoComplete: "off",
+          spellCheck: false,
+          value: draft,
+          onChange: (e) => setDraft(e.target.value),
+          onKeyDown: (e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              add();
+            }
+          }
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: addId, className: "btn-primary", onClick: add, children: "+ Add" })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: hint })
+  ] });
+}
+function WorkListPanel({
+  label,
+  onRefresh,
+  note,
+  hint,
+  children,
+  rowId,
+  refreshId,
+  noteId,
+  listId,
+  toolbarExtra
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row", id: rowId, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-toolbar", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: refreshId, className: "test-btn", onClick: onRefresh, children: "Refresh" }),
+      toolbarExtra,
+      note ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: noteId, className: "pr-open-note", children: note }) : null
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: listId, className: "pr-open-list", children }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: hint })
+  ] });
+}
+function WorkItemRow({
+  reference,
+  url,
+  title,
+  meta,
+  tooltip,
+  hasSession,
+  eligible,
+  eligibleLabel,
+  reasons,
+  actionLabel,
+  onStart,
+  failPrefix
+}) {
+  const [state, setState] = reactExports.useState("idle");
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-item", title: tooltip, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-main", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "a",
+        {
+          href: url || "#",
+          target: "_blank",
+          rel: "noopener noreferrer",
+          className: "pr-open-ref",
+          title: "Open " + reference + " on GitHub",
+          children: reference
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-title", children: title || "" })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-meta", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: meta }),
+      hasSession ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip on", children: "session open" }) : eligible ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip ok", children: eligibleLabel }) : (reasons || []).map((reason) => /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip", children: reason }, reason))
+    ] }),
+    hasSession ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className: "btn-primary pr-review-btn", disabled: true, children: "Session open" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        className: "btn-primary pr-review-btn",
+        disabled: state !== "idle",
+        onClick: async () => {
+          setState("starting");
+          try {
+            const created = await onStart();
+            toast(created + " — provisioning, see the sidebar");
+            setState("started");
+          } catch (err) {
+            toast(failPrefix + ": " + (err.message || "error"));
+            setState("idle");
+          }
+        },
+        children: state === "starting" ? "Starting…" : state === "started" ? "Started" : actionLabel
+      }
+    )
+  ] });
+}
+function IngestionToggle({ sourceCount }) {
   const [busy, setBusy] = reactExports.useState(false);
   const [optimistic, setOptimistic] = reactExports.useState(null);
   const { data: status, refetch } = useQuery({
@@ -30456,28 +30643,21 @@ function IngestionToggle() {
       refetch();
     }
   };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "div",
+  const n = sourceCount;
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    AutomationSwitch,
     {
-      className: "set-row set-switch-row",
-      id: "tk-ingestion-toggle-row",
+      label: "Automated ingestion",
       title: "Run or stop ticket ingestion — polls your connected sources and auto-creates a coding session for each assigned ticket. Stays in this state across restarts.",
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Automated ingestion" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              type: "checkbox",
-              id: "tk-ingestion-enabled",
-              checked: desired,
-              disabled: busy,
-              onChange: (e) => toggle(e.target.checked)
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
-        ] })
-      ]
+      rowId: "tk-ingestion-toggle-row",
+      inputId: "tk-ingestion-enabled",
+      statusId: "tk-ingestion-status",
+      checked: desired,
+      onChange: (next) => {
+        if (!busy) toggle(next);
+      },
+      tone: n > 0 && desired ? "on" : n > 0 ? "paused" : "",
+      status: !n ? "○ Add a ticketing source below to start turning tickets into sessions" : desired ? `● Active — polling ${n} ${n === 1 ? "source" : "sources"} for tickets assigned to you` : `‖ Paused — ${n} ${n === 1 ? "source" : "sources"} kept; turn Automated ingestion on to resume`
     }
   );
 }
@@ -30570,7 +30750,7 @@ function Ticketing(_) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Ticketing" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint set-block-hint", children: "Connect one or more ticketing platforms and MindFlock auto-creates a coding session for each ticket assigned to you. Add several sources — even two of the same provider (e.g. two Jira sites) — each with its own credentials. Stored in ~/.mindflock/settings.json (never committed)." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(IngestionToggle, {}),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(IngestionToggle, { sourceCount: (sources || []).length }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "ticketing-sources", children: sources.map((src) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       SourceCard,
       {
@@ -30891,7 +31071,7 @@ function SourceCard({
   const provName = (meta == null ? void 0 : meta.label) || source.provider;
   const detail = (source.label || source.member_id || source.repo_url || "").trim();
   const base = detail ? provName + " — " + detail : provName;
-  const summary = source.agent ? base + " · " + source.agent : base;
+  const summary = base + " · " + (source.agent || (agents.fallback ? agents.fallback + " (default)" : "app default"));
   const repoMissing = !(source.repo_url || "").trim();
   const testPayload = () => {
     const payload = { id: source.id, provider: source.provider };
@@ -30985,7 +31165,7 @@ function SourceCard({
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Required — tickets from this source clone into this repo." })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "set-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Agent" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Agent CLI" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "select",
           {
@@ -31089,23 +31269,55 @@ function Workspace({ gotoScreen }) {
     ] })
   ] });
 }
-function prAgeText(iso) {
-  const t = Date.parse(iso || "");
-  if (!isFinite(t)) return "";
-  const mins = Math.max(0, Math.round((Date.now() - t) / 6e4));
-  if (mins < 60) return mins + "m old";
-  const h = Math.round(mins / 60);
-  if (h < 48) return h + "h old";
-  return Math.round(h / 24) + "d old";
+function useAgentChoices() {
+  const [choices, setChoices] = reactExports.useState({ names: [], fallback: "" });
+  reactExports.useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const p = await api(
+          "/api/providers"
+        );
+        if (!alive) return;
+        setChoices({
+          names: ((p == null ? void 0 : p.providers) || []).map((x) => x.name).filter(Boolean),
+          fallback: (p == null ? void 0 : p.default) || ""
+        });
+      } catch {
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return choices;
+}
+function AgentPicker({
+  label,
+  hint,
+  value,
+  choices,
+  fallbackLabel,
+  onChange
+}) {
+  const empty = fallbackLabel || (choices.fallback ? `App default (${choices.fallback})` : "App default");
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "set-row", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("select", { value: value || "", onChange: (e) => onChange(e.target.value), children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "", children: empty }),
+      choices.names.map((n) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: n, children: n }, n))
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: hint })
+  ] });
 }
 function PrReview({ gotoScreen }) {
   var _a2, _b2, _c2;
   const s = useSettings();
+  const agentChoices = useAgentChoices();
   const gh = s.settings.github || {};
   const enabled = gh.enabled !== false;
   const repos = Array.isArray(gh.repos) ? gh.repos : [];
   const skipAuthors = Array.isArray(gh.skip_authors) ? gh.skip_authors.join(", ") : gh.skip_authors || "";
-  const [repoNew, setRepoNew] = reactExports.useState("");
   const [skipDraft, setSkipDraft] = reactExports.useState(String(skipAuthors));
   reactExports.useEffect(() => setSkipDraft(String(skipAuthors)), [skipAuthors]);
   const prsQuery = usePanelQuery("github-prs");
@@ -31119,24 +31331,7 @@ function PrReview({ gotoScreen }) {
     testing: false
   });
   const saveGithub = (patch, okMsg) => s.saveGroup("github", patch, okMsg);
-  const saveRepos = (list, msg) => saveGithub({ repos: list }, msg);
-  const addRepo = () => {
-    const val = repoNew.trim();
-    if (!val) return;
-    if (!/^[^\s/]+\/[^\s/]+$/.test(val)) {
-      toast("Use owner/name, e.g. MindFlock/MindFlock");
-      return;
-    }
-    if (repos.some((r) => r.toLowerCase() === val.toLowerCase())) {
-      setRepoNew("");
-      toast(val + " is already in the list");
-      return;
-    }
-    setRepoNew("");
-    saveRepos([...repos, val], "Added " + val);
-  };
   const n = repos.length;
-  const statusText = !n ? "○ Add a repository below to start reviewing your PRs" : enabled ? `● Active — reviewing PRs in ${n} ${n === 1 ? "repository" : "repositories"}` : `‖ Paused — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated review on to resume`;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Automated PR review" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "caps-gate", "data-caps-gate": "git", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { children: [
@@ -31162,99 +31357,92 @@ function PrReview({ gotoScreen }) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("em", { children: "your own" }),
       " open pull requests on the repositories below and automatically spins up a coding session to address review comments. It runs while ingestion is active."
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "div",
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      AutomationSwitch,
       {
-        className: "set-row set-switch-row",
-        id: "gh-pr-toggle-row",
+        label: "Automated review",
         title: "Turn automated PR review on or off — your repositories are kept either way",
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Automated review" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "input",
-              {
-                type: "checkbox",
-                id: "gh-pr-enabled",
-                checked: enabled,
-                onChange: (e) => saveGithub(
-                  { enabled: e.target.checked },
-                  e.target.checked ? "Automated review on" : "Automated review paused"
-                )
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
-          ] })
-        ]
+        rowId: "gh-pr-toggle-row",
+        inputId: "gh-pr-enabled",
+        statusId: "gh-pr-status",
+        checked: enabled,
+        onChange: (next) => saveGithub(
+          { enabled: next },
+          next ? "Automated review on" : "Automated review paused"
+        ),
+        tone: n > 0 && enabled ? "on" : n > 0 ? "paused" : "",
+        status: !n ? "○ Add a repository below to start reviewing your PRs" : enabled ? `● Active — reviewing PRs in ${n} ${n === 1 ? "repository" : "repositories"}` : `‖ Paused — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated review on to resume`
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "div",
+      RepoListField,
       {
-        id: "gh-pr-status",
-        className: "pr-status" + (n > 0 && enabled ? " on" : n > 0 ? " paused" : ""),
-        children: statusText
+        label: "Repositories to review",
+        repos,
+        onSave: (list, msg) => saveGithub({ repos: list }, msg),
+        emptyText: "No repositories yet — add one below to start reviewing your PRs.",
+        listId: "gh-repos-list",
+        inputId: "gh-repo-new",
+        addId: "gh-repo-add-btn",
+        hint: /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          "Type a repo as ",
+          /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "owner/name" }),
+          ", then press Enter or click Add. Adding one turns review on; remove them all to turn it off."
+        ] })
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Repositories to review" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "gh-repos-list", className: "repo-list", children: !repos.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "No repositories yet — add one below to start reviewing your PRs." }) : repos.map((repo) => /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "repo-chip", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "repo-chip-name", children: repo }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      AgentPicker,
+      {
+        label: "Agent CLI",
+        value: String(gh.agent || ""),
+        choices: agentChoices,
+        onChange: (v) => s.saveField("github", "agent", v),
+        hint: /* @__PURE__ */ jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, { children: "Which coding CLI runs PR-review sessions. Independent of issue handling's — pick a provider whose Connections row is green, or leave it on the app default." })
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      WorkListPanel,
+      {
+        label: "Open pull requests",
+        onRefresh: loadOpenPrs,
+        note: prsNote,
+        rowId: "gh-open-prs-row",
+        refreshId: "gh-prs-refresh",
+        noteId: "gh-prs-note",
+        listId: "gh-prs-list",
+        hint: /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          "Every non-draft open PR on the repositories above, with why auto review has or hasn't picked it up. ",
+          /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "Begin review" }),
+          " starts a review session for that PR right now, bypassing the author / age / already-reviewed filters."
+        ] }),
+        children: prsError ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: prsError }) : prs === null ? null : !prsRepos.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "Add a repository above to see its open PRs." }) : !prs.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "No open pull requests on the watched repositories." }) : prs.map((p) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          WorkItemRow,
           {
-            type: "button",
-            className: "repo-chip-x",
-            title: "Remove " + repo,
-            "aria-label": "Remove " + repo,
-            onClick: () => saveRepos(
-              repos.filter((r) => r !== repo),
-              "Removed " + repo
-            ),
-            children: "✕"
-          }
-        )
-      ] }, repo)) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "repo-add-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "text",
-            id: "gh-repo-new",
-            placeholder: "owner/name — e.g. mindflockai/MindFlock",
-            autoComplete: "off",
-            spellCheck: false,
-            value: repoNew,
-            onChange: (e) => setRepoNew(e.target.value),
-            onKeyDown: (e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                addRepo();
-              }
+            reference: (p.repo || "") + "#" + p.number,
+            url: p.url,
+            title: p.title,
+            tooltip: (p.repo || "") + "#" + p.number + " — " + (p.title || "") + "\nby " + (p.author || "?") + " · " + (p.head_ref || "?") + " → " + (p.base_ref || "?"),
+            meta: `by ${p.author || "?"} · ${ageText(p.created_at)} · into ${p.base_ref || "?"}`,
+            hasSession: p.has_session,
+            eligible: p.eligible,
+            eligibleLabel: "queued for auto review",
+            reasons: p.reasons,
+            actionLabel: "Begin review",
+            failPrefix: "Begin review failed",
+            onStart: async () => {
+              const r = await api("/api/github/prs/review", {
+                json: { repo: p.repo, number: p.number }
+              });
+              refreshInstances();
+              setTimeout(relistPrs, 5e3);
+              return "Review session " + ((r == null ? void 0 : r.title) || "");
             }
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "gh-repo-add-btn", className: "btn-primary", onClick: addRepo, children: "+ Add" })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "set-hint", children: [
-        "Type a repo as ",
-        /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "owner/name" }),
-        ", then press Enter or click Add. Adding one turns review on; remove them all to turn it off."
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row", id: "gh-open-prs-row", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Open pull requests" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-toolbar", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "gh-prs-refresh", className: "test-btn", onClick: loadOpenPrs, children: "Refresh" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "gh-prs-note", className: "pr-open-note", children: prsNote })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "gh-prs-list", className: "pr-open-list", children: prsError ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: prsError }) : prs === null ? null : !prsRepos.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "Add a repository above to see its open PRs." }) : !prs.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "No open pull requests on the watched repositories." }) : prs.map((p) => /* @__PURE__ */ jsxRuntimeExports.jsx(OpenPrRow, { p, onStarted: relistPrs }, (p.repo || "") + p.number)) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "set-hint", children: [
-        "Every non-draft open PR on the repositories above, with why auto review has or hasn't picked it up. ",
-        /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "Begin review" }),
-        " starts a review session for that PR right now, bypassing the author / age / already-reviewed filters."
-      ] })
-    ] }),
+          },
+          (p.repo || "") + p.number
+        ))
+      }
+    ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "pr-advanced", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { children: "Advanced options" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-advanced-body", children: [
@@ -31327,84 +31515,14 @@ function PrReview({ gotoScreen }) {
     ] })
   ] });
 }
-function OpenPrRow({ p, onStarted }) {
-  const [state, setState] = reactExports.useState("idle");
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "div",
-    {
-      className: "pr-open-item",
-      title: (p.repo || "") + "#" + p.number + " — " + (p.title || "") + "\nby " + (p.author || "?") + " · " + (p.head_ref || "?") + " → " + (p.base_ref || "?"),
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-main", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "a",
-            {
-              href: p.url || "#",
-              target: "_blank",
-              rel: "noopener noreferrer",
-              className: "pr-open-ref",
-              title: "Open " + (p.repo || "") + "#" + p.number + " on GitHub",
-              children: (p.repo || "") + "#" + p.number
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-title", children: p.title || "" })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-meta", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
-            "by ",
-            p.author || "?",
-            " · ",
-            prAgeText(p.created_at),
-            " · into ",
-            p.base_ref || "?"
-          ] }),
-          p.has_session ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip on", children: "session open" }) : p.eligible ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip ok", children: "queued for auto review" }) : (p.reasons || []).map((reason) => /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip", children: reason }, reason))
-        ] }),
-        p.has_session ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className: "btn-primary pr-review-btn", disabled: true, children: "Session open" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            type: "button",
-            className: "btn-primary pr-review-btn",
-            disabled: state !== "idle",
-            onClick: async () => {
-              setState("starting");
-              try {
-                const r = await api("/api/github/prs/review", {
-                  json: { repo: p.repo, number: p.number }
-                });
-                toast("Review session " + ((r == null ? void 0 : r.title) || "") + " — provisioning, see the sidebar");
-                setState("started");
-                refreshInstances();
-                setTimeout(onStarted, 5e3);
-              } catch (err) {
-                toast("Begin review failed: " + (err.message || "error"));
-                setState("idle");
-              }
-            },
-            children: state === "starting" ? "Starting…" : state === "started" ? "Started" : "Begin review"
-          }
-        )
-      ]
-    }
-  );
-}
-function issueAgeText(iso) {
-  const t = Date.parse(iso || "");
-  if (!isFinite(t)) return "";
-  const mins = Math.max(0, Math.round((Date.now() - t) / 6e4));
-  if (mins < 60) return mins + "m old";
-  const h = Math.round(mins / 60);
-  if (h < 48) return h + "h old";
-  return Math.round(h / 24) + "d old";
-}
 function GitIssues({ gotoScreen }) {
   var _a2;
   const s = useSettings();
+  const agentChoices = useAgentChoices();
   const gh = s.settings.github || {};
   const enabled = gh.issues_enabled === true;
   const repos = Array.isArray(gh.issue_repos) ? gh.issue_repos : [];
   const skipAuthors = Array.isArray(gh.issue_skip_authors) ? gh.issue_skip_authors.join(", ") : gh.issue_skip_authors || "";
-  const [repoNew, setRepoNew] = reactExports.useState("");
   const [skipDraft, setSkipDraft] = reactExports.useState(String(skipAuthors));
   reactExports.useEffect(() => setSkipDraft(String(skipAuthors)), [skipAuthors]);
   const issuesQuery = usePanelQuery("github-issues");
@@ -31418,24 +31536,7 @@ function GitIssues({ gotoScreen }) {
     testing: false
   });
   const saveGithub = (patch, okMsg) => s.saveGroup("github", patch, okMsg);
-  const saveRepos = (list, msg) => saveGithub({ issue_repos: list }, msg);
-  const addRepo = () => {
-    const val = repoNew.trim();
-    if (!val) return;
-    if (!/^[^\s/]+\/[^\s/]+$/.test(val)) {
-      toast("Use owner/name, e.g. MindFlock/MindFlock");
-      return;
-    }
-    if (repos.some((r) => r.toLowerCase() === val.toLowerCase())) {
-      setRepoNew("");
-      toast(val + " is already in the list");
-      return;
-    }
-    setRepoNew("");
-    saveRepos([...repos, val], "Added " + val);
-  };
   const n = repos.length;
-  const statusText = !n ? "○ Add a repository below, then turn Automated handling on" : enabled ? `● Active — handling new issues in ${n} ${n === 1 ? "repository" : "repositories"}` : `‖ Off — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated handling on to start`;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Automated issue handling" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "caps-gate", "data-caps-gate": "git", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { children: [
@@ -31460,99 +31561,92 @@ function GitIssues({ gotoScreen }) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("em", { children: "newly opened issues" }),
       " on the repositories below, grabs each issue and all its comments, and automatically spins up a coding session that starts work on a fresh branch for it. Separate from PR review — the repository lists are independent."
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "div",
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      AutomationSwitch,
       {
-        className: "set-row set-switch-row",
-        id: "gh-issues-toggle-row",
+        label: "Automated handling",
         title: "Turn automated issue handling on or off — your repositories are kept either way",
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Automated handling" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "input",
-              {
-                type: "checkbox",
-                id: "gh-issues-enabled",
-                checked: enabled,
-                onChange: (e) => saveGithub(
-                  { issues_enabled: e.target.checked },
-                  e.target.checked ? "Automated issue handling on" : "Automated issue handling off"
-                )
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
-          ] })
-        ]
+        rowId: "gh-issues-toggle-row",
+        inputId: "gh-issues-enabled",
+        statusId: "gh-issues-status",
+        checked: enabled,
+        onChange: (next) => saveGithub(
+          { issues_enabled: next },
+          next ? "Automated issue handling on" : "Automated issue handling off"
+        ),
+        tone: n > 0 && enabled ? "on" : n > 0 ? "paused" : "",
+        status: !n ? "○ Add a repository below, then turn Automated handling on" : enabled ? `● Active — handling new issues in ${n} ${n === 1 ? "repository" : "repositories"}` : `‖ Off — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated handling on to start`
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "div",
+      RepoListField,
       {
-        id: "gh-issues-status",
-        className: "pr-status" + (n > 0 && enabled ? " on" : n > 0 ? " paused" : ""),
-        children: statusText
+        label: "Repositories to watch",
+        repos,
+        onSave: (list, msg) => saveGithub({ issue_repos: list }, msg),
+        emptyText: "No repositories yet — add one below to start handling new issues.",
+        listId: "gh-issue-repos-list",
+        inputId: "gh-issue-repo-new",
+        addId: "gh-issue-repo-add-btn",
+        hint: /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          "Type a repo as ",
+          /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "owner/name" }),
+          ", then press Enter or click Add. This list is separate from PR review's — a repo can be on either, or both."
+        ] })
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Repositories to watch" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "gh-issue-repos-list", className: "repo-list", children: !repos.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "No repositories yet — add one below to start handling new issues." }) : repos.map((repo) => /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "repo-chip", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "repo-chip-name", children: repo }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      AgentPicker,
+      {
+        label: "Agent CLI",
+        value: String(gh.issue_agent || ""),
+        choices: agentChoices,
+        onChange: (v) => s.saveField("github", "issue_agent", v),
+        hint: /* @__PURE__ */ jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, { children: "Which coding CLI runs issue-handling sessions. Independent of PR review's — setting one does not change the other." })
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      WorkListPanel,
+      {
+        label: "Open issues",
+        onRefresh: loadOpenIssues,
+        note: issuesNote,
+        rowId: "gh-open-issues-row",
+        refreshId: "gh-issues-refresh",
+        noteId: "gh-issues-note",
+        listId: "gh-issues-list",
+        hint: /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          "Every open issue on the repositories above, with why auto handling has or hasn't picked it up. ",
+          /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "Start work" }),
+          " spins up a session for that issue right now, bypassing the age / already-handled filters."
+        ] }),
+        children: issuesError ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: issuesError }) : issues === null ? null : !issuesRepos.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "Add a repository above to see its open issues." }) : !issues.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "No open issues on the watched repositories." }) : issues.map((i) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          WorkItemRow,
           {
-            type: "button",
-            className: "repo-chip-x",
-            title: "Remove " + repo,
-            "aria-label": "Remove " + repo,
-            onClick: () => saveRepos(
-              repos.filter((r) => r !== repo),
-              "Removed " + repo
-            ),
-            children: "✕"
-          }
-        )
-      ] }, repo)) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "repo-add-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "text",
-            id: "gh-issue-repo-new",
-            placeholder: "owner/name — e.g. mindflockai/MindFlock",
-            autoComplete: "off",
-            spellCheck: false,
-            value: repoNew,
-            onChange: (e) => setRepoNew(e.target.value),
-            onKeyDown: (e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                addRepo();
-              }
+            reference: (i.repo || "") + "#" + i.number,
+            url: i.url,
+            title: i.title,
+            tooltip: (i.repo || "") + "#" + i.number + " — " + (i.title || "") + "\nby " + (i.author || "?"),
+            meta: `by ${i.author || "?"} · ${ageText(i.created_at)}`,
+            hasSession: i.has_session,
+            eligible: i.eligible,
+            eligibleLabel: "queued for auto handling",
+            reasons: i.reasons,
+            actionLabel: "Start work",
+            failPrefix: "Start work failed",
+            onStart: async () => {
+              const r = await api("/api/github/issues/start", {
+                json: { repo: i.repo, number: i.number }
+              });
+              refreshInstances();
+              setTimeout(relistIssues, 5e3);
+              return "Issue session " + ((r == null ? void 0 : r.title) || "");
             }
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "gh-issue-repo-add-btn", className: "btn-primary", onClick: addRepo, children: "+ Add" })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "set-hint", children: [
-        "Type a repo as ",
-        /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "owner/name" }),
-        ", then press Enter or click Add. This list is separate from PR review's — a repo can be on either, or both."
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row", id: "gh-open-issues-row", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: "Open issues" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-toolbar", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "gh-issues-refresh", className: "test-btn", onClick: loadOpenIssues, children: "Refresh" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "gh-issues-note", className: "pr-open-note", children: issuesNote })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "gh-issues-list", className: "pr-open-list", children: issuesError ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: issuesError }) : issues === null ? null : !issuesRepos.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "Add a repository above to see its open issues." }) : !issues.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "repo-empty", children: "No open issues on the watched repositories." }) : issues.map((i) => /* @__PURE__ */ jsxRuntimeExports.jsx(OpenIssueRow, { i, onStarted: relistIssues }, (i.repo || "") + i.number)) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "set-hint", children: [
-        "Every open issue on the repositories above, with why auto handling has or hasn't picked it up. ",
-        /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "Start work" }),
-        " spins up a session for that issue right now, bypassing the age / already-handled filters."
-      ] })
-    ] }),
+          },
+          (i.repo || "") + i.number
+        ))
+      }
+    ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "pr-advanced", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { children: "Advanced options" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-advanced-body", children: [
@@ -31620,65 +31714,6 @@ function GitIssues({ gotoScreen }) {
       ] })
     ] })
   ] });
-}
-function OpenIssueRow({ i, onStarted }) {
-  const [state, setState] = reactExports.useState("idle");
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "div",
-    {
-      className: "pr-open-item",
-      title: (i.repo || "") + "#" + i.number + " — " + (i.title || "") + "\nby " + (i.author || "?"),
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-main", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "a",
-            {
-              href: i.url || "#",
-              target: "_blank",
-              rel: "noopener noreferrer",
-              className: "pr-open-ref",
-              title: "Open " + (i.repo || "") + "#" + i.number + " on GitHub",
-              children: (i.repo || "") + "#" + i.number
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-title", children: i.title || "" })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-meta", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
-            "by ",
-            i.author || "?",
-            " · ",
-            issueAgeText(i.created_at)
-          ] }),
-          i.has_session ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip on", children: "session open" }) : i.eligible ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip ok", children: "queued for auto handling" }) : (i.reasons || []).map((reason) => /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip", children: reason }, reason))
-        ] }),
-        i.has_session ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className: "btn-primary pr-review-btn", disabled: true, children: "Session open" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            type: "button",
-            className: "btn-primary pr-review-btn",
-            disabled: state !== "idle",
-            onClick: async () => {
-              setState("starting");
-              try {
-                const r = await api("/api/github/issues/start", {
-                  json: { repo: i.repo, number: i.number }
-                });
-                toast("Issue session " + ((r == null ? void 0 : r.title) || "") + " — provisioning, see the sidebar");
-                setState("started");
-                refreshInstances();
-                setTimeout(onStarted, 5e3);
-              } catch (err) {
-                toast("Start work failed: " + (err.message || "error"));
-                setState("idle");
-              }
-            },
-            children: state === "starting" ? "Starting…" : state === "started" ? "Started" : "Start work"
-          }
-        )
-      ]
-    }
-  );
 }
 const CUSTOM_IDE = "__custom__";
 function Ide(_) {
@@ -33531,20 +33566,29 @@ function AssistantAgentDialog() {
   const closeDialog = useUi((s) => s.closeDialog);
   const [text, setText] = reactExports.useState("");
   const [status, setStatus] = reactExports.useState("");
+  const [agent, setAgent] = reactExports.useState("");
+  const agentChoices = useAgentChoices();
   const taRef = reactExports.useRef(null);
   reactExports.useEffect(() => {
     if (!open) return;
     setStatus("");
     (async () => {
+      var _a2, _b2;
       try {
         const r = await api("/api/assistant/instructions");
         setText((r == null ? void 0 : r.text) || "");
       } catch {
         setText("");
       }
+      try {
+        const st = await api("/api/settings");
+        setAgent(String(((_b2 = (_a2 = st == null ? void 0 : st.settings) == null ? void 0 : _a2.coding_cli) == null ? void 0 : _b2.assistant_provider) || ""));
+      } catch {
+        setAgent("");
+      }
       setTimeout(() => {
-        var _a2;
-        return (_a2 = taRef.current) == null ? void 0 : _a2.focus();
+        var _a3;
+        return (_a3 = taRef.current) == null ? void 0 : _a3.focus();
       }, 0);
     })();
   }, [open]);
@@ -33581,6 +33625,31 @@ function AssistantAgentDialog() {
           /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "assistant-agent-close", onClick: closeDialog, children: "Close" })
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Your own instructions for the personal assistant — added on top of its built-in behavior. MindFlock always keeps the assistant's core rules (how it answers, how it manages your todo list), so nothing here can break those. Describe how it should behave, what it knows, tone, etc. Applies the next time it starts." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          AgentPicker,
+          {
+            label: "Agent CLI",
+            value: agent,
+            choices: agentChoices,
+            onChange: async (v) => {
+              setAgent(v);
+              try {
+                await api("/api/settings", {
+                  method: "PUT",
+                  json: { coding_cli: { assistant_provider: v } }
+                });
+                setStatus("Agent saved — Save & restart to switch the running assistant.");
+              } catch (err) {
+                setStatus("Could not save agent: " + (err.message || ""));
+              }
+            },
+            hint: /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+              "Which coding CLI powers the assistant. It does not have to be the one your coding sessions use. Changing it takes effect the next time the assistant starts — ",
+              /* @__PURE__ */ jsxRuntimeExports.jsx("b", { children: "Save & restart" }),
+              " below does that now."
+            ] })
+          }
+        ),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "textarea",
           {

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -90,10 +90,15 @@
 
 .wt-card {
   position: relative;
-  width: min(460px, calc(100vw - 40px));
+  width: min(520px, calc(100vw - 40px));
   /* Constant size across every slide — the body flexes to absorb length
-     differences so the card never resizes as you page through. */
-  height: 440px;
+     differences so the card never resizes as you page through. Sized off the
+     tallest slide ("3. PR review", the only one with both a long body and a
+     Set up now button) with ~20px to spare: at 440px it needed 394px of a
+     320px content box and scrolled. Widening the body to 48ch did most of the
+     work — it took that slide from 394px to 350px — so if a future slide
+     overflows, re-measure before reaching for more height. */
+  height: 490px;
   max-height: calc(100vh - 40px);
   display: flex;
   flex-direction: column;
@@ -176,7 +181,7 @@
 
 .wt-body {
   margin: 0;
-  max-width: 42ch;
+  max-width: 48ch;
   font-size: 13.5px;
   line-height: 1.6;
   color: var(--muted);

--- a/frontend/src/components/dialogs/AssistantAgentDialog.tsx
+++ b/frontend/src/components/dialogs/AssistantAgentDialog.tsx
@@ -5,12 +5,15 @@ import { useEffect, useRef, useState } from "react";
 import { api } from "../../api/client";
 import { useUi } from "../../state/store";
 import { toast } from "../../lib/toast";
+import { AgentPicker, useAgentChoices } from "../settings/screens/AgentPicker";
 
 export function AssistantAgentDialog() {
   const open = useUi((s) => s.openDialog === "assistant-agent");
   const closeDialog = useUi((s) => s.closeDialog);
   const [text, setText] = useState("");
   const [status, setStatus] = useState("");
+  const [agent, setAgent] = useState("");
+  const agentChoices = useAgentChoices();
   const taRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
@@ -22,6 +25,14 @@ export function AssistantAgentDialog() {
         setText(r?.text || "");
       } catch {
         setText("");
+      }
+      try {
+        const st = await api<{
+          settings?: { coding_cli?: { assistant_provider?: string } };
+        }>("/api/settings");
+        setAgent(String(st?.settings?.coding_cli?.assistant_provider || ""));
+      } catch {
+        setAgent("");
       }
       setTimeout(() => taRef.current?.focus(), 0);
     })();
@@ -72,6 +83,30 @@ export function AssistantAgentDialog() {
           manages your todo list), so nothing here can break those. Describe how it should
           behave, what it knows, tone, etc. Applies the next time it starts.
         </p>
+        <AgentPicker
+          label="Agent CLI"
+          value={agent}
+          choices={agentChoices}
+          onChange={async (v) => {
+            setAgent(v);
+            try {
+              await api("/api/settings", {
+                method: "PUT",
+                json: { coding_cli: { assistant_provider: v } },
+              });
+              setStatus("Agent saved — Save & restart to switch the running assistant.");
+            } catch (err) {
+              setStatus("Could not save agent: " + ((err as Error).message || ""));
+            }
+          }}
+          hint={
+            <>
+              Which coding CLI powers the assistant. It does not have to be the one your
+              coding sessions use. Changing it takes effect the next time the assistant
+              starts — <b>Save &amp; restart</b> below does that now.
+            </>
+          }
+        />
         <textarea
           id="assistant-agent-text"
           ref={taRef}

--- a/frontend/src/components/onboarding/WelcomeTour.css
+++ b/frontend/src/components/onboarding/WelcomeTour.css
@@ -6,10 +6,15 @@
 
 .wt-card {
   position: relative;
-  width: min(460px, calc(100vw - 40px));
+  width: min(520px, calc(100vw - 40px));
   /* Constant size across every slide — the body flexes to absorb length
-     differences so the card never resizes as you page through. */
-  height: 440px;
+     differences so the card never resizes as you page through. Sized off the
+     tallest slide ("3. PR review", the only one with both a long body and a
+     Set up now button) with ~20px to spare: at 440px it needed 394px of a
+     320px content box and scrolled. Widening the body to 48ch did most of the
+     work — it took that slide from 394px to 350px — so if a future slide
+     overflows, re-measure before reaching for more height. */
+  height: 490px;
   max-height: calc(100vh - 40px);
   display: flex;
   flex-direction: column;
@@ -92,7 +97,7 @@
 
 .wt-body {
   margin: 0;
-  max-width: 42ch;
+  max-width: 48ch;
   font-size: 13.5px;
   line-height: 1.6;
   color: var(--muted);

--- a/frontend/src/components/settings/screens/AgentPicker.tsx
+++ b/frontend/src/components/settings/screens/AgentPicker.tsx
@@ -1,0 +1,80 @@
+/** A "which coding CLI runs this?" dropdown, shared by the surfaces that can
+ * each pick their own agent: PR review, issue handling and the Assistant.
+ *
+ * Ticketing has its own copy inline because it renders one picker per source
+ * row inside that screen's own grid; everything else is a single field and uses
+ * this. The empty option is always offered and always means "fall back" — never
+ * a provider literally named "" — and it names the fallback so the choice isn't
+ * a mystery.
+ */
+
+import { useEffect, useState } from "react";
+import { api } from "../../../api/client";
+
+interface Choices {
+  names: string[];
+  fallback: string;
+}
+
+/** Providers the app knows about, plus the app-wide default's name. Shared by
+ * every picker instance on a screen; cheap enough to fetch per mount. */
+export function useAgentChoices(): Choices {
+  const [choices, setChoices] = useState<Choices>({ names: [], fallback: "" });
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const p = await api<{ providers?: Array<{ name: string }>; default?: string }>(
+          "/api/providers"
+        );
+        if (!alive) return;
+        setChoices({
+          names: (p?.providers || []).map((x) => x.name).filter(Boolean),
+          fallback: p?.default || "",
+        });
+      } catch {
+        /* keep the empty list — the picker still offers "app default" */
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return choices;
+}
+
+export function AgentPicker({
+  label,
+  hint,
+  value,
+  choices,
+  fallbackLabel,
+  onChange,
+}: {
+  label: string;
+  hint: React.ReactNode;
+  value: string;
+  choices: Choices;
+  /** Overrides the empty option's text — the Assistant's fallback is the app
+   *  default too, but it reads better spelled out on that screen. */
+  fallbackLabel?: string;
+  onChange(next: string): void;
+}) {
+  const empty =
+    fallbackLabel ||
+    (choices.fallback ? `App default (${choices.fallback})` : "App default");
+  return (
+    <label className="set-row">
+      <span className="set-label">{label}</span>
+      <select value={value || ""} onChange={(e) => onChange(e.target.value)}>
+        <option value="">{empty}</option>
+        {choices.names.map((n) => (
+          <option key={n} value={n}>
+            {n}
+          </option>
+        ))}
+      </select>
+      <span className="set-hint">{hint}</span>
+    </label>
+  );
+}

--- a/frontend/src/components/settings/screens/GitIssues.tsx
+++ b/frontend/src/components/settings/screens/GitIssues.tsx
@@ -1,13 +1,17 @@
 /** Settings → Git issues: the issue-handling twin of PrReview.tsx. Its own
  * repo list (github.issue_repos, independent of PR review's github.repos) and
- * opt-in toggle (github.issues_enabled — absent = OFF, unlike PR review);
- * open-issues panel with skip-reason chips + force start. */
+ * opt-in toggle (github.issues_enabled — absent = OFF, unlike PR review).
+ *
+ * The screen's shape — switch, status, watched list, agent, open-work panel,
+ * Advanced — comes from ./automation so this and PR review and Ticketing stay
+ * the same screen with different nouns. */
 
 import { useEffect, useState } from "react";
 import { api } from "../../../api/client";
-import { toast } from "../../../lib/toast";
 import { refreshInstances, usePanelQuery } from "../../../state/queries";
 import { SettingField, useSettings } from "../useSettings";
+import { AgentPicker, useAgentChoices } from "./AgentPicker";
+import { AutomationSwitch, RepoListField, WorkItemRow, WorkListPanel, ageText } from "./automation";
 import { runGithubTest } from "../../dialogs/SetupDialog";
 import type { ScreenProps } from "../SettingsDialog";
 
@@ -23,20 +27,12 @@ interface OpenIssue {
   reasons?: string[];
 }
 
-function issueAgeText(iso?: string): string {
-  const t = Date.parse(iso || "");
-  if (!isFinite(t)) return "";
-  const mins = Math.max(0, Math.round((Date.now() - t) / 60000));
-  if (mins < 60) return mins + "m old";
-  const h = Math.round(mins / 60);
-  if (h < 48) return h + "h old";
-  return Math.round(h / 24) + "d old";
-}
-
 export function GitIssues({ gotoScreen }: ScreenProps) {
   const s = useSettings();
+  const agentChoices = useAgentChoices();
   const gh = (s.settings.github || {}) as {
     issues_enabled?: boolean;
+    issue_agent?: string;
     issue_repos?: string[];
     issue_skip_authors?: string[] | string;
   };
@@ -47,7 +43,6 @@ export function GitIssues({ gotoScreen }: ScreenProps) {
     ? gh.issue_skip_authors.join(", ")
     : gh.issue_skip_authors || "";
 
-  const [repoNew, setRepoNew] = useState("");
   const [skipDraft, setSkipDraft] = useState(String(skipAuthors));
   useEffect(() => setSkipDraft(String(skipAuthors)), [skipAuthors]);
   // Cached in the query client so reopening the screen keeps the last list.
@@ -74,31 +69,7 @@ export function GitIssues({ gotoScreen }: ScreenProps) {
   const saveGithub = (patch: Record<string, unknown>, okMsg: string) =>
     s.saveGroup("github", patch, okMsg);
 
-  const saveRepos = (list: string[], msg: string) =>
-    saveGithub({ issue_repos: list }, msg);
-
-  const addRepo = () => {
-    const val = repoNew.trim();
-    if (!val) return;
-    if (!/^[^\s/]+\/[^\s/]+$/.test(val)) {
-      toast("Use owner/name, e.g. MindFlock/MindFlock");
-      return;
-    }
-    if (repos.some((r) => r.toLowerCase() === val.toLowerCase())) {
-      setRepoNew("");
-      toast(val + " is already in the list");
-      return;
-    }
-    setRepoNew("");
-    saveRepos([...repos, val], "Added " + val);
-  };
-
   const n = repos.length;
-  const statusText = !n
-    ? "○ Add a repository below, then turn Automated handling on"
-    : enabled
-      ? `● Active — handling new issues in ${n} ${n === 1 ? "repository" : "repositories"}`
-      : `‖ Off — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated handling on to start`;
 
   return (
     <>
@@ -130,117 +101,111 @@ export function GitIssues({ gotoScreen }: ScreenProps) {
         are independent.
       </p>
 
-      <div
-        className="set-row set-switch-row"
-        id="gh-issues-toggle-row"
+      <AutomationSwitch
+        label="Automated handling"
         title="Turn automated issue handling on or off — your repositories are kept either way"
-      >
-        <span className="set-label">Automated handling</span>
-        {/* label wraps only the switch, so clicking the row text no longer flips it */}
-        <label className="ca-switch">
-          <input
-            type="checkbox"
-            id="gh-issues-enabled"
-            checked={enabled}
-            onChange={(e) =>
-              saveGithub(
-                { issues_enabled: e.target.checked },
-                e.target.checked ? "Automated issue handling on" : "Automated issue handling off"
-              )
-            }
-          />
-          <span className="ca-slider" />
-        </label>
-      </div>
-      <div
-        id="gh-issues-status"
-        className={"pr-status" + (n > 0 && enabled ? " on" : n > 0 ? " paused" : "")}
-      >
-        {statusText}
-      </div>
+        rowId="gh-issues-toggle-row"
+        inputId="gh-issues-enabled"
+        statusId="gh-issues-status"
+        checked={enabled}
+        onChange={(next) =>
+          saveGithub(
+            { issues_enabled: next },
+            next ? "Automated issue handling on" : "Automated issue handling off"
+          )
+        }
+        tone={n > 0 && enabled ? "on" : n > 0 ? "paused" : ""}
+        status={
+          !n
+            ? "○ Add a repository below, then turn Automated handling on"
+            : enabled
+              ? `● Active — handling new issues in ${n} ${n === 1 ? "repository" : "repositories"}`
+              : `‖ Off — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated handling on to start`
+        }
+      />
 
-      <div className="set-row">
-        <span className="set-label">Repositories to watch</span>
-        <div id="gh-issue-repos-list" className="repo-list">
-          {!repos.length ? (
-            <div className="repo-empty">
-              No repositories yet — add one below to start handling new issues.
-            </div>
-          ) : (
-            repos.map((repo) => (
-              <span className="repo-chip" key={repo}>
-                <span className="repo-chip-name">{repo}</span>
-                <button
-                  type="button"
-                  className="repo-chip-x"
-                  title={"Remove " + repo}
-                  aria-label={"Remove " + repo}
-                  onClick={() =>
-                    saveRepos(
-                      repos.filter((r) => r !== repo),
-                      "Removed " + repo
-                    )
-                  }
-                >
-                  ✕
-                </button>
-              </span>
-            ))
-          )}
-        </div>
-        <div className="repo-add-row">
-          <input
-            type="text"
-            id="gh-issue-repo-new"
-            placeholder="owner/name — e.g. mindflockai/MindFlock"
-            autoComplete="off"
-            spellCheck={false}
-            value={repoNew}
-            onChange={(e) => setRepoNew(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                addRepo();
+      <RepoListField
+        label="Repositories to watch"
+        repos={repos}
+        onSave={(list, msg) => saveGithub({ issue_repos: list }, msg)}
+        emptyText="No repositories yet — add one below to start handling new issues."
+        listId="gh-issue-repos-list"
+        inputId="gh-issue-repo-new"
+        addId="gh-issue-repo-add-btn"
+        hint={
+          <>
+            Type a repo as <code>owner/name</code>, then press Enter or click Add. This list
+            is separate from PR review's — a repo can be on either, or both.
+          </>
+        }
+      />
+
+      <AgentPicker
+        label="Agent CLI"
+        value={String(gh.issue_agent || "")}
+        choices={agentChoices}
+        onChange={(v) => s.saveField("github", "issue_agent", v)}
+        hint={
+          <>
+            Which coding CLI runs issue-handling sessions. Independent of PR review's —
+            setting one does not change the other.
+          </>
+        }
+      />
+
+      <WorkListPanel
+        label="Open issues"
+        onRefresh={loadOpenIssues}
+        note={issuesNote}
+        rowId="gh-open-issues-row"
+        refreshId="gh-issues-refresh"
+        noteId="gh-issues-note"
+        listId="gh-issues-list"
+        hint={
+          <>
+            Every open issue on the repositories above, with why auto handling has or hasn't
+            picked it up. <strong>Start work</strong> spins up a session for that issue right
+            now, bypassing the age / already-handled filters.
+          </>
+        }
+      >
+        {issuesError ? (
+          <div className="repo-empty">{issuesError}</div>
+        ) : issues === null ? null : !issuesRepos.length ? (
+          <div className="repo-empty">Add a repository above to see its open issues.</div>
+        ) : !issues.length ? (
+          <div className="repo-empty">No open issues on the watched repositories.</div>
+        ) : (
+          issues.map((i) => (
+            <WorkItemRow
+              key={(i.repo || "") + i.number}
+              reference={(i.repo || "") + "#" + i.number}
+              url={i.url}
+              title={i.title}
+              tooltip={
+                (i.repo || "") + "#" + i.number + " — " + (i.title || "") + "\nby " + (i.author || "?")
               }
-            }}
-          />
-          <button type="button" id="gh-issue-repo-add-btn" className="btn-primary" onClick={addRepo}>
-            + Add
-          </button>
-        </div>
-        <span className="set-hint">
-          Type a repo as <code>owner/name</code>, then press Enter or click Add. This list
-          is separate from PR review's — a repo can be on either, or both.
-        </span>
-      </div>
-
-      <div className="set-row" id="gh-open-issues-row">
-        <span className="set-label">Open issues</span>
-        <div className="pr-open-toolbar">
-          <button type="button" id="gh-issues-refresh" className="test-btn" onClick={loadOpenIssues}>
-            Refresh
-          </button>
-          <span id="gh-issues-note" className="pr-open-note">{issuesNote}</span>
-        </div>
-        <div id="gh-issues-list" className="pr-open-list">
-          {issuesError ? (
-            <div className="repo-empty">{issuesError}</div>
-          ) : issues === null ? null : !issuesRepos.length ? (
-            <div className="repo-empty">Add a repository above to see its open issues.</div>
-          ) : !issues.length ? (
-            <div className="repo-empty">No open issues on the watched repositories.</div>
-          ) : (
-            issues.map((i) => (
-              <OpenIssueRow key={(i.repo || "") + i.number} i={i} onStarted={relistIssues} />
-            ))
-          )}
-        </div>
-        <span className="set-hint">
-          Every open issue on the repositories above, with why auto handling has or hasn't
-          picked it up. <strong>Start work</strong> spins up a session for that issue right
-          now, bypassing the age / already-handled filters.
-        </span>
-      </div>
+              meta={`by ${i.author || "?"} · ${ageText(i.created_at)}`}
+              hasSession={i.has_session}
+              eligible={i.eligible}
+              eligibleLabel="queued for auto handling"
+              reasons={i.reasons}
+              actionLabel="Start work"
+              failPrefix="Start work failed"
+              onStart={async () => {
+                const r = await api<{ title?: string }>("/api/github/issues/start", {
+                  json: { repo: i.repo, number: i.number },
+                });
+                // The server already has a provisioning row for it: pull it now
+                // instead of leaving the sidebar blank until the next poll.
+                refreshInstances();
+                setTimeout(relistIssues, 5000);
+                return "Issue session " + (r?.title || "");
+              }}
+            />
+          ))
+        )}
+      </WorkListPanel>
 
       <details className="pr-advanced">
         <summary>Advanced options</summary>
@@ -313,74 +278,5 @@ export function GitIssues({ gotoScreen }: ScreenProps) {
         </div>
       </details>
     </>
-  );
-}
-
-function OpenIssueRow({ i, onStarted }: { i: OpenIssue; onStarted(): void }) {
-  const [state, setState] = useState<"idle" | "starting" | "started">("idle");
-  return (
-    <div
-      className="pr-open-item"
-      title={(i.repo || "") + "#" + i.number + " — " + (i.title || "") + "\nby " + (i.author || "?")}
-    >
-      <div className="pr-open-main">
-        <a
-          href={i.url || "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="pr-open-ref"
-          title={"Open " + (i.repo || "") + "#" + i.number + " on GitHub"}
-        >
-          {(i.repo || "") + "#" + i.number}
-        </a>
-        <span className="pr-open-title">{i.title || ""}</span>
-      </div>
-      <div className="pr-open-meta">
-        <span>
-          by {i.author || "?"} · {issueAgeText(i.created_at)}
-        </span>
-        {i.has_session ? (
-          <span className="pr-open-chip on">session open</span>
-        ) : i.eligible ? (
-          <span className="pr-open-chip ok">queued for auto handling</span>
-        ) : (
-          (i.reasons || []).map((reason) => (
-            <span className="pr-open-chip" key={reason}>
-              {reason}
-            </span>
-          ))
-        )}
-      </div>
-      {i.has_session ? (
-        <button type="button" className="btn-primary pr-review-btn" disabled>
-          Session open
-        </button>
-      ) : (
-        <button
-          type="button"
-          className="btn-primary pr-review-btn"
-          disabled={state !== "idle"}
-          onClick={async () => {
-            setState("starting");
-            try {
-              const r = await api<{ title?: string }>("/api/github/issues/start", {
-                json: { repo: i.repo, number: i.number },
-              });
-              toast("Issue session " + (r?.title || "") + " — provisioning, see the sidebar");
-              setState("started");
-              // The server already has a provisioning row for it: pull it now
-              // instead of leaving the sidebar blank until the next poll.
-              refreshInstances();
-              setTimeout(onStarted, 5000);
-            } catch (err) {
-              toast("Start work failed: " + ((err as Error).message || "error"));
-              setState("idle");
-            }
-          }}
-        >
-          {state === "starting" ? "Starting…" : state === "started" ? "Started" : "Start work"}
-        </button>
-      )}
-    </div>
   );
 }

--- a/frontend/src/components/settings/screens/PrReview.tsx
+++ b/frontend/src/components/settings/screens/PrReview.tsx
@@ -1,11 +1,17 @@
 /** Settings → PR review (partial 109 + section 21's github wiring): the repo
- * list IS the switch; open-PR panel with skip-reason chips + force review. */
+ * list IS the switch; open-PR panel with skip-reason chips + force review.
+ *
+ * The screen's shape — switch, status, watched list, agent, open-work panel,
+ * Advanced — comes from ./automation so this and Git issues and Ticketing stay
+ * the same screen with different nouns. This one additionally owns the GitHub
+ * token, which issue handling shares and links back to. */
 
 import { useEffect, useState } from "react";
 import { api } from "../../../api/client";
-import { toast } from "../../../lib/toast";
 import { refreshInstances, usePanelQuery } from "../../../state/queries";
 import { SettingField, useSettings } from "../useSettings";
+import { AgentPicker, useAgentChoices } from "./AgentPicker";
+import { AutomationSwitch, RepoListField, WorkItemRow, WorkListPanel, ageText } from "./automation";
 import { runGithubTest } from "../../dialogs/SetupDialog";
 import type { ScreenProps } from "../SettingsDialog";
 
@@ -23,20 +29,13 @@ interface OpenPr {
   reasons?: string[];
 }
 
-function prAgeText(iso?: string): string {
-  const t = Date.parse(iso || "");
-  if (!isFinite(t)) return "";
-  const mins = Math.max(0, Math.round((Date.now() - t) / 60000));
-  if (mins < 60) return mins + "m old";
-  const h = Math.round(mins / 60);
-  if (h < 48) return h + "h old";
-  return Math.round(h / 24) + "d old";
-}
-
 export function PrReview({ gotoScreen }: ScreenProps) {
   const s = useSettings();
+  const agentChoices = useAgentChoices();
   const gh = (s.settings.github || {}) as {
     enabled?: boolean;
+    agent?: string;
+    issue_agent?: string;
     repos?: string[];
     skip_authors?: string[] | string;
   };
@@ -47,7 +46,6 @@ export function PrReview({ gotoScreen }: ScreenProps) {
     ? gh.skip_authors.join(", ")
     : gh.skip_authors || "";
 
-  const [repoNew, setRepoNew] = useState("");
   const [skipDraft, setSkipDraft] = useState(String(skipAuthors));
   useEffect(() => setSkipDraft(String(skipAuthors)), [skipAuthors]);
 
@@ -87,31 +85,7 @@ export function PrReview({ gotoScreen }: ScreenProps) {
   const saveGithub = (patch: Record<string, unknown>, okMsg: string) =>
     s.saveGroup("github", patch, okMsg);
 
-  const saveRepos = (list: string[], msg: string) =>
-    saveGithub({ repos: list }, msg);
-
-  const addRepo = () => {
-    const val = repoNew.trim();
-    if (!val) return;
-    if (!/^[^\s/]+\/[^\s/]+$/.test(val)) {
-      toast("Use owner/name, e.g. MindFlock/MindFlock");
-      return;
-    }
-    if (repos.some((r) => r.toLowerCase() === val.toLowerCase())) {
-      setRepoNew("");
-      toast(val + " is already in the list");
-      return;
-    }
-    setRepoNew("");
-    saveRepos([...repos, val], "Added " + val);
-  };
-
   const n = repos.length;
-  const statusText = !n
-    ? "○ Add a repository below to start reviewing your PRs"
-    : enabled
-      ? `● Active — reviewing PRs in ${n} ${n === 1 ? "repository" : "repositories"}`
-      : `‖ Paused — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated review on to resume`;
 
   return (
     <>
@@ -142,115 +116,122 @@ export function PrReview({ gotoScreen }: ScreenProps) {
         ingestion is active.
       </p>
 
-      <div
-        className="set-row set-switch-row"
-        id="gh-pr-toggle-row"
+      <AutomationSwitch
+        label="Automated review"
         title="Turn automated PR review on or off — your repositories are kept either way"
-      >
-        <span className="set-label">Automated review</span>
-        {/* label wraps only the switch, so clicking the row text no longer flips it */}
-        <label className="ca-switch">
-          <input
-            type="checkbox"
-            id="gh-pr-enabled"
-            checked={enabled}
-            onChange={(e) =>
-              saveGithub(
-                { enabled: e.target.checked },
-                e.target.checked ? "Automated review on" : "Automated review paused"
-              )
-            }
-          />
-          <span className="ca-slider" />
-        </label>
-      </div>
-      <div
-        id="gh-pr-status"
-        className={"pr-status" + (n > 0 && enabled ? " on" : n > 0 ? " paused" : "")}
-      >
-        {statusText}
-      </div>
+        rowId="gh-pr-toggle-row"
+        inputId="gh-pr-enabled"
+        statusId="gh-pr-status"
+        checked={enabled}
+        onChange={(next) =>
+          saveGithub(
+            { enabled: next },
+            next ? "Automated review on" : "Automated review paused"
+          )
+        }
+        tone={n > 0 && enabled ? "on" : n > 0 ? "paused" : ""}
+        status={
+          !n
+            ? "○ Add a repository below to start reviewing your PRs"
+            : enabled
+              ? `● Active — reviewing PRs in ${n} ${n === 1 ? "repository" : "repositories"}`
+              : `‖ Paused — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated review on to resume`
+        }
+      />
 
-      <div className="set-row">
-        <span className="set-label">Repositories to review</span>
-        <div id="gh-repos-list" className="repo-list">
-          {!repos.length ? (
-            <div className="repo-empty">
-              No repositories yet — add one below to start reviewing your PRs.
-            </div>
-          ) : (
-            repos.map((repo) => (
-              <span className="repo-chip" key={repo}>
-                <span className="repo-chip-name">{repo}</span>
-                <button
-                  type="button"
-                  className="repo-chip-x"
-                  title={"Remove " + repo}
-                  aria-label={"Remove " + repo}
-                  onClick={() =>
-                    saveRepos(
-                      repos.filter((r) => r !== repo),
-                      "Removed " + repo
-                    )
-                  }
-                >
-                  ✕
-                </button>
-              </span>
-            ))
-          )}
-        </div>
-        <div className="repo-add-row">
-          <input
-            type="text"
-            id="gh-repo-new"
-            placeholder="owner/name — e.g. mindflockai/MindFlock"
-            autoComplete="off"
-            spellCheck={false}
-            value={repoNew}
-            onChange={(e) => setRepoNew(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                addRepo();
+      <RepoListField
+        label="Repositories to review"
+        repos={repos}
+        onSave={(list, msg) => saveGithub({ repos: list }, msg)}
+        emptyText="No repositories yet — add one below to start reviewing your PRs."
+        listId="gh-repos-list"
+        inputId="gh-repo-new"
+        addId="gh-repo-add-btn"
+        hint={
+          <>
+            Type a repo as <code>owner/name</code>, then press Enter or click Add. Adding one
+            turns review on; remove them all to turn it off.
+          </>
+        }
+      />
+
+      <AgentPicker
+        label="Agent CLI"
+        value={String(gh.agent || "")}
+        choices={agentChoices}
+        onChange={(v) => s.saveField("github", "agent", v)}
+        hint={
+          <>
+            Which coding CLI runs PR-review sessions. Independent of issue handling's —
+            pick a provider whose Connections row is green, or leave it on the app
+            default.
+          </>
+        }
+      />
+
+      <WorkListPanel
+        label="Open pull requests"
+        onRefresh={loadOpenPrs}
+        note={prsNote}
+        rowId="gh-open-prs-row"
+        refreshId="gh-prs-refresh"
+        noteId="gh-prs-note"
+        listId="gh-prs-list"
+        hint={
+          <>
+            Every non-draft open PR on the repositories above, with why auto review has or hasn't
+            picked it up. <strong>Begin review</strong> starts a review session for that PR right
+            now, bypassing the author / age / already-reviewed filters.
+          </>
+        }
+      >
+        {prsError ? (
+          <div className="repo-empty">{prsError}</div>
+        ) : prs === null ? null : !prsRepos.length ? (
+          <div className="repo-empty">Add a repository above to see its open PRs.</div>
+        ) : !prs.length ? (
+          <div className="repo-empty">No open pull requests on the watched repositories.</div>
+        ) : (
+          prs.map((p) => (
+            <WorkItemRow
+              key={(p.repo || "") + p.number}
+              reference={(p.repo || "") + "#" + p.number}
+              url={p.url}
+              title={p.title}
+              tooltip={
+                (p.repo || "") +
+                "#" +
+                p.number +
+                " — " +
+                (p.title || "") +
+                "\nby " +
+                (p.author || "?") +
+                " · " +
+                (p.head_ref || "?") +
+                " → " +
+                (p.base_ref || "?")
               }
-            }}
-          />
-          <button type="button" id="gh-repo-add-btn" className="btn-primary" onClick={addRepo}>
-            + Add
-          </button>
-        </div>
-        <span className="set-hint">
-          Type a repo as <code>owner/name</code>, then press Enter or click Add. Adding one
-          turns review on; remove them all to turn it off.
-        </span>
-      </div>
-
-      <div className="set-row" id="gh-open-prs-row">
-        <span className="set-label">Open pull requests</span>
-        <div className="pr-open-toolbar">
-          <button type="button" id="gh-prs-refresh" className="test-btn" onClick={loadOpenPrs}>
-            Refresh
-          </button>
-          <span id="gh-prs-note" className="pr-open-note">{prsNote}</span>
-        </div>
-        <div id="gh-prs-list" className="pr-open-list">
-          {prsError ? (
-            <div className="repo-empty">{prsError}</div>
-          ) : prs === null ? null : !prsRepos.length ? (
-            <div className="repo-empty">Add a repository above to see its open PRs.</div>
-          ) : !prs.length ? (
-            <div className="repo-empty">No open pull requests on the watched repositories.</div>
-          ) : (
-            prs.map((p) => <OpenPrRow key={(p.repo || "") + p.number} p={p} onStarted={relistPrs} />)
-          )}
-        </div>
-        <span className="set-hint">
-          Every non-draft open PR on the repositories above, with why auto review has or hasn't
-          picked it up. <strong>Begin review</strong> starts a review session for that PR right
-          now, bypassing the author / age / already-reviewed filters.
-        </span>
-      </div>
+              meta={`by ${p.author || "?"} · ${ageText(p.created_at)} · into ${p.base_ref || "?"}`}
+              hasSession={p.has_session}
+              eligible={p.eligible}
+              eligibleLabel="queued for auto review"
+              reasons={p.reasons}
+              actionLabel="Begin review"
+              failPrefix="Begin review failed"
+              onStart={async () => {
+                const r = await api<{ title?: string }>("/api/github/prs/review", {
+                  json: { repo: p.repo, number: p.number },
+                });
+                // The server already has a provisioning row for it: pull it now
+                // instead of leaving the sidebar blank through the PR clone.
+                refreshInstances();
+                setTimeout(relistPrs, 5000);
+                return "Review session " + (r?.title || "");
+              }}
+            />
+          ))
+        )}
+      </WorkListPanel>
 
       <details className="pr-advanced">
         <summary>Advanced options</summary>
@@ -328,86 +309,5 @@ export function PrReview({ gotoScreen }: ScreenProps) {
         </div>
       </details>
     </>
-  );
-}
-
-function OpenPrRow({ p, onStarted }: { p: OpenPr; onStarted(): void }) {
-  const [state, setState] = useState<"idle" | "starting" | "started">("idle");
-  return (
-    <div
-      className="pr-open-item"
-      title={
-        (p.repo || "") +
-        "#" +
-        p.number +
-        " — " +
-        (p.title || "") +
-        "\nby " +
-        (p.author || "?") +
-        " · " +
-        (p.head_ref || "?") +
-        " → " +
-        (p.base_ref || "?")
-      }
-    >
-      <div className="pr-open-main">
-        <a
-          href={p.url || "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="pr-open-ref"
-          title={"Open " + (p.repo || "") + "#" + p.number + " on GitHub"}
-        >
-          {(p.repo || "") + "#" + p.number}
-        </a>
-        <span className="pr-open-title">{p.title || ""}</span>
-      </div>
-      <div className="pr-open-meta">
-        <span>
-          by {p.author || "?"} · {prAgeText(p.created_at)} · into {p.base_ref || "?"}
-        </span>
-        {p.has_session ? (
-          <span className="pr-open-chip on">session open</span>
-        ) : p.eligible ? (
-          <span className="pr-open-chip ok">queued for auto review</span>
-        ) : (
-          (p.reasons || []).map((reason) => (
-            <span className="pr-open-chip" key={reason}>
-              {reason}
-            </span>
-          ))
-        )}
-      </div>
-      {p.has_session ? (
-        <button type="button" className="btn-primary pr-review-btn" disabled>
-          Session open
-        </button>
-      ) : (
-        <button
-          type="button"
-          className="btn-primary pr-review-btn"
-          disabled={state !== "idle"}
-          onClick={async () => {
-            setState("starting");
-            try {
-              const r = await api<{ title?: string }>("/api/github/prs/review", {
-                json: { repo: p.repo, number: p.number },
-              });
-              toast("Review session " + (r?.title || "") + " — provisioning, see the sidebar");
-              setState("started");
-              // The server already has a provisioning row for it: pull it now
-              // instead of leaving the sidebar blank through the PR clone.
-              refreshInstances();
-              setTimeout(onStarted, 5000);
-            } catch (err) {
-              toast("Begin review failed: " + ((err as Error).message || "error"));
-              setState("idle");
-            }
-          }}
-        >
-          {state === "starting" ? "Starting…" : state === "started" ? "Started" : "Begin review"}
-        </button>
-      )}
-    </div>
   );
 }

--- a/frontend/src/components/settings/screens/Ticketing.tsx
+++ b/frontend/src/components/settings/screens/Ticketing.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../api/client";
+import { AutomationSwitch } from "./automation";
 import { refreshConfig, refreshInstances, usePanelQuery } from "../../../state/queries";
 import { toast } from "../../../lib/toast";
 import type { ScreenProps } from "../SettingsDialog";
@@ -40,7 +41,7 @@ interface AgentChoices {
  * desired state, POST /api/mindflock/{start,stop} to flip it) and the same
  * ["mindflock-status"] query key, so the two switches stay in lock-step.
  * Clicking the row text does nothing — only the switch itself flips it. */
-function IngestionToggle() {
+function IngestionToggle({ sourceCount }: { sourceCount: number }) {
   const [busy, setBusy] = useState(false);
   const [optimistic, setOptimistic] = useState<boolean | null>(null);
   const { data: status, refetch } = useQuery({
@@ -72,25 +73,25 @@ function IngestionToggle() {
     }
   };
 
+  const n = sourceCount;
   return (
-    <div
-      className="set-row set-switch-row"
-      id="tk-ingestion-toggle-row"
+    <AutomationSwitch
+      label="Automated ingestion"
       title="Run or stop ticket ingestion — polls your connected sources and auto-creates a coding session for each assigned ticket. Stays in this state across restarts."
-    >
-      <span className="set-label">Automated ingestion</span>
-      {/* label wraps only the switch, so clicking the row text no longer flips it */}
-      <label className="ca-switch">
-        <input
-          type="checkbox"
-          id="tk-ingestion-enabled"
-          checked={desired}
-          disabled={busy}
-          onChange={(e) => toggle(e.target.checked)}
-        />
-        <span className="ca-slider" />
-      </label>
-    </div>
+      rowId="tk-ingestion-toggle-row"
+      inputId="tk-ingestion-enabled"
+      statusId="tk-ingestion-status"
+      checked={desired}
+      onChange={(next) => { if (!busy) toggle(next); }}
+      tone={n > 0 && desired ? "on" : n > 0 ? "paused" : ""}
+      status={
+        !n
+          ? "○ Add a ticketing source below to start turning tickets into sessions"
+          : desired
+            ? `● Active — polling ${n} ${n === 1 ? "source" : "sources"} for tickets assigned to you`
+            : `‖ Paused — ${n} ${n === 1 ? "source" : "sources"} kept; turn Automated ingestion on to resume`
+      }
+    />
   );
 }
 
@@ -206,7 +207,7 @@ export function Ticketing(_: ScreenProps) {
         two Jira sites) — each with its own credentials. Stored in ~/.mindflock/settings.json
         (never committed).
       </p>
-      <IngestionToggle />
+      <IngestionToggle sourceCount={(sources || []).length} />
       <div id="ticketing-sources">
         {sources.map((src) => (
           <SourceCard
@@ -665,9 +666,13 @@ function SourceCard({
   const provName = meta?.label || source.provider;
   const detail = (source.label || source.member_id || source.repo_url || "").trim();
   const base = detail ? provName + " — " + detail : provName;
-  // A non-default agent is worth seeing without expanding the card: it is the
-  // difference between this queue running on a cloud CLI and on a local model.
-  const summary = source.agent ? base + " · " + source.agent : base;
+  // Always show which CLI this queue runs, not just when it is overridden.
+  // Saved sources render collapsed, so an agent shown only when explicitly set
+  // made the common case — "it's on the app default" — indistinguishable from
+  // "this source has no agent setting at all", which is what sent people
+  // looking for the picker in the first place.
+  const summary =
+    base + " · " + (source.agent || (agents.fallback ? agents.fallback + " (default)" : "app default"));
   const repoMissing = !(source.repo_url || "").trim();
 
   const testPayload = () => {
@@ -763,7 +768,7 @@ function SourceCard({
           <span className="set-hint">Required — tickets from this source clone into this repo.</span>
         </label>
         <label className="set-row">
-          <span className="set-label">Agent</span>
+          <span className="set-label">Agent CLI</span>
           <select
             className="tk-agent"
             data-tk-field="agent"

--- a/frontend/src/components/settings/screens/automation.tsx
+++ b/frontend/src/components/settings/screens/automation.tsx
@@ -1,0 +1,309 @@
+/** The shared shell behind the three "MindFlock watches X and starts sessions"
+ * screens: PR review, Git issues and Ticketing.
+ *
+ * They had drifted into three dialects of the same screen — same master switch,
+ * same status line, same watched-things list, same open-work panel with a
+ * force-start button, same Advanced block — with different wording, different
+ * ordering and, in Ticketing's case, a missing status line and a differently
+ * named agent field. Every difference was incidental, and each one cost a reader
+ * a moment working out whether it meant something.
+ *
+ * The pieces here are the vocabulary all three now speak. What legitimately
+ * differs (Ticketing is multi-source; PR review owns the shared GitHub token)
+ * stays in the individual screens.
+ */
+
+import { useState } from "react";
+import { toast } from "../../../lib/toast";
+
+/** "3h old" / "20m old" / "2d old" — one implementation, three screens. */
+export function ageText(iso?: string): string {
+  const t = Date.parse(iso || "");
+  if (!isFinite(t)) return "";
+  const mins = Math.max(0, Math.round((Date.now() - t) / 60000));
+  if (mins < 60) return mins + "m old";
+  const h = Math.round(mins / 60);
+  if (h < 48) return h + "h old";
+  return Math.round(h / 24) + "d old";
+}
+
+/** Master on/off switch plus the one-line status underneath it.
+ *
+ * The two are one component because the status is only ever a readout of the
+ * switch and the watched-list size; keeping them together is what stops the
+ * three screens from describing the same three states in three ways. */
+export function AutomationSwitch({
+  label,
+  title,
+  rowId,
+  inputId,
+  statusId,
+  checked,
+  onChange,
+  status,
+  tone,
+}: {
+  label: string;
+  title: string;
+  rowId?: string;
+  inputId?: string;
+  statusId?: string;
+  checked: boolean;
+  onChange(next: boolean): void;
+  /** The status sentence. Convention: "● " active, "‖ " paused, "○ " not set up. */
+  status: string;
+  /** "on" tints it live, "paused" tints it muted, "" is the not-yet-set-up grey. */
+  tone: "on" | "paused" | "";
+}) {
+  return (
+    <>
+      <div className="set-row set-switch-row" id={rowId} title={title}>
+        <span className="set-label">{label}</span>
+        {/* label wraps only the switch, so clicking the row text never flips it */}
+        <label className="ca-switch">
+          <input
+            type="checkbox"
+            id={inputId}
+            checked={checked}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+          <span className="ca-slider" />
+        </label>
+      </div>
+      <div id={statusId} className={"pr-status" + (tone ? " " + tone : "")}>
+        {status}
+      </div>
+    </>
+  );
+}
+
+/** The `owner/name` chip list + add row that PR review and Git issues both use
+ * to choose what gets watched. */
+export function RepoListField({
+  label,
+  repos,
+  onSave,
+  emptyText,
+  hint,
+  listId,
+  inputId,
+  addId,
+}: {
+  label: string;
+  repos: string[];
+  /** Called with the new list and a toast message. */
+  onSave(next: string[], msg: string): void;
+  emptyText: string;
+  hint: React.ReactNode;
+  listId?: string;
+  inputId?: string;
+  addId?: string;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const add = () => {
+    const val = draft.trim();
+    if (!val) return;
+    if (!/^[^\s/]+\/[^\s/]+$/.test(val)) {
+      toast("Use owner/name, e.g. MindFlock/MindFlock");
+      return;
+    }
+    if (repos.some((r) => r.toLowerCase() === val.toLowerCase())) {
+      setDraft("");
+      toast(val + " is already in the list");
+      return;
+    }
+    setDraft("");
+    onSave([...repos, val], "Added " + val);
+  };
+
+  return (
+    <div className="set-row">
+      <span className="set-label">{label}</span>
+      <div id={listId} className="repo-list">
+        {!repos.length ? (
+          <div className="repo-empty">{emptyText}</div>
+        ) : (
+          repos.map((repo) => (
+            <span className="repo-chip" key={repo}>
+              <span className="repo-chip-name">{repo}</span>
+              <button
+                type="button"
+                className="repo-chip-x"
+                title={"Remove " + repo}
+                aria-label={"Remove " + repo}
+                onClick={() =>
+                  onSave(
+                    repos.filter((r) => r !== repo),
+                    "Removed " + repo
+                  )
+                }
+              >
+                ✕
+              </button>
+            </span>
+          ))
+        )}
+      </div>
+      <div className="repo-add-row">
+        <input
+          type="text"
+          id={inputId}
+          placeholder="owner/name — e.g. mindflockai/MindFlock"
+          autoComplete="off"
+          spellCheck={false}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              add();
+            }
+          }}
+        />
+        <button type="button" id={addId} className="btn-primary" onClick={add}>
+          + Add
+        </button>
+      </div>
+      <span className="set-hint">{hint}</span>
+    </div>
+  );
+}
+
+/** "Here is the work we can see, and why each item has or hasn't been picked
+ * up" — open PRs, open issues, assigned tickets. */
+export function WorkListPanel({
+  label,
+  onRefresh,
+  note,
+  hint,
+  children,
+  rowId,
+  refreshId,
+  noteId,
+  listId,
+  toolbarExtra,
+}: {
+  label: string;
+  onRefresh(): void;
+  note?: string;
+  hint: React.ReactNode;
+  children: React.ReactNode;
+  rowId?: string;
+  refreshId?: string;
+  noteId?: string;
+  listId?: string;
+  /** Ticketing puts its bucket picker here. */
+  toolbarExtra?: React.ReactNode;
+}) {
+  return (
+    <div className="set-row" id={rowId}>
+      <span className="set-label">{label}</span>
+      <div className="pr-open-toolbar">
+        <button type="button" id={refreshId} className="test-btn" onClick={onRefresh}>
+          Refresh
+        </button>
+        {toolbarExtra}
+        {note ? (
+          <span id={noteId} className="pr-open-note">
+            {note}
+          </span>
+        ) : null}
+      </div>
+      <div id={listId} className="pr-open-list">
+        {children}
+      </div>
+      <span className="set-hint">{hint}</span>
+    </div>
+  );
+}
+
+/** One row of a WorkListPanel: reference, title, meta, eligibility chips and
+ * the force-start button. */
+export function WorkItemRow({
+  reference,
+  url,
+  title,
+  meta,
+  tooltip,
+  hasSession,
+  eligible,
+  eligibleLabel,
+  reasons,
+  actionLabel,
+  onStart,
+  failPrefix,
+}: {
+  reference: string;
+  url?: string;
+  title?: string;
+  meta: React.ReactNode;
+  tooltip: string;
+  hasSession?: boolean;
+  eligible?: boolean;
+  /** e.g. "queued for auto review" */
+  eligibleLabel: string;
+  reasons?: string[];
+  /** e.g. "Begin review" */
+  actionLabel: string;
+  /** Starts the session; resolve with the created session's title for the toast. */
+  onStart(): Promise<string>;
+  /** e.g. "Begin review failed" */
+  failPrefix: string;
+}) {
+  const [state, setState] = useState<"idle" | "starting" | "started">("idle");
+  return (
+    <div className="pr-open-item" title={tooltip}>
+      <div className="pr-open-main">
+        <a
+          href={url || "#"}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="pr-open-ref"
+          title={"Open " + reference + " on GitHub"}
+        >
+          {reference}
+        </a>
+        <span className="pr-open-title">{title || ""}</span>
+      </div>
+      <div className="pr-open-meta">
+        <span>{meta}</span>
+        {hasSession ? (
+          <span className="pr-open-chip on">session open</span>
+        ) : eligible ? (
+          <span className="pr-open-chip ok">{eligibleLabel}</span>
+        ) : (
+          (reasons || []).map((reason) => (
+            <span className="pr-open-chip" key={reason}>
+              {reason}
+            </span>
+          ))
+        )}
+      </div>
+      {hasSession ? (
+        <button type="button" className="btn-primary pr-review-btn" disabled>
+          Session open
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="btn-primary pr-review-btn"
+          disabled={state !== "idle"}
+          onClick={async () => {
+            setState("starting");
+            try {
+              const created = await onStart();
+              toast(created + " — provisioning, see the sidebar");
+              setState("started");
+            } catch (err) {
+              toast(failPrefix + ": " + ((err as Error).message || "error"));
+              setState("idle");
+            }
+          }}
+        >
+          {state === "starting" ? "Starting…" : state === "started" ? "Started" : actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/tests/unit/test_default_program_resolution.py
+++ b/tests/unit/test_default_program_resolution.py
@@ -1,0 +1,240 @@
+"""Settings → Coding provider must decide what actually launches.
+
+The regression these guard against: the chosen default lived in
+``settings.json`` (``coding_cli.default_provider``) while every launch path read
+``config.json``'s ``default_program``, which is seeded once on first run by a
+helper that only hunts for ``claude``. Nothing bridged the two, so picking a
+different default changed the Providers badge and ``mindflock doctor`` and
+nothing else — every session, ingested or hand-started, still ran Claude.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.config import program as P
+
+
+class _Cfg:
+    def __init__(self, program: str) -> None:
+        self._program = program
+
+    def GetProgram(self) -> str:
+        return self._program
+
+
+def _settings(default_provider: str):
+    """A stand-in for the settings store exposing only what the resolver reads."""
+    return type(
+        "S",
+        (),
+        {"coding_cli": type("C", (), {"default_provider": default_provider})()},
+    )()
+
+
+class TestResolveDefaultProgram:
+    def test_settings_choice_beats_the_engine_config(self, monkeypatch):
+        """The whole point: config.json still says claude on every install that
+        predates this, so the user's pick has to win or nothing changes."""
+        monkeypatch.setattr(P, "load_settings", lambda: _settings("codex"))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg("claude"))
+        assert P.resolve_default_program() == "codex"
+
+    def test_falls_back_to_engine_config_when_nothing_is_chosen(self, monkeypatch):
+        monkeypatch.setattr(P, "load_settings", lambda: _settings(""))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg("aider"))
+        assert P.resolve_default_program() == "aider"
+
+    def test_blank_setting_is_not_a_choice(self, monkeypatch):
+        """A whitespace-only value is an empty form field, not a provider named
+        ' ' — it must not shadow the engine config."""
+        monkeypatch.setattr(P, "load_settings", lambda: _settings("   "))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg("goose"))
+        assert P.resolve_default_program() == "goose"
+
+    @pytest.mark.parametrize("broken", ["settings", "config", "both"])
+    def test_a_broken_store_degrades_instead_of_raising(self, monkeypatch, broken):
+        """Every caller is mid-launch; an unreadable store must not become an
+        exception that kills the session."""
+
+        def _boom():
+            raise OSError("unreadable")
+
+        monkeypatch.setattr(
+            P,
+            "load_settings",
+            _boom if broken in ("settings", "both") else lambda: _settings(""),
+        )
+        monkeypatch.setattr(
+            P,
+            "LoadConfig",
+            _boom if broken in ("config", "both") else lambda: _Cfg("codex"),
+        )
+        expected = "claude" if broken in ("config", "both") else "codex"
+        assert P.resolve_default_program() == expected
+
+    def test_last_resort_is_the_literal_default(self, monkeypatch):
+        monkeypatch.setattr(P, "load_settings", lambda: _settings(""))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg(""))
+        assert P.resolve_default_program() == P.DEFAULT_PROGRAM == "claude"
+
+
+class TestLaunchPathsUseTheResolver:
+    """Each launch path resolved the default independently before this, which is
+    how they drifted. These pin them to the shared chain."""
+
+    def test_ingestion_engine_path(self, monkeypatch):
+        from backend.ticket_ingestion import session_runner
+
+        monkeypatch.setattr(P, "load_settings", lambda: _settings("codex"))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg("claude"))
+        assert session_runner._resolve_program("") == "codex"
+
+    def test_ingestion_standalone_path(self, monkeypatch):
+        from backend.ticket_ingestion import claude_runner
+
+        monkeypatch.setattr(P, "load_settings", lambda: _settings("codex"))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg("claude"))
+        assert claude_runner.default_agent() == "codex"
+
+    def test_an_explicit_per_source_agent_still_wins(self, monkeypatch):
+        """A ticketing source that names its own CLI outranks the global
+        default — otherwise per-source routing would be silently ignored."""
+        from backend.ticket_ingestion import session_runner
+
+        monkeypatch.setattr(P, "load_settings", lambda: _settings("codex"))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg("claude"))
+        assert session_runner._resolve_program("aider") == "aider"
+
+
+def _pipeline(github_agent="", issue_agent="", engine_agent=""):
+    """A PipelineConfig carrying only the fields the agent chain reads."""
+    from backend.ticket_ingestion.config import (
+        EngineConfig,
+        GithubConfig,
+        PipelineConfig,
+    )
+
+    gh = GithubConfig(
+        base_branch="main",
+        min_age_minutes=15,
+        poll_interval_seconds=60,
+        enabled=True,
+        skip_authors=[],
+        agent=github_agent,
+        issue_agent=issue_agent,
+    )
+    cfg = PipelineConfig()
+    cfg.github = gh
+    cfg.engine = EngineConfig(agent=engine_agent)
+    return cfg
+
+
+class TestPerSurfaceAgents:
+    """PR review and issue handling each pick their own CLI. They are separately
+    configured features — separate repo lists, separate toggles — so neither may
+    quietly inherit the other's choice."""
+
+    def test_pr_review_uses_its_own_agent(self):
+        assert _pipeline(github_agent="codex").pr_agent() == "codex"
+
+    def test_issue_handling_uses_its_own_agent(self):
+        assert _pipeline(issue_agent="aider").issue_agent() == "aider"
+
+    def test_issue_handling_does_not_inherit_the_review_agent(self):
+        """Setting only PR review's CLI must leave issue handling on the shared
+        default, not silently adopt the review one."""
+        cfg = _pipeline(github_agent="codex")
+        assert cfg.pr_agent() == "codex"
+        assert cfg.issue_agent() == ""
+
+    def test_review_does_not_inherit_the_issue_agent(self):
+        cfg = _pipeline(issue_agent="aider")
+        assert cfg.issue_agent() == "aider"
+        assert cfg.pr_agent() == ""
+
+    def test_both_fall_back_to_the_pipeline_wide_agent(self):
+        cfg = _pipeline(engine_agent="goose")
+        assert cfg.pr_agent() == "goose"
+        assert cfg.issue_agent() == "goose"
+
+    def test_a_surface_agent_outranks_the_pipeline_wide_one(self):
+        cfg = _pipeline(github_agent="codex", issue_agent="aider", engine_agent="goose")
+        assert cfg.pr_agent() == "codex"
+        assert cfg.issue_agent() == "aider"
+
+    def test_unset_means_empty_so_the_resolver_decides(self):
+        cfg = _pipeline()
+        assert cfg.pr_agent() == ""
+        assert cfg.issue_agent() == ""
+
+
+class TestAssistantProgram:
+    def test_uses_its_own_setting_first(self, monkeypatch):
+        """The assistant was hardcoded to claude, which made it unusable for
+        anyone who had never set Claude up."""
+        from backend.web.addons import assistant
+        from backend.config import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod,
+            "load_settings",
+            lambda: type(
+                "S",
+                (),
+                {
+                    "coding_cli": type(
+                        "C", (), {"assistant_provider": "codex", "default_provider": ""}
+                    )()
+                },
+            )(),
+        )
+        assert assistant._assistant_program() == "codex"
+
+    def test_falls_back_to_the_shared_default(self, monkeypatch):
+        from backend.web.addons import assistant
+        from backend.config import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod,
+            "load_settings",
+            lambda: type(
+                "S",
+                (),
+                {"coding_cli": type("C", (), {"assistant_provider": ""})()},
+            )(),
+        )
+        monkeypatch.setattr(P, "load_settings", lambda: _settings("aider"))
+        monkeypatch.setattr(P, "LoadConfig", lambda: _Cfg("claude"))
+        assert assistant._assistant_program() == "aider"
+
+
+class TestSettingsRoundTrip:
+    """The new fields have to survive a save/load cycle or the pickers silently
+    forget what you chose."""
+
+    def test_github_agents(self):
+        from backend.config.settings import GithubSettings
+
+        gh = GithubSettings(agent="codex", issue_agent="aider")
+        again = GithubSettings.from_dict(gh.to_dict())
+        assert (again.agent, again.issue_agent) == ("codex", "aider")
+
+    def test_github_agents_are_omitted_when_unset(self):
+        """Blank must not be written, so an unset picker keeps falling through
+        rather than pinning an empty provider name into settings.json."""
+        from backend.config.settings import GithubSettings
+
+        assert "agent" not in GithubSettings().to_dict()
+        assert "issue_agent" not in GithubSettings().to_dict()
+
+    def test_assistant_provider(self):
+        from backend.config.settings import CodingCliSettings
+
+        cc = CodingCliSettings(assistant_provider="goose")
+        assert CodingCliSettings.from_dict(cc.to_dict()).assistant_provider == "goose"
+
+    def test_assistant_provider_omitted_when_unset(self):
+        from backend.config.settings import CodingCliSettings
+
+        assert "assistant_provider" not in CodingCliSettings().to_dict()

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -421,9 +421,17 @@ def test_settings_panel_refresh_asks_the_server_to_skip_its_cache():
     assert '"gh-prs-refresh"' in js
     # A force start does NOT force a sweep: has_session is annotated live on
     # every response, so the cheap re-list already shows the new session.
-    assert "onStarted: relistPrs" in js
-    assert "onStarted: relistIssues" in js
-    assert "onStarted: relistTickets" in js
+    # PR review and Git issues call these inside the shared WorkItemRow's
+    # onStart (screens/automation.tsx) rather than through an `onStarted` prop,
+    # so assert the re-list is still wired, not how it is passed. The negative
+    # below is the actual contract: the refresh-only `loadOpen*` sweep must not
+    # be what a force start triggers.
+    assert "relistPrs" in js
+    assert "relistIssues" in js
+    assert "relistTickets" in js
+    for sweep in ("loadOpenPrs", "loadOpenIssues"):
+        # Referenced exactly once — by the Refresh button, not by a force start.
+        assert js.count(sweep) == 2, f"{sweep} should only be the Refresh handler"
 
 
 def test_settings_panel_repolls_only_while_the_server_reports_stale():

--- a/tests/unit/test_pr_review_settings.py
+++ b/tests/unit/test_pr_review_settings.py
@@ -221,7 +221,12 @@ def test_app_js_wires_pr_review_repos_and_toggle():
     assert "skip_authors" in js
     # Multi-repo add/remove: renders chips and persists the whole array.
     assert "repo-chip" in js
-    assert "addRepo" in js
+    # The add flow moved into the shared RepoListField (screens/automation.tsx)
+    # when PR review, Git issues and Ticketing were unified, so assert on its
+    # two guards rather than on the old local `addRepo` identifier. Exactly one
+    # copy of each IS the point: PR review and Git issues had their own before.
+    assert js.count("Use owner/name") == 1  # owner/name format guard
+    assert js.count("is already in the list") == 1  # duplicate guard
     assert "repos:" in js  # POST { github: { repos: [...] } }
     # Explicit pause toggle owns github.enabled; a 3-state status line reflects it.
     assert "Paused —" in js


### PR DESCRIPTION
## The bug

Settings → Coding provider has never decided what actually launches.

It writes `coding_cli.default_provider` into `settings.json`. Every launch path reads `default_program` out of `config.json` — a different store, seeded once on first run by a helper that only hunts for `claude`, and which the UI never writes to. Nothing bridged them, so picking a default changed the Providers screen badge and `mindflock doctor` and nothing else. Ingested tickets, PR-review sessions, issue sessions and the New Session dialog all still ran Claude Code.

`backend/config/program.py` is now the single answer to *which CLI, when nobody asked for a specific one*: chosen provider → engine config → `claude`. The engine bridge, the standalone tmux launcher and the web layer all resolve through it, so they can't drift again. It reads fresh rather than from the config snapshot taken at server start, so changing the default no longer needs a restart, and an explicitly chosen agent still outranks it.

It lives in its own module because `settings.py` already imports `config.py` — putting the resolver in either would close an import cycle.

## Then the same choice, per surface

PR review, issue handling and the Assistant each get their own agent CLI (`github.agent`, `github.issue_agent`, `coding_cli.assistant_provider`), the way a ticketing source already could since 0.1.8.

Issue handling deliberately does **not** inherit PR review's choice, or vice versa — separate repo lists, separate toggles, separate features, so inheriting would surprise anyone who set one and not the other. Both fall back to `[mindflock].agent`, then the resolved default. There's a test pinning that.

The Assistant needed this most: it was hardcoded to `claude` in two places, which made it unusable for anyone who had never set Claude up.

## Unifying the three screens

PR review, Git issues and Ticketing had drifted into three dialects of one layout, and every incidental difference cost a reader a moment working out whether it meant something.

All three now read the same way top to bottom — switch → status line → what's watched → agent CLI → open-work panel → Advanced — from shared pieces in `settings/screens/automation.tsx`. **PrReview goes 431 → 313 lines, GitIssues 402 → 283**, with 309 shared.

Ticketing keeps its own body (it's genuinely multi-source; forcing it into a repo-chip list would be a worse screen, not a more unified one) but gains the status line its toggle never had and matches the **Agent CLI** label.

The picker is a top-level field on all three now. Which CLI does the work is not a tuning knob.

A collapsed ticketing source also always names its CLI now — `Shortcut — Allure Security · claude (default)`. Naming it only when overridden made "on the app default" indistinguishable from "this source has no agent setting", which is what sent people hunting for the picker.

## Welcome tour

Two slides scrolled: "Welcome to MindFlock" needed 327px and "3. PR review" 394px inside a 320px content box, and the latter hid its own *Set up now* button. The card is now 520×490 with a 48ch body — widening did most of the work, taking that slide from 394px to 350px — which fits all twelve with room to spare.

## Two tests I changed rather than deleted

`test_app_js_wires_pr_review_repos_and_toggle` and `test_settings_panel_refresh_asks_the_server_to_skip_its_cache` asserted on internal identifiers this renamed (`addRepo`, `onStarted: relistPrs`), not on behaviour. Both are re-pointed at the contract they were protecting, and one got stronger: `count("Use owner/name") == 1` now fails if anyone re-duplicates the repo-add flow, and the force-start rule gained the negative assertion it always described in its comment but never actually checked.

## Verification

- 3654 unit tests pass (23 new), `tsc --noEmit` clean, bundle rebuilt and deterministic.
- Driven in the running app: all 12 tour slides measured at `370/370` (no scroll); all three settings screens confirmed to render switch + status + Agent CLI + work panel.
- New settings fields round-trip through the real `update_settings` API.
