### PR TITLE
Release 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-08-03
+
 ### Fixed
 
 - **The default coding provider was ignored by everything that launches a
@@ -694,7 +696,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.9
 [0.1.8]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.8
 [0.1.7]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.7
 [0.1.6]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.6

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.8"
+version = "0.1.9"
 description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **v0.1.9**. Version bumped across the three manifests + `uv.lock`; the CHANGELOG's `[Unreleased]` section rolls into `[0.1.9] - 2026-08-03`.

Contents — everything merged in #33:

**Fixed**
- **The default coding provider was ignored by everything that launches a session.** Settings → Coding provider wrote `coding_cli.default_provider` into `settings.json` while every launch path read `default_program` out of `config.json`, a store the UI never writes to. Choosing a default changed the Providers badge and `mindflock doctor` and nothing else — ingested tickets, PR-review sessions, issue sessions and the New Session dialog all still ran Claude Code.
- **Two welcome-tour slides scrolled**, and the PR-review one hid its own *Set up now* button.

**Added**
- **PR review, issue handling and the Assistant each pick their own agent CLI**, the way a ticketing source already could. The Assistant needed it most — it was hardcoded to `claude`, unusable for anyone who had never set Claude up.

**Changed**
- **PR review, Git issues and Ticketing are one screen with different nouns.** Ticketing gains the status line its toggle never had.
- The agent picker is a top-level field, not an Advanced one.

Tag `v0.1.9` goes on main once this merges, which triggers the release build.