### PR TITLE
Make the provider you picked the provider every launch uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The per-surface Agent CLI pickers chose a provider that nothing read.**
+  0.1.9 added `github.agent` and `github.issue_agent` so PR review and issue
+  handling could each run their own coding CLI, and the settings round-tripped
+  correctly — but `_parse_github` built its `GithubConfig` without passing either
+  field, so both sat at their `""` dataclass default however they were
+  configured. The merged config computed the right value and then threw it away
+  one line before anything could read it. `pr_agent()` and `issue_agent()` were
+  correct and unreachable, so every review and every issue session fell through
+  to the app-wide default provider.
+
+  The gap survived the suite because the precedence logic was tested against a
+  hand-built `GithubConfig` and the storage against `GithubSettings`, with
+  nothing exercising the parse between them. That seam is now covered.
+
+- **"Begin review" ignored the Agent CLI setting directly above it.** The forced
+  PR-review route passed `ENGINE.default_program()` outright, so the dropdown in
+  Settings → PR review governed only the auto monitor: clicking the button
+  launched the app-wide default. It now resolves through `pr_review.review_agent()`,
+  the same `pr_agent()` chain the monitor uses. The issue equivalent had the
+  matching bug one level up — `prepare_start` read the ingestion-wide
+  `agent_for()`, which skips straight past `github.issue_agent`.
+
+- **Switching provider needed a pipeline restart to take effect.** The ingestion
+  pipeline calls `load_config()` once at startup and holds that snapshot for the
+  life of the process, which is right for poll intervals and tokens and wrong for
+  "which CLI should this session run": a provider chosen in Settings was invisible
+  until the pipeline was restarted. Agent choice is now re-read at the moment of
+  launch — the rule `resolve_default_program` already followed for the app-wide
+  default — via `config_for_launch` / `fresh_agent`, across tickets, issues and
+  both PR runners. An injected config stays the fallback rather than being
+  discarded, so a caller that builds one by hand still has it honoured.
+
+- **A ticket that had run before could not be run again.** Ending a session
+  deliberately keeps its worktree, so a second run of the same ticket met a
+  leftover worktree still holding the feature branch and died in
+  `git worktree add` with "already checked out at …". Nothing in the UI could see
+  it: with no live session the panel enabled **Run ticket**, and the failure was
+  then recorded with advice to delete the `state.json` ledger entry — which
+  clears the *record* of the failure and leaves its cause in place, so the retry
+  failed identically.
+
+  Force-start now reclaims the leftover first, under two rules it never breaks:
+  it never touches a worktree a live session owns, and it never removes one
+  holding work (uncommitted changes, a stash, or unpushed commits). Anything it
+  declines to take keeps the previous behaviour, so the worst case is the error
+  message you already got.
+
+- **A recorded failure now says what went wrong.** The ledger stored a
+  `failure_reason` — "branch '…' is already checked out at `<path>`" — and the
+  loader dropped it, leaving the panel to show a generic chip whose suggested
+  remedy fixed nothing. The reason is carried through and shown in full (chip
+  ellipsizes, tooltip has all of it; the actionable half of these messages is at
+  the end, so clipping server-side removed exactly the part worth reading).
+
 ## [0.1.9] - 2026-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-08-03
+
 ### Fixed
+
+- **The default coding provider was ignored by everything that launches a
+  session.** Settings → Coding provider writes `coding_cli.default_provider`
+  into `settings.json`, but every launch path read `default_program` out of
+  `config.json` — a different store, seeded once on first run by a helper that
+  only ever hunts for `claude`, and which the UI never writes to. Nothing
+  bridged the two, so choosing a default changed the Providers screen badge and
+  `mindflock doctor` and nothing else: ingested tickets, PR-review sessions,
+  issue sessions and the New Session dialog all still launched Claude Code.
+
+  `backend.config.program.resolve_default_program` is now the single answer to
+  "which CLI, when nobody asked for a specific one" — the chosen provider, then
+  the engine config, then `claude` — and the engine bridge, the standalone tmux
+  launcher and the web layer all resolve through it. It is also read fresh
+  rather than from the config snapshot taken at server start, so changing the
+  default no longer needs a restart. An explicitly chosen agent (a ticketing
+  source's own, say) still outranks it.
+
+- **Two welcome-tour slides scrolled.** "Welcome to MindFlock" needed 327px and
+  "3. PR review" 394px inside a 320px content box, so both got a scrollbar and
+  the PR-review slide hid its own *Set up now* button. The card is now 520×490
+  with a 48ch body — widening did most of the work, taking that slide from 394px
+  to 350px — which fits all twelve with room to spare.
 
 - **The per-surface Agent CLI pickers chose a provider that nothing read.**
   0.1.9 added `github.agent` and `github.issue_agent` so PR review and issue
@@ -62,33 +87,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remedy fixed nothing. The reason is carried through and shown in full (chip
   ellipsizes, tooltip has all of it; the actionable half of these messages is at
   the end, so clipping server-side removed exactly the part worth reading).
-
-## [0.1.9] - 2026-08-03
-
-### Fixed
-
-- **The default coding provider was ignored by everything that launches a
-  session.** Settings → Coding provider writes `coding_cli.default_provider`
-  into `settings.json`, but every launch path read `default_program` out of
-  `config.json` — a different store, seeded once on first run by a helper that
-  only ever hunts for `claude`, and which the UI never writes to. Nothing
-  bridged the two, so choosing a default changed the Providers screen badge and
-  `mindflock doctor` and nothing else: ingested tickets, PR-review sessions,
-  issue sessions and the New Session dialog all still launched Claude Code.
-
-  `backend.config.program.resolve_default_program` is now the single answer to
-  "which CLI, when nobody asked for a specific one" — the chosen provider, then
-  the engine config, then `claude` — and the engine bridge, the standalone tmux
-  launcher and the web layer all resolve through it. It is also read fresh
-  rather than from the config snapshot taken at server start, so changing the
-  default no longer needs a restart. An explicitly chosen agent (a ticketing
-  source's own, say) still outranks it.
-
-- **Two welcome-tour slides scrolled.** "Welcome to MindFlock" needed 327px and
-  "3. PR review" 394px inside a 320px content box, so both got a scrollbar and
-  the PR-review slide hid its own *Set up now* button. The card is now 520×490
-  with a 48ch body — widening did most of the work, taking that slide from 394px
-  to 350px — which fits all twelve with room to spare.
 
 ### Added
 

--- a/backend/session/provisioned.py
+++ b/backend/session/provisioned.py
@@ -739,11 +739,12 @@ def _resolve_base_sha(worktree_dir: str, base_branch: str) -> str:
 # ---------------------------------------------------------------------------
 # Base repo (worktree strategy)
 # ---------------------------------------------------------------------------
-def _check_branch_not_checked_out(base_repo: str, branch_name: str) -> None:
-    """Raise a clear error if ``branch_name`` is already checked out in base_repo.
+def worktree_holding_branch(base_repo: str, branch_name: str) -> str:
+    """Path of the worktree that has ``branch_name`` checked out, else ``""``.
 
-    `git worktree add` of a branch that is checked out in another live worktree
-    fails with an opaque message; this turns it into an actionable one.
+    Shared by the pre-flight guard below and the orphan reclaim in
+    :mod:`backend.web.core.worktree_reclaim`, so "who holds this branch" has one
+    implementation and the two can't disagree.
     """
     try:
         cp = subprocess.run(
@@ -753,21 +754,33 @@ def _check_branch_not_checked_out(base_repo: str, branch_name: str) -> None:
             timeout=60,
         )
     except subprocess.TimeoutExpired:
-        return
+        return ""
     if cp.returncode != 0:
-        return
+        return ""
     target = "branch refs/heads/" + branch_name
     current = None
     for line in cp.stdout.decode("utf-8", "replace").splitlines():
         if line.startswith("worktree "):
             current = line[len("worktree ") :]
         elif line.strip() == target:
-            raise ProvisionError(
-                "branch '{}' is already checked out at {}. Kill that "
-                "session first, or use a different story id / title.".format(
-                    branch_name, current
-                )
+            return current or ""
+    return ""
+
+
+def _check_branch_not_checked_out(base_repo: str, branch_name: str) -> None:
+    """Raise a clear error if ``branch_name`` is already checked out in base_repo.
+
+    `git worktree add` of a branch that is checked out in another live worktree
+    fails with an opaque message; this turns it into an actionable one.
+    """
+    held_at = worktree_holding_branch(base_repo, branch_name)
+    if held_at:
+        raise ProvisionError(
+            "branch '{}' is already checked out at {}. Kill that "
+            "session first, or use a different story id / title.".format(
+                branch_name, held_at
             )
+        )
 
 
 def repo_display_name(repo_url: str) -> str:

--- a/backend/ticket_ingestion/config.py
+++ b/backend/ticket_ingestion/config.py
@@ -345,6 +345,59 @@ def load_config(config_path: Path | str | None = None) -> PipelineConfig:
     return _parse_config(raw, path, layered=layered)
 
 
+def config_for_launch(
+    fallback: "PipelineConfig | None" = None,
+) -> "PipelineConfig | None":
+    """The config to make a LAUNCH decision from — re-read from disk.
+
+    The pipeline calls :func:`load_config` once at startup and holds that
+    snapshot for the life of the process, which is right for poll intervals and
+    tokens but wrong for "which coding CLI should this session run": switching
+    provider in Settings has to apply to the very next ticket / issue / PR, not
+    to the next time the pipeline is restarted. Agent choice is therefore read
+    fresh at the moment of launch — the same rule
+    :func:`backend.config.program.resolve_default_program` follows for the
+    app-wide default.
+
+    Best-effort: a config that has become unreadable since startup falls back to
+    ``fallback`` (the caller's snapshot) rather than failing the launch.
+    """
+    try:
+        return load_config()
+    except Exception:  # noqa: BLE001 — never let a re-read break a launch
+        return fallback
+
+
+def fresh_agent(pick, snapshot: "PipelineConfig | None") -> str:
+    """Resolve one surface's coding CLI, preferring the config on disk NOW.
+
+    ``pick`` is the surface's own chain applied to a config — e.g.
+    ``lambda c: c.pr_agent()``. It is tried against a freshly-read config first
+    so a provider switched in Settings takes effect on the next launch, and falls
+    back to ``snapshot`` (the long-lived config the caller was built with) when
+    the fresh read has no opinion or is unavailable.
+
+    Keeping the snapshot as the fallback rather than replacing it outright means a
+    caller that was handed a config by hand still has it honoured; only an
+    explicit on-disk choice overrides it. Every failure mode answers ``""``, which
+    every launch path reads as "use the resolved app default".
+    """
+    fresh = config_for_launch(None)
+    if fresh is not None:
+        try:
+            chosen = pick(fresh)
+        except Exception:  # noqa: BLE001
+            chosen = ""
+        if chosen:
+            return chosen
+    if snapshot is None:
+        return ""
+    try:
+        return pick(snapshot) or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def _merge_layers(raw: dict) -> dict:
     """Overlay the settings store + env vars onto a parsed ``config.toml`` dict.
 
@@ -804,6 +857,12 @@ def _parse_github(raw: dict, config_path: Path) -> GithubConfig | None:
             github_section.get("issue_poll_interval_seconds", 60)
         ),
         issue_skip_authors=list(github_section.get("issue_skip_authors", []) or []),
+        # Per-surface coding CLI. Omitting these left both at the dataclass ""
+        # default no matter what the merged config said, so Settings → PR review
+        # → Agent CLI (and its issue-handling twin) resolved to nothing and every
+        # review fell through to the app-wide default provider.
+        agent=str(github_section.get("agent", "") or ""),
+        issue_agent=str(github_section.get("issue_agent", "") or ""),
     )
 
 

--- a/backend/ticket_ingestion/orchestrator.py
+++ b/backend/ticket_ingestion/orchestrator.py
@@ -13,7 +13,7 @@ from backend.ticket_ingestion.providers import get_provider
 from backend.ticket_ingestion.clarification import InteractiveClarificationHandler
 from backend.ticket_ingestion.claude_runner import ClaudeCodeRunner
 from backend.ticket_ingestion.session_runner import SessionRunner, engine_bridge_error
-from backend.ticket_ingestion.config import PipelineConfig
+from backend.ticket_ingestion.config import PipelineConfig, fresh_agent
 from backend.ticket_ingestion.filter import AssigneeFilter
 from backend.ticket_ingestion.issue_monitor import (
     IssueCommentsFetchError,
@@ -137,9 +137,12 @@ class PipelineOrchestrator:
         self._pr_monitor = PRMonitor(config.github) if config.github else None
         self._issue_monitor = IssueMonitor(config.github) if config.github else None
         self._pr_provisioner = PRProvisioner(config)
-        # PR review has no ticketing source of its own, so it runs the
-        # ingestion-wide default agent ([mindflock].agent).
-        self._pr_runner = PRClaudeRunner(agent=config.agent_for())
+        # PR review has no ticketing source of its own, so it runs PR review's
+        # OWN agent ([github].agent) before the ingestion-wide fallback — the
+        # same chain the engine path uses, so the two runners can't disagree
+        # about which CLI reviews a PR. The agent is refreshed at launch (see
+        # _review_pr) because this snapshot is taken once per process.
+        self._pr_runner = PRClaudeRunner(agent=config.pr_agent())
         # Counts of in-flight work per kind, mirrored to the activity beacon.
         self._busy: dict[str, int] = {"ticket": 0, "pr": 0, "issue": 0}
 
@@ -422,7 +425,9 @@ class PipelineOrchestrator:
         # issue handling's own choice onto the ticket here — every downstream
         # launch path already reads `story.agent` first. Blank leaves the
         # existing fallback chain untouched.
-        story.agent = self.config.issue_agent()
+        # Re-read at launch, so switching the issue-handling provider in Settings
+        # applies to the next issue rather than the next pipeline restart.
+        story.agent = fresh_agent(lambda c: c.issue_agent(), self.config)
         try:
             if self._cs_runner is not None:
                 await self._cs_runner.run(story)
@@ -507,6 +512,10 @@ class PipelineOrchestrator:
                 await self._cs_runner.run_pr(pr, comments)
             else:
                 workspace = await self._pr_provisioner.provision(pr)
+                # Refresh the CLI first: the runner was built with the provider
+                # configured at process start, which may be several Settings
+                # changes ago.
+                self._pr_runner.agent = fresh_agent(lambda c: c.pr_agent(), self.config)
                 await self._pr_runner.launch(pr, workspace, comments)
         except Exception as e:
             # Cap retries: without a record, a PR whose provisioning keeps

--- a/backend/ticket_ingestion/session_runner.py
+++ b/backend/ticket_ingestion/session_runner.py
@@ -225,13 +225,25 @@ class SessionRunner:
     def _agent_for(self, story) -> str:
         """The agent CLI this story's session runs (``""`` = engine default).
 
-        The ticket's own stamp wins (the orchestrator copies it from the source
-        that produced the ticket), then the pipeline-wide chain in
-        :meth:`PipelineConfig.agent_for`.
+        Precedence: the ticket's own stamp (the orchestrator copies it from the
+        source that produced the ticket) → the config **as it is on disk right
+        now** → the config this runner was constructed with.
+
+        The re-read is what makes a provider switched in Settings apply to the
+        next ticket instead of the next pipeline restart, since ``__main__``
+        loads the config once and hands that snapshot over for the life of the
+        process. The injected config stays the fallback rather than being
+        discarded: it is a constructor argument and tests (and any caller that
+        builds a config by hand) are entitled to have it honoured when the
+        on-disk config expresses no opinion for this story's source.
         """
-        return getattr(story, "agent", "") or self.config.agent_for(
-            getattr(story, "provider", "")
-        )
+        from backend.ticket_ingestion.config import fresh_agent
+
+        stamped = getattr(story, "agent", "")
+        if stamped:
+            return stamped
+        provider = getattr(story, "provider", "")
+        return fresh_agent(lambda c: c.agent_for(provider), self.config)
 
     def _create_instance(
         self,
@@ -269,7 +281,11 @@ class SessionRunner:
 
         # PR review has no ticketing source, so it runs its own configured
         # agent ([github].agent) before falling back to the ingestion-wide one.
-        program = _resolve_program(self.config.pr_agent())
+        # Re-read at launch: the pipeline's startup snapshot would pin whatever
+        # provider was configured when the process began.
+        from backend.ticket_ingestion.config import fresh_agent
+
+        program = _resolve_program(fresh_agent(lambda c: c.pr_agent(), self.config))
 
         # Adopt the already-provisioned PR workspace: clone-style worktree at the
         # exact directory, on the PR's existing head branch (verbatim, no fork).

--- a/backend/ticket_ingestion/state.py
+++ b/backend/ticket_ingestion/state.py
@@ -148,6 +148,35 @@ def load_processed_story_statuses(state_dir: Path | str) -> dict:
     return out
 
 
+def load_processed_story_failures(state_dir: Path | str) -> dict:
+    """Slug -> the ``failure_reason`` on its latest ``failed`` ledger entry.
+
+    The companion to :func:`load_processed_story_statuses`, which returns only
+    the status. The reason is the one string that says what to DO about a
+    failure — "branch '…' is already checked out at <path>", say — and it sat
+    unread in state.json while the UI offered a generic "delete the ledger entry
+    to retry" remedy that clears the *record* of the failure and not its cause.
+    Same last-entry-wins rule as the status loader.
+    """
+    data = _read_state(state_dir)
+    stories = data.get("processed_stories")
+    if not isinstance(stories, list):
+        return {}
+    out: dict = {}
+    for entry in stories:
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("story_id")
+        if not (isinstance(sid, str) and sid):
+            continue
+        if entry.get("status") == "failed":
+            out[sid] = str(entry.get("failure_reason") or "")
+        else:
+            # A later success supersedes an earlier failure's reason.
+            out.pop(sid, None)
+    return out
+
+
 def record_processed_story(state_dir: Path | str, record: ProcessingRecord) -> None:
     data = _read_state(state_dir)
     stories = data.get("processed_stories")

--- a/backend/web/core/issue_start.py
+++ b/backend/web/core/issue_start.py
@@ -181,10 +181,13 @@ async def prepare_start(issue) -> tuple:
     cfg = _load_config()
     comments = await IssueMonitor(cfg.github).fetch_comments(issue)
     story = issue_to_ticket(issue, comments)
-    # GitHub's issue loop has no ticketing source, so it takes the
-    # ingestion-wide default agent ([mindflock].agent); "" = the app default.
-    agent_for = getattr(cfg, "agent_for", None)
-    story.agent = agent_for() if callable(agent_for) else ""
+    # Settings → Git issues → Agent CLI first (``github.issue_agent``), then the
+    # ingestion-wide ``[mindflock].agent``; "" = the app default. This used to
+    # call agent_for(), which skips straight to the ingestion-wide value — so the
+    # Agent CLI picker on the Git issues screen governed only the auto monitor
+    # and "Start work" launched whatever the app default was.
+    issue_agent = getattr(cfg, "issue_agent", None)
+    story.agent = issue_agent() if callable(issue_agent) else ""
     prompt = ClaudeCodeRunner(cfg)._build_prompt(story, None, None)
     return story, prompt, _branch_name_for(story)
 

--- a/backend/web/core/pr_review.py
+++ b/backend/web/core/pr_review.py
@@ -64,6 +64,32 @@ def _load_config():
     return cfg
 
 
+def review_agent() -> str:
+    """The coding CLI a PR-review session should run, ``""`` = the app default.
+
+    Reads the SAME chain the automated pipeline does
+    (:meth:`PipelineConfig.pr_agent` — Settings → PR review → Agent CLI, stored
+    as ``github.agent``, then ``[mindflock].agent``). The forced-review route
+    used to launch ``ENGINE.default_program()`` outright, so the Agent CLI
+    dropdown sitting directly above the "Begin review" button governed only the
+    auto monitor: clicking Begin review launched the app-wide default instead of
+    the provider the user had picked for reviews.
+
+    Best-effort by design: this is a launch path, and an unconfigured or
+    unreadable ingestion config should fall through to the app default rather
+    than block the review.
+    """
+    try:
+        cfg = _load_config()
+    except Exception:  # noqa: BLE001 — ingestion may not be configured at all
+        return ""
+    fn = getattr(cfg, "pr_agent", None)
+    try:
+        return (fn() if callable(fn) else "") or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def session_title(pr) -> str:
     """Engine session title for a PR review — ``pr-<repo-name>-<number>`` (via
     :func:`pr_slug`), so #7 in two different repos never share a session, and a

--- a/backend/web/core/ticket_start.py
+++ b/backend/web/core/ticket_start.py
@@ -103,6 +103,26 @@ def branch_for(story) -> str:
     return _branch_name_for(story)
 
 
+def _failed_label(reason: str) -> str:
+    """The chip text for a ``failed`` ledger entry.
+
+    This used to read "failed earlier — delete its state.json ledger entry to
+    retry", which was wrong twice over: force-start never consults the ledger
+    (only a live session blocks it), and the common cause is a leftover worktree
+    still holding the branch — so deleting the ledger entry drops the record of
+    the failure and the retry fails identically. Showing what actually went
+    wrong is the difference between an actionable chip and a wild goose chase.
+
+    Returned in full, only whitespace-normalized: the useful half of these
+    reasons ("… is already checked out at <path>") is at the END, so clipping to
+    a chip-sized budget here would cut off the part worth reading. The chip
+    ellipsizes in CSS and carries the whole string in its tooltip.
+    """
+    if not reason:
+        return "failed earlier (no reason recorded) — Run ticket to retry"
+    return "failed earlier: " + " ".join(reason.split())
+
+
 def skip_reasons(
     story,
     ledger: dict,
@@ -110,6 +130,7 @@ def skip_reasons(
     branches: set,
     member_ids,
     ingest_state: list | None = None,
+    failures: dict | None = None,
 ) -> list[str]:
     """Why auto ingestion would skip ``story`` right now (empty = eligible).
 
@@ -130,12 +151,15 @@ def skip_reasons(
         reasons.append("not in an ingest state — won't auto-ingest")
     status = ledger.get(story.slug) or ledger.get(str(story.id))
     if status:
-        label = {
-            "completed": "already ingested (recorded completed in the ledger)",
-            "in_flight": "a session for it is in flight",
-            "failed": "failed earlier — delete its state.json ledger entry to retry",
-            "skipped": "skipped earlier (recorded in the ledger)",
-        }.get(status, f"already in the processed ledger ({status})")
+        if status == "failed":
+            f = failures or {}
+            label = _failed_label(f.get(story.slug) or f.get(str(story.id)) or "")
+        else:
+            label = {
+                "completed": "already ingested (recorded completed in the ledger)",
+                "in_flight": "a session for it is in flight",
+                "skipped": "skipped earlier (recorded in the ledger)",
+            }.get(status, f"already in the processed ledger ({status})")
         reasons.append(label)
     if story.slug in pending_ids:
         reasons.append("queued for ingestion (pending)")
@@ -158,12 +182,14 @@ async def list_assigned_tickets() -> dict:
     from backend.ticket_ingestion.providers import get_provider
     from backend.ticket_ingestion.state import (
         load_pending_stories,
+        load_processed_story_failures,
         load_processed_story_statuses,
     )
 
     cfg = _load_config()
     sources = cfg.ticketing_sources or []
     ledger = load_processed_story_statuses(_REPO_ROOT)
+    failures = load_processed_story_failures(_REPO_ROOT)
     pending_ids = {e.get("story_id") for e in load_pending_stories(_REPO_ROOT)}
 
     tickets: list[dict] = []
@@ -228,6 +254,7 @@ async def list_assigned_tickets() -> dict:
                 branch_cache[repo],
                 member_ids,
                 ingest_state=ingest_state,
+                failures=failures,
             )
             bucket = story.state or NO_STATE_BUCKET
             if bucket not in bucket_order:

--- a/backend/web/core/worktree_reclaim.py
+++ b/backend/web/core/worktree_reclaim.py
@@ -1,0 +1,183 @@
+"""Reclaim a leftover worktree so a re-run of the same ticket/issue can proceed.
+
+The state this fixes: a ticket ran once, its session later went away (ended,
+cleaned up from the engine, or lost with a restart), but the *worktree* stayed on
+disk — deliberately, because ending a session keeps its worktree so the work can
+be reopened. Nothing owns that worktree any more, yet git still has the feature
+branch checked out there, so the next ``git worktree add`` for the same branch
+fails with "already checked out at …".
+
+From the panel's point of view the ticket looks perfectly runnable (there is no
+live session, so **Run ticket** is enabled), and the run then dies on a leftover
+nobody can see. Worse, the failure was recorded as a ledger entry whose advice
+was to delete the ledger entry — which clears the record and leaves the actual
+blocker in place, so the retry fails identically.
+
+So force-start reclaims the leftover first, under two absolute rules:
+
+* **Never take a worktree a live session owns.** Ownership is decided by the
+  caller (it is the engine that knows its sessions), passed in as ``is_owned``.
+* **Never destroy work.** A worktree with uncommitted changes, a stash, or
+  commits its branch hasn't pushed is left exactly where it is, and the original
+  clear error stands. Reclaiming is only ever for a pristine checkout.
+
+Anything it declines to touch keeps the existing behaviour, so the worst case is
+the error message the user already got.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Callable
+
+from backend import log
+
+#: Per-git-call ceiling. These run on a force-start request, so a hung git must
+#: not hold the launch open indefinitely — a timeout is treated as "don't touch".
+_GIT_TIMEOUT = 30
+
+
+def _git(repo: str, *args: str) -> tuple[int, str]:
+    """``git -C repo <args>`` -> (returncode, stdout). Never raises."""
+    try:
+        cp = subprocess.run(
+            ["git", "-C", repo, *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return 1, ""
+    return cp.returncode, cp.stdout.decode("utf-8", "replace")
+
+
+def worktree_is_pristine(path: str) -> bool:
+    """True when ``path`` holds nothing worth preserving.
+
+    Pristine means: no uncommitted or untracked changes, no stash entries, and
+    no commits that aren't already reachable from the branch's upstream (or, with
+    no upstream, no commits at all beyond what the checkout started from). Any
+    doubt — a git call that fails or times out — answers False, because the
+    consequence of a wrong True is deleting someone's work.
+    """
+    rc, out = _git(path, "status", "--porcelain=v1")
+    if rc != 0 or out.strip():
+        return False
+
+    rc, out = _git(path, "stash", "list")
+    if rc != 0 or out.strip():
+        return False
+
+    # Commits not yet on the upstream. No upstream configured (never pushed) is
+    # not a licence to delete: compare against the remote's default instead, and
+    # if that can't be resolved either, refuse.
+    rc, upstream = _git(path, "rev-parse", "--abbrev-ref", "@{upstream}")
+    ref = upstream.strip() if rc == 0 and upstream.strip() else ""
+    if not ref:
+        rc, head = _git(path, "symbolic-ref", "--short", "HEAD")
+        rc2, remote_head = _git(path, "rev-parse", "--abbrev-ref", "origin/HEAD")
+        ref = remote_head.strip() if rc2 == 0 and remote_head.strip() else ""
+        if not ref:
+            return False
+    rc, ahead = _git(path, "rev-list", "--count", f"{ref}..HEAD")
+    if rc != 0:
+        return False
+    try:
+        return int(ahead.strip() or "1") == 0
+    except ValueError:
+        return False
+
+
+def reclaim_for_branch(
+    base_repo: str,
+    branch_name: str,
+    is_owned: Callable[[str], bool],
+) -> str:
+    """Free ``branch_name`` for a fresh ``git worktree add``, if that is safe.
+
+    Returns the path reclaimed, or ``""`` when there was nothing to reclaim or
+    reclaiming would not have been safe. Never raises: every refusal leaves the
+    repository exactly as it was, and the caller's normal provisioning path then
+    produces its usual (now accurate) error.
+
+    ``is_owned(path)`` must return True when a live session is using ``path``.
+    """
+    from backend.session.provisioned import worktree_holding_branch
+
+    try:
+        held_at = worktree_holding_branch(base_repo, branch_name)
+    except Exception:  # noqa: BLE001 — a probe must not break a launch
+        return ""
+    if not held_at:
+        return ""
+
+    try:
+        if is_owned(held_at):
+            return ""
+    except Exception:  # noqa: BLE001 — unknown ownership means hands off
+        return ""
+
+    if not worktree_is_pristine(held_at):
+        if log.InfoLog is not None:
+            log.InfoLog.Printf(
+                "leftover worktree %s holds branch %s but has local work — "
+                "left in place",
+                held_at,
+                branch_name,
+            )
+        return ""
+
+    rc, _ = _git(base_repo, "worktree", "remove", held_at)
+    if rc != 0:
+        # --force only escalates past git's own dirty/locked checks, which
+        # worktree_is_pristine has already cleared; it is still refused for a
+        # worktree that has work, because we never get here in that case.
+        rc, _ = _git(base_repo, "worktree", "remove", "--force", held_at)
+    if rc != 0:
+        return ""
+    _git(base_repo, "worktree", "prune")
+    if log.InfoLog is not None:
+        log.InfoLog.Printf(
+            "reclaimed orphaned worktree %s (branch %s, no live session, no local "
+            "work) so the run can proceed",
+            held_at,
+            branch_name,
+        )
+    return held_at
+
+
+def reclaim_for_launch(repo_url: str, branch: str) -> str:
+    """Pre-flight a provisioned ticket/issue launch: free ``branch`` if a
+    leftover worktree is holding it and nothing would be lost.
+
+    Resolves the base clone exactly the way the engine does
+    (:func:`load_provision_settings` + :func:`resolve_base_repo_dir`) so this
+    can't drift from where the worktrees are actually added. Returns the path
+    reclaimed, or ``""`` for the (usual) case of nothing to do.
+
+    Ownership comes from the engine's own live-instance check, so a worktree
+    shared by a session and its copy is never taken out from under them.
+    """
+    if not branch:
+        return ""
+    try:
+        from backend.session.provisioned import (
+            load_provision_settings,
+            resolve_base_repo_dir,
+        )
+
+        settings = load_provision_settings(repo_url_override=repo_url or "")
+        base = str(resolve_base_repo_dir(settings))
+    except Exception:  # noqa: BLE001 — unresolvable base repo: nothing to do
+        return ""
+    if not base or not os.path.isdir(os.path.join(base, ".git")):
+        return ""
+
+    def _is_owned(path: str) -> bool:
+        from backend.web.core.workspaces import _worktree_in_use_by_other
+
+        # exclude_title="" — any live instance on that directory counts.
+        return _worktree_in_use_by_other(path, "")
+
+    return reclaim_for_branch(base, branch, _is_owned)

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -104,6 +104,7 @@ from backend.web.core import ports as _ports
 from backend.web.core import issue_start as _issue_start
 from backend.web.core import github_pr as _github_pr
 from backend.web.core import pr_review as _pr_review
+from backend.web.core import worktree_reclaim as _worktree_reclaim
 from backend.web.core import ticket_start as _ticket_start
 from backend.web.core import remote as _remote
 from backend.web.core import pending as _pending
@@ -4202,7 +4203,11 @@ async def github_force_review(payload: dict) -> JSONResponse:
                 session.InstanceOptions(
                     title=title,
                     path=".",
-                    program=ENGINE.default_program(),
+                    # Settings → PR review → Agent CLI first (same chain the
+                    # auto monitor uses), then the app-wide default. Mirrors the
+                    # issue force-start below, which already reads its resolved
+                    # agent before falling back.
+                    program=_pr_review.review_agent() or ENGINE.default_program(),
                     provisioned=True,
                     workspace_strategy="clone",
                     new_branch=pr.head_ref,
@@ -4350,6 +4355,16 @@ async def ticket_force_start(payload: dict) -> JSONResponse:
         try:
             prompt = _ticket_start.build_prompt(story)
             branch = _ticket_start.branch_for(story)
+            # A previous run of this ticket may have left a worktree holding the
+            # branch: the session is long gone (nothing blocked the button) but
+            # git still refuses to check the branch out twice. Reclaim it when
+            # nothing owns it and it holds no work — otherwise the provisioning
+            # error stands, unchanged.
+            await asyncio.to_thread(
+                _worktree_reclaim.reclaim_for_launch,
+                getattr(story, "repo_url", "") or "",
+                branch,
+            )
             # In-flight ledger marker BEFORE the slow launch, so a running
             # pipeline's scans treat the ticket as taken (orchestrator guard).
             _ticket_start.record_started(story)
@@ -4505,6 +4520,12 @@ async def github_issue_force_start(payload: dict) -> JSONResponse:
         # provisioning (inside Instance.Start), like the ticket path.
         try:
             story, prompt, branch = await _issue_start.prepare_start(issue)
+            # Same leftover-worktree reclaim as the ticket path above.
+            await asyncio.to_thread(
+                _worktree_reclaim.reclaim_for_launch,
+                getattr(story, "repo_url", "") or "",
+                branch,
+            )
             inst = session.NewInstance(
                 session.InstanceOptions(
                     title=title,

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -30592,7 +30592,12 @@ function WorkItemRow({
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pr-open-meta", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: meta }),
-      hasSession ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip on", children: "session open" }) : eligible ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip ok", children: eligibleLabel }) : (reasons || []).map((reason) => /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip", children: reason }, reason))
+      hasSession ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip on", children: "session open" }) : eligible ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip ok", children: eligibleLabel }) : (reasons || []).map((reason) => (
+        // title: a recorded failure reason is a full sentence of git output
+        // whose actionable half is at the end, so the chip ellipsizes and
+        // hovering gives you the whole thing.
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pr-open-chip", title: reason, children: reason }, reason)
+      ))
     ] }),
     hasSession ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className: "btn-primary pr-review-btn", disabled: true, children: "Session open" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
       "button",

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -1741,6 +1741,14 @@ p.set-hint {
   font-size: 11px;
   color: var(--muted);
   background: var(--bg);
+  /* A recorded failure reason is a whole sentence of git output. Cap it here
+     rather than in the server's label (the actionable half is at the end, so a
+     server-side clip would remove the useful part); the full string is in the
+     chip's title. */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pr-open-chip.ok {

--- a/frontend/src/components/settings/screens/automation.tsx
+++ b/frontend/src/components/settings/screens/automation.tsx
@@ -274,7 +274,10 @@ export function WorkItemRow({
           <span className="pr-open-chip ok">{eligibleLabel}</span>
         ) : (
           (reasons || []).map((reason) => (
-            <span className="pr-open-chip" key={reason}>
+            // title: a recorded failure reason is a full sentence of git output
+            // whose actionable half is at the end, so the chip ellipsizes and
+            // hovering gives you the whole thing.
+            <span className="pr-open-chip" key={reason} title={reason}>
               {reason}
             </span>
           ))

--- a/frontend/src/components/settings/screens/screens.css
+++ b/frontend/src/components/settings/screens/screens.css
@@ -382,6 +382,14 @@
   font-size: 11px;
   color: var(--muted);
   background: var(--bg);
+  /* A recorded failure reason is a whole sentence of git output. Cap it here
+     rather than in the server's label (the actionable half is at the end, so a
+     server-side clip would remove the useful part); the full string is in the
+     chip's title. */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pr-open-chip.ok {

--- a/tests/unit/test_default_program_resolution.py
+++ b/tests/unit/test_default_program_resolution.py
@@ -209,6 +209,213 @@ class TestAssistantProgram:
         assert assistant._assistant_program() == "aider"
 
 
+class TestParsedGithubCarriesTheAgents:
+    """The seam the per-surface pickers actually travel through.
+
+    TestPerSurfaceAgents builds a GithubConfig by hand and TestSettingsRoundTrip
+    stops at GithubSettings, so nothing used to exercise ``_parse_github`` — and
+    it silently dropped both agent fields, leaving them at their "" dataclass
+    default however the config was configured. The precedence logic was correct
+    and unreachable: every PR review fell through to the app-wide default.
+    """
+
+    def _parsed(self, **github):
+        from pathlib import Path
+
+        from backend.ticket_ingestion.config import _parse_github
+
+        return _parse_github(
+            {"github": {"base_branch": "main", **github}}, Path("config.toml")
+        )
+
+    def test_pr_review_agent_survives_the_parse(self):
+        assert self._parsed(agent="antigravity").agent == "antigravity"
+
+    def test_issue_agent_survives_the_parse(self):
+        assert self._parsed(issue_agent="codex").issue_agent == "codex"
+
+    def test_both_default_to_empty_so_the_resolver_still_decides(self):
+        gh = self._parsed()
+        assert (gh.agent, gh.issue_agent) == ("", "")
+
+    def test_parsed_config_reaches_pr_agent(self):
+        """End to end through the chain the launch paths call."""
+        from backend.ticket_ingestion.config import EngineConfig, PipelineConfig
+
+        cfg = PipelineConfig()
+        cfg.github = self._parsed(agent="antigravity")
+        cfg.engine = EngineConfig(agent="")
+        assert cfg.pr_agent() == "antigravity"
+
+
+class TestForcedReviewHonoursTheReviewAgent:
+    """ "Begin review" used to launch ENGINE.default_program() outright, so the
+    Agent CLI dropdown directly above the button governed only the auto
+    monitor."""
+
+    def test_review_agent_reads_the_configured_pr_agent(self, monkeypatch):
+        from backend.web.core import pr_review
+
+        monkeypatch.setattr(
+            pr_review,
+            "_load_config",
+            lambda: type("C", (), {"pr_agent": lambda self: "antigravity"})(),
+        )
+        assert pr_review.review_agent() == "antigravity"
+
+    def test_unset_returns_blank_so_the_caller_falls_back(self, monkeypatch):
+        from backend.web.core import pr_review
+
+        monkeypatch.setattr(
+            pr_review,
+            "_load_config",
+            lambda: type("C", (), {"pr_agent": lambda self: ""})(),
+        )
+        assert pr_review.review_agent() == ""
+
+    def test_unconfigured_ingestion_degrades_instead_of_blocking_the_review(
+        self, monkeypatch
+    ):
+        from backend.web.core import pr_review
+
+        def boom():
+            raise RuntimeError("ingestion was never configured")
+
+        monkeypatch.setattr(pr_review, "_load_config", boom)
+        assert pr_review.review_agent() == ""
+
+    def test_the_route_prefers_the_review_agent_over_the_app_default(self):
+        """Pins the launch expression itself: the forced-review instance takes
+        review_agent() first and only then ENGINE.default_program()."""
+        import inspect
+
+        from backend.web import server
+
+        src = inspect.getsource(server.github_force_review)
+        assert "_pr_review.review_agent() or ENGINE.default_program()" in src
+
+
+class TestProviderSwitchAppliesToTheNextLaunch:
+    """Switching provider must apply to the NEXT ticket / issue / PR, not to the
+    one after the next pipeline restart.
+
+    ``__main__.main`` calls ``load_config()`` once and hands the snapshot to the
+    orchestrator for the life of the process, so every per-surface agent read off
+    ``self.config`` was pinned to whatever was configured at startup. Agent
+    choice is re-read at launch instead — the rule ``resolve_default_program``
+    already follows for the app-wide default.
+    """
+
+    def test_config_for_launch_rereads(self, monkeypatch):
+        from backend.ticket_ingestion import config as C
+
+        monkeypatch.setattr(C, "load_config", lambda: _pipeline(github_agent="codex"))
+        assert (
+            C.config_for_launch(_pipeline(github_agent="stale")).pr_agent() == "codex"
+        )
+
+    def test_fresh_agent_prefers_disk_over_the_snapshot(self, monkeypatch):
+        from backend.ticket_ingestion import config as C
+
+        monkeypatch.setattr(C, "load_config", lambda: _pipeline(github_agent="codex"))
+        snap = _pipeline(github_agent="stale")
+        assert C.fresh_agent(lambda c: c.pr_agent(), snap) == "codex"
+
+    def test_fresh_agent_keeps_the_snapshot_when_disk_has_no_opinion(self, monkeypatch):
+        """The config is a constructor argument; a caller that built one by hand
+        keeps it unless the on-disk config makes an explicit choice."""
+        from backend.ticket_ingestion import config as C
+
+        monkeypatch.setattr(C, "load_config", lambda: _pipeline())
+        snap = _pipeline(github_agent="aider")
+        assert C.fresh_agent(lambda c: c.pr_agent(), snap) == "aider"
+
+    def test_fresh_agent_survives_an_unreadable_config(self, monkeypatch):
+        from backend.ticket_ingestion import config as C
+
+        def boom():
+            raise RuntimeError("gone")
+
+        monkeypatch.setattr(C, "load_config", boom)
+        assert (
+            C.fresh_agent(lambda c: c.pr_agent(), _pipeline(github_agent="aider"))
+            == "aider"
+        )
+
+    def test_fresh_agent_with_nothing_anywhere_is_blank(self, monkeypatch):
+        from backend.ticket_ingestion import config as C
+
+        monkeypatch.setattr(C, "load_config", lambda: _pipeline())
+        assert C.fresh_agent(lambda c: c.pr_agent(), None) == ""
+
+    def test_config_for_launch_falls_back_when_the_reread_fails(self, monkeypatch):
+        """A config that broke since startup must not fail the launch."""
+        from backend.ticket_ingestion import config as C
+
+        def boom():
+            raise RuntimeError("config.toml went missing")
+
+        monkeypatch.setattr(C, "load_config", boom)
+        snapshot = _pipeline(github_agent="snapshot-value")
+        assert C.config_for_launch(snapshot) is snapshot
+
+    def test_ticket_launch_sees_a_provider_switched_after_startup(self, monkeypatch):
+        """SessionRunner holds a startup snapshot; the ticket's CLI must not."""
+        from backend.ticket_ingestion import config as C, session_runner
+
+        runner = session_runner.SessionRunner(_pipeline(engine_agent="stale"))
+        monkeypatch.setattr(C, "load_config", lambda: _pipeline(engine_agent="codex"))
+        story = type("S", (), {"agent": "", "provider": ""})()
+        assert runner._agent_for(story) == "codex"
+
+    def test_a_ticket_that_pins_its_own_agent_still_wins(self, monkeypatch):
+        from backend.ticket_ingestion import config as C, session_runner
+
+        runner = session_runner.SessionRunner(_pipeline())
+        monkeypatch.setattr(C, "load_config", lambda: _pipeline(engine_agent="codex"))
+        story = type("S", (), {"agent": "aider", "provider": ""})()
+        assert runner._agent_for(story) == "aider"
+
+    def test_pr_launch_rereads_the_review_agent(self):
+        """Both PR runners resolve through pr_agent(), re-read at launch."""
+        import inspect
+
+        from backend.ticket_ingestion import orchestrator, session_runner
+
+        pr_src = inspect.getsource(session_runner.SessionRunner._create_pr_instance)
+        assert "fresh_agent" in pr_src
+        assert "c.pr_agent()" in pr_src
+        # The engine-off fallback runner used the ingestion-wide agent, so the
+        # two runners disagreed about which CLI reviews a PR.
+        init_src = inspect.getsource(orchestrator.PipelineOrchestrator.__init__)
+        assert "config.pr_agent()" in init_src
+        assert "config.agent_for()" not in init_src
+
+    def test_issue_force_start_uses_the_issue_agent_not_the_pipeline_one(self):
+        """Settings → Git issues → Agent CLI governed only the auto monitor:
+        "Start work" read agent_for(), which skips past github.issue_agent."""
+        import inspect
+
+        from backend.web.core import issue_start
+
+        src = inspect.getsource(issue_start.prepare_start)
+        # Comments explain the old behaviour by name, so compare CODE only.
+        code = "\n".join(
+            line for line in src.splitlines() if not line.strip().startswith("#")
+        )
+        assert 'getattr(cfg, "issue_agent"' in code
+        assert "agent_for(" not in code
+
+    def test_every_surface_resolves_through_its_own_chain(self):
+        """One config, three surfaces, three answers — no cross-contamination."""
+        cfg = _pipeline(github_agent="codex", issue_agent="aider", engine_agent="goose")
+        assert (cfg.pr_agent(), cfg.issue_agent(), cfg.agent_for("")) == (
+            "codex",
+            "aider",
+            "goose",
+        )
+
+
 class TestSettingsRoundTrip:
     """The new fields have to survive a save/load cycle or the pickers silently
     forget what you chose."""

--- a/tests/unit/test_ticket_force_start.py
+++ b/tests/unit/test_ticket_force_start.py
@@ -525,3 +525,119 @@ async def test_list_assigned_tickets_states_failure_and_branch_error(
     assert out["tickets"][0]["bucket"] == ticket_start.NO_STATE_BUCKET
     # Branch lookup failed but listing still succeeds (no "feature branch" chip).
     assert not any("feature branch" in r for r in out["tickets"][0]["reasons"])
+
+
+# --------------------------------------------------------------------------- #
+# A failure's chip says what actually went wrong
+# --------------------------------------------------------------------------- #
+# The old chip read "failed earlier — delete its state.json ledger entry to
+# retry". Both halves misled: force-start never consults the ledger (only a live
+# session blocks it), and the usual cause is a leftover worktree still holding
+# the branch — so clearing the ledger entry drops the RECORD of the failure and
+# the retry fails identically.
+_REAL_REASON = (
+    "failed to create provisioned worktree: branch "
+    "'feature/shortcut-19674/config-build-the-orchestrator-wiring-lay' is already "
+    "checked out at /home/u/.mindflock/worktrees/feature/shortcut-19674/x_18c8. "
+    "Kill that session first, or use a different story id / title."
+)
+
+
+def test_failed_chip_carries_the_recorded_reason():
+    story = _story()
+    reasons = ticket_start.skip_reasons(
+        story,
+        {story.slug: "failed"},
+        set(),
+        set(),
+        MEMBER_IDS,
+        failures={story.slug: _REAL_REASON},
+    )
+    (chip,) = [r for r in reasons if r.startswith("failed earlier")]
+    assert "already checked out" in chip
+    # The remedy that does not fix anything is gone.
+    assert "state.json" not in chip
+
+
+def test_failed_reason_is_never_clipped_by_the_server():
+    """The actionable half of these reasons is at the END, so a server-side
+    character budget would remove exactly the part worth reading. The chip
+    ellipsizes in CSS and keeps the full text in its title."""
+    chip = ticket_start._failed_label(_REAL_REASON)
+    assert chip.endswith("different story id / title.")
+    assert "…" not in chip
+
+
+def test_failed_reason_whitespace_is_normalized():
+    """Captured output arrives with newlines in it; a chip is one line."""
+    assert ticket_start._failed_label("line one\n  line two") == (
+        "failed earlier: line one line two"
+    )
+
+
+def test_failed_with_no_recorded_reason_still_points_at_the_button():
+    chip = ticket_start._failed_label("")
+    assert "Run ticket" in chip
+    assert "state.json" not in chip
+
+
+def test_failed_chip_matches_by_id_when_the_slug_is_absent():
+    story = _story(id=1)  # slug defaults to "sc-1"
+    reasons = ticket_start.skip_reasons(
+        story, {"1": "failed"}, set(), set(), MEMBER_IDS, failures={"1": _REAL_REASON}
+    )
+    assert any("already checked out" in r for r in reasons)
+
+
+def test_missing_failures_map_degrades_to_the_generic_label():
+    """skip_reasons is called from more than one place; the argument is optional
+    and its absence must not crash the panel."""
+    story = _story()
+    reasons = ticket_start.skip_reasons(
+        story, {story.slug: "failed"}, set(), set(), MEMBER_IDS
+    )
+    assert any(r.startswith("failed earlier") for r in reasons)
+
+
+def test_failure_reasons_loader_keeps_the_reason(tmp_path):
+    from backend.ticket_ingestion.state import (
+        load_processed_story_failures,
+        record_processed_story,
+        update_processed_story,
+    )
+    from backend.ticket_ingestion.models import ProcessingRecord
+    from datetime import datetime, timezone
+
+    record_processed_story(
+        tmp_path,
+        ProcessingRecord(
+            story_id="sc-9",
+            branch="sc-9",
+            status="in_flight",
+            processed_at=datetime.now(timezone.utc),
+        ),
+    )
+    update_processed_story(tmp_path, "sc-9", status="failed", failure_reason="boom")
+    assert load_processed_story_failures(tmp_path) == {"sc-9": "boom"}
+
+
+def test_a_later_success_supersedes_an_earlier_failure_reason(tmp_path):
+    from backend.ticket_ingestion.state import (
+        load_processed_story_failures,
+        record_processed_story,
+    )
+    from backend.ticket_ingestion.models import ProcessingRecord
+    from datetime import datetime, timezone
+
+    for status, reason in (("failed", "boom"), ("completed", None)):
+        record_processed_story(
+            tmp_path,
+            ProcessingRecord(
+                story_id="sc-9",
+                branch="sc-9",
+                status=status,
+                processed_at=datetime.now(timezone.utc),
+                failure_reason=reason,
+            ),
+        )
+    assert load_processed_story_failures(tmp_path) == {}

--- a/tests/unit/test_worktree_reclaim.py
+++ b/tests/unit/test_worktree_reclaim.py
@@ -1,0 +1,185 @@
+"""Reclaiming a leftover worktree so a re-run of the same ticket can proceed.
+
+The bug: ending a session deliberately KEEPS its worktree, so a ticket that ran
+once leaves a worktree holding its feature branch. Once the session is gone
+nothing blocks the panel's Run ticket button, but ``git worktree add`` still
+refuses to check the branch out twice — and the failure was recorded with advice
+to delete the ledger entry, which clears the record and leaves the blocker.
+
+These run against real git repos: the whole feature is "what does git think about
+this worktree", which a mock cannot answer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from backend.session.provisioned import worktree_holding_branch
+from backend.web.core.worktree_reclaim import (
+    reclaim_for_branch,
+    worktree_is_pristine,
+)
+
+
+def _git(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A base clone with an ``origin`` it can be compared against.
+
+    ``origin`` is a real (bare) remote, because "is this worktree ahead of what
+    has been pushed" is the question that decides whether work would be lost.
+    """
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    base = tmp_path / "base"
+    subprocess.run(
+        ["git", "clone", str(origin), str(base)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    _git(base, "config", "user.email", "t@t.t")
+    _git(base, "config", "user.name", "t")
+    (base / "seed.txt").write_text("seed\n")
+    _git(base, "add", ".")
+    _git(base, "commit", "-m", "seed")
+    _git(base, "push", "-u", "origin", "main")
+    return base
+
+
+def _add_worktree(base, branch, tmp_path, name="wt"):
+    """A worktree on a new branch, pushed so it has an upstream (the shape a
+    ticket session's worktree has once its branch exists on the remote)."""
+    path = tmp_path / name
+    _git(base, "worktree", "add", "-b", branch, str(path), "main")
+    _git(path, "config", "user.email", "t@t.t")
+    _git(path, "config", "user.name", "t")
+    _git(path, "push", "-u", "origin", branch)
+    return path
+
+
+NOTHING_OWNS_IT = lambda path: False  # noqa: E731
+SOMETHING_OWNS_IT = lambda path: True  # noqa: E731
+
+
+class TestWorktreeHoldingBranch:
+    def test_finds_the_holder(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        assert worktree_holding_branch(str(repo), "feature/x") == str(path)
+
+    def test_empty_when_nothing_holds_it(self, repo):
+        assert worktree_holding_branch(str(repo), "feature/nope") == ""
+
+
+class TestPristine:
+    def test_a_fresh_checkout_is_pristine(self, repo, tmp_path):
+        assert worktree_is_pristine(str(_add_worktree(repo, "feature/x", tmp_path)))
+
+    def test_uncommitted_changes_are_work(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        (path / "seed.txt").write_text("edited\n")
+        assert not worktree_is_pristine(str(path))
+
+    def test_untracked_files_are_work(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        (path / "brand-new.txt").write_text("mine\n")
+        assert not worktree_is_pristine(str(path))
+
+    def test_unpushed_commits_are_work(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        (path / "seed.txt").write_text("committed but not pushed\n")
+        _git(path, "commit", "-am", "local work")
+        assert not worktree_is_pristine(str(path))
+
+    def test_a_stash_is_work(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        (path / "seed.txt").write_text("stashed\n")
+        _git(path, "stash")
+        assert not worktree_is_pristine(str(path))
+
+    def test_a_branch_with_no_upstream_is_refused(self, repo, tmp_path):
+        """Never pushed means nothing to compare against, so there is no way to
+        know the commits are safe. Refuse rather than guess."""
+        path = tmp_path / "unpushed"
+        _git(repo, "worktree", "add", "-b", "feature/local-only", str(path), "main")
+        _git(repo, "remote", "set-head", "origin", "--delete")
+        assert not worktree_is_pristine(str(path))
+
+    def test_a_nonexistent_path_is_refused(self, tmp_path):
+        assert not worktree_is_pristine(str(tmp_path / "gone"))
+
+
+class TestReclaim:
+    def test_reclaims_a_pristine_orphan(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        assert reclaim_for_branch(str(repo), "feature/x", NOTHING_OWNS_IT) == str(path)
+        # The branch is free, so a fresh worktree add can have it.
+        assert worktree_holding_branch(str(repo), "feature/x") == ""
+        _git(repo, "worktree", "add", str(tmp_path / "again"), "feature/x")
+
+    def test_refuses_a_worktree_a_live_session_owns(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        assert reclaim_for_branch(str(repo), "feature/x", SOMETHING_OWNS_IT) == ""
+        assert worktree_holding_branch(str(repo), "feature/x") == str(path)
+        assert path.is_dir()
+
+    def test_refuses_to_destroy_uncommitted_work(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        (path / "precious.txt").write_text("hours of work\n")
+        assert reclaim_for_branch(str(repo), "feature/x", NOTHING_OWNS_IT) == ""
+        assert (path / "precious.txt").read_text() == "hours of work\n"
+
+    def test_refuses_to_destroy_unpushed_commits(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+        (path / "seed.txt").write_text("real work\n")
+        _git(path, "commit", "-am", "real work")
+        assert reclaim_for_branch(str(repo), "feature/x", NOTHING_OWNS_IT) == ""
+        assert path.is_dir()
+
+    def test_nothing_to_reclaim_is_not_an_error(self, repo):
+        assert (
+            reclaim_for_branch(str(repo), "feature/never-existed", NOTHING_OWNS_IT)
+            == ""
+        )
+
+    def test_an_ownership_probe_that_raises_means_hands_off(self, repo, tmp_path):
+        path = _add_worktree(repo, "feature/x", tmp_path)
+
+        def boom(_path):
+            raise RuntimeError("engine unreachable")
+
+        assert reclaim_for_branch(str(repo), "feature/x", boom) == ""
+        assert path.is_dir()
+
+    def test_a_broken_base_repo_is_not_an_error(self, tmp_path):
+        assert (
+            reclaim_for_branch(str(tmp_path / "nope"), "feature/x", NOTHING_OWNS_IT)
+            == ""
+        )
+
+
+class TestLaunchPathsPreflightTheReclaim:
+    """Wiring: both provisioned force-start paths reclaim before launching."""
+
+    def test_ticket_and_issue_routes_call_it(self):
+        import inspect
+
+        from backend.web import server
+
+        for fn in (server.ticket_force_start, server.github_issue_force_start):
+            src = inspect.getsource(fn)
+            assert "_worktree_reclaim.reclaim_for_launch" in src, fn.__name__


### PR DESCRIPTION
## Why

Reported symptom: PR review kept opening a Claude window after switching to codex/antigravity, and a ticket that had already run once refused to run again with advice to hand-edit `state.json`.

Both turned out to be real, and the provider one was two bugs stacked.

## What was wrong

**1. The per-surface Agent CLI setting was parsed and then discarded.** 0.1.9 added `github.agent` / `github.issue_agent`, and they saved correctly — but `_parse_github` built its `GithubConfig` without passing either field, so both sat at their `""` dataclass default however they were configured:

```
settings.json github.agent   = 'antigravity'   ✓ saved
_merge_layers → github.agent = 'antigravity'   ✓ bridged
_parse_github → cfg.github.agent = ''          ✗ dropped
```

`pr_agent()` / `issue_agent()` were correct and unreachable. This broke the auto monitor too, not just the button.

It survived the suite because precedence was tested on a hand-built `GithubConfig` and storage on `GithubSettings`, with the parse between them uncovered. That seam is now tested.

**2. "Begin review" never asked for the review agent.** It passed `ENGINE.default_program()` outright, so the dropdown directly above the button governed only the auto monitor. Issue force-start had the matching bug one level up: `prepare_start` read the ingestion-wide `agent_for()`, which skips past `github.issue_agent`.

**3. Switching provider needed a pipeline restart.** `__main__` calls `load_config()` once and hands that snapshot to the orchestrator for the life of the process. Agent choice is now re-read at launch — the rule `resolve_default_program` already followed — across tickets, issues and both PR runners. An injected config stays the fallback, so a caller that builds one by hand still has it honoured.

**4. A ticket that had run before could not run again.** Ending a session deliberately keeps its worktree, so a second run met a leftover holding the feature branch and died in `git worktree add`. Nothing in the UI could see it, and the recorded failure told you to delete the ledger entry — which clears the record and leaves the cause, so the retry failed identically.

Force-start now reclaims the leftover under two rules it never breaks: never a worktree a live session owns, never one holding work (uncommitted changes, a stash, or unpushed commits). Anything it declines to take keeps the old behaviour.

**5. The recorded reason is now shown.** The ledger stored `failure_reason` and the loader dropped it. It is carried through in full — the actionable half of these messages is at the end, so the chip ellipsizes in CSS with the whole string in its tooltip rather than being clipped server-side.

## Verification

All three surfaces tracking the live config, no restart, snapshot held from before the switch:

| | ticket | pr | issue |
|---|---|---|---|
| start | claude | antigravity | claude |
| switch all → codex | claude | codex | codex |
| pr→aider, issue→opencode | claude | aider | opencode |
| default → antigravity (no pins) | antigravity | antigravity | antigravity |

`3726 passed` (backend), `157 passed` (frontend). The reclaim tests run against real git repos — "what does git think about this worktree" is not a question a mock can answer.

## Notes

- Folded into the 0.1.9 notes rather than cut as 0.1.10, per owner call. The `v0.1.9` tag needs re-cutting onto the merge commit.
- Not included: `issue_start`'s route-level gap is fixed, but the `_ERRORISH_RE` fallback in `_parse_failed_step` can still pick a benign git line as a "failure detail" — a separate bug needing a judgment call about what the badge should say when no hook name exists.