### PR TITLE
Quiet the Intake tabs: drop the switch status line, tighten the rhythm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Intake tabs dropped the status line under their master switch, and
+  tightened up.** "● Active — polling 1 source for tickets assigned to you" sat in
+  a row of its own, under a switch that was already green, directly above the very
+  sources it was counting — it restated what was on screen in a third colour and
+  cost a full row in each of the three tabs. The switch is a banded row now, and
+  says something only when the tab has nothing to switch on yet ("Add a repository
+  below and this starts reviewing your PRs on it") — the one state a switch cannot
+  show by itself.
+
+  The dialog also sizes to its content instead of a flat `84vh`, which drew an
+  empty box under any tab that ended early (Issues is 581px now, not a forced
+  760). Each tab's sections — **Sources**, **Repositories**, **Assigned
+  tickets**, **Open issues** — read as headings rather than another line of prose,
+  and workflow-state rows print in the provider's own casing (`Ready for Review`,
+  not `READY FOR REVIEW`), so on this surface uppercase means exactly one thing: a
+  section heading.
+
 ### Fixed
+
+- **The Intake master switch's label sat 10px above its own toggle.** It reused
+  `.set-switch-row`, which nudges its label up to compensate for the desktop app's
+  font; on a row whose label is already centered against a 20px switch, the nudge
+  just pulled the two apart.
+
+- **The Intake top-bar button announced itself as "Open work"** to a screen
+  reader — the surface's name two renames ago, so the spoken label matched nothing
+  on screen. The visible "Intake" is its accessible name now.
 
 - **A commit message the pre-commit hooks rejected is offered back, not retyped.**
   It always survived on disk — `.mindflock_commit_msg` is the file

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -24209,7 +24209,6 @@ function TopBar() {
             className: "tb-item",
             type: "button",
             title: "Intake — tickets, pull requests and issues waiting to become sessions (Alt+I)",
-            "aria-label": "Open work",
             onClick: () => ui.openDialogFor("intake"),
             children: "Intake"
           }
@@ -29327,26 +29326,25 @@ function AutomationSwitch({
   statusId,
   checked,
   onChange,
-  status,
-  tone
+  note
 }) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row set-switch-row", id: rowId, title, children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ik-switch", id: rowId, title, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ik-switch-text", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-label", children: label }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "checkbox",
-            id: inputId,
-            checked,
-            onChange: (e) => onChange(e.target.checked)
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
-      ] })
+      note ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", id: statusId, children: note }) : null
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: statusId, className: "pr-status" + (tone ? " " + tone : ""), children: status })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "ca-switch", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "checkbox",
+          id: inputId,
+          checked,
+          onChange: (e) => onChange(e.target.checked)
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ca-slider" })
+    ] })
   ] });
 }
 function SourceCard({
@@ -29613,7 +29611,6 @@ function IngestionToggle({ sourceCount }) {
       refetch();
     }
   };
-  const n = sourceCount;
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
     AutomationSwitch,
     {
@@ -29626,8 +29623,7 @@ function IngestionToggle({ sourceCount }) {
       onChange: (next) => {
         if (!busy) toggle(next);
       },
-      tone: n > 0 && desired ? "on" : n > 0 ? "paused" : "",
-      status: !n ? "○ Add a ticketing source below to start turning tickets into sessions" : desired ? `● Active — polling ${n} ${n === 1 ? "source" : "sources"} for tickets assigned to you` : `‖ Paused — ${n} ${n === 1 ? "source" : "sources"} kept; turn Automated ingestion on to resume`
+      note: sourceCount ? void 0 : "Add a ticketing source below and this starts polling it"
     }
   );
 }
@@ -30609,8 +30605,7 @@ function PullRequestsTab({ gotoTab }) {
           { enabled: next },
           next ? "Automated review on" : "Automated review paused"
         ),
-        tone: n > 0 && enabled ? "on" : n > 0 ? "paused" : "",
-        status: !n ? "○ Add a repository below to start reviewing your PRs" : enabled ? `● Active — reviewing PRs in ${n} ${n === 1 ? "repository" : "repositories"}` : `‖ Paused — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated review on to resume`
+        note: n ? void 0 : "Add a repository below and this starts reviewing your PRs on it"
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -30880,8 +30875,7 @@ function IssuesTab({ gotoTab }) {
           { issues_enabled: next },
           next ? "Automated issue handling on" : "Automated issue handling off"
         ),
-        tone: n > 0 && enabled ? "on" : n > 0 ? "paused" : "",
-        status: !n ? "○ Add a repository below, then turn Automated handling on" : enabled ? `● Active — handling new issues in ${n} ${n === 1 ? "repository" : "repositories"}` : `‖ Off — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated handling on to start`
+        note: n ? void 0 : "Add a repository below and this starts handling its new issues"
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -30920,7 +30914,7 @@ function IssuesTab({ gotoTab }) {
         noteId: "gh-issues-note",
         listId: "gh-issues-list",
         hint: /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-          "Every open issue on the repositories above , grouped by repository, with why auto handling has or hasn't picked it up. ",
+          "Every open issue on the repositories above, grouped by repository, with why auto handling has or hasn't picked it up. ",
           /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "Start work" }),
           " spins up a session for that issue right now, bypassing the age / already-handled filters."
         ] }),

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -1500,22 +1500,6 @@ p.set-hint {
   line-height: 1.5;
 }
 
-/* Automated PR review status line: no on/off toggle — the repo list is the
-   switch, and this line reflects it. */
-.pr-status {
-  font-size: 13px;
-  color: var(--muted);
-  margin: 2px 0 8px;
-}
-
-.pr-status.on {
-  color: var(--green);
-}
-
-.pr-status.paused {
-  color: var(--amber, #d9a441);
-}
-
 /* Advanced options fold (tuning fields hidden by default so "add a repo" is
    the clear primary action). */
 .pr-advanced {
@@ -7479,11 +7463,16 @@ button.linklike {
  * navigation is a horizontal strip with live counts and the panel gets the full
  * width. Wider than Settings too (780 vs 640) because a work row carries a
  * reference, a title, chips and a button on one line. */
+/* Sized to its content, not to the viewport. A flat `height: 84vh` made every
+   tab as tall as the tallest one could ever be, so a panel that ended at the
+   Assigned-tickets hint still drew ~90px of empty box under it and the whole
+   dialog read as half-finished. Floor keeps a sparse tab (no sources yet) from
+   collapsing into a strip; the body scrolls once content passes the ceiling. */
 #intake-panel {
   width: 780px;
   max-width: 94vw;
-  height: 84vh;
-  max-height: 760px;
+  min-height: min(420px, 84vh);
+  max-height: min(84vh, 760px);
   padding: 18px 22px 20px;
   border-radius: 12px;
   background: var(--panel);
@@ -7575,15 +7564,43 @@ button.linklike {
 }
 
 /* Same display contract as .set-screen, because capsGate.css hides the direct
-   children of a gated panel and reveals its .caps-gate — see the rules there. */
+   children of a gated panel and reveals its .caps-gate — see the rules there.
+
+   The gap is the tab's whole vertical rhythm: three sections (switch, sources,
+   work list), each already fenced by its own heading rule or border, so 16px
+   between them was spacing a boundary that was drawn anyway. */
 .ik-panel {
   display: none;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .ik-panel.active {
   display: flex;
+}
+
+/* The intro paragraph carries its own <p> margins from .set-block-hint; here the
+   flex gap above already spaces it, and doubling the two pushed the master
+   switch a third of the way down the panel. */
+.ik-panel > .set-block-hint {
+  margin: 0;
+}
+
+/* Section headings — "Sources", "Repositories", "Assigned tickets", "Open pull
+   requests". As a plain 13px label these sat at body weight and read as another
+   line of prose, which is what made a structurally-fine panel feel like an
+   undifferentiated column. Same treatment as .set-section-title, so the three
+   tabs and Settings agree on what "a section starts here" looks like. Direct
+   children only: the labels *inside* a source card (Provider, Repo URL) are
+   field labels, not sections. */
+.ik-panel > .set-row > .set-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
 }
 
 .ik-panel > .set-section-title:first-child {
@@ -7596,11 +7613,49 @@ button.linklike {
   padding-top: 10px;
 }
 
+/* The master switch (AutomationSwitch) ------------------------------------- */
+
+/* A banded row rather than a bare label-and-toggle pair. It is the one control
+   that governs everything below it, and the band both says so and gives it a
+   definite edge — the same --panel-2 fill a source group heading wears, so the
+   tab reads as bands-with-content instead of floating text.
+   Deliberately NOT .set-switch-row: that class nudges its label up 10px for the
+   desktop font, which on this surface just left the label hanging above its own
+   switch. Here the row centers them honestly. */
+.ik-switch {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 9px 12px;
+}
+
+/* Label over optional subtitle. min-width:0 so a long "nothing connected yet"
+   note ellipsizes/wraps inside the row instead of shoving the switch off it. */
+.ik-switch-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
 /* Source cards stack in their own column so the "+ Add" button below them is
    not mistaken for part of the last card. */
 .ik-cards {
   display: flex;
   flex-direction: column;
+  gap: 8px;
+}
+
+/* The card's own bottom margin is for the Settings screens it came from; inside
+   .ik-cards the flex gap spaces them, and both together left a dead 12px strip
+   between the last card and + Add source. */
+.ik-cards > .tk-source {
+  margin-bottom: 0;
 }
 
 /* Size the add button to its label instead of letting the .set-row flex column
@@ -7699,6 +7754,18 @@ button.linklike {
   text-transform: none;
   letter-spacing: 0;
   color: var(--text);
+}
+
+/* The leaf level — one provider workflow state ("Ready for review", "Deferred").
+   .tk-bucket-name shouts in uppercase for historical reasons, and the two levels
+   above it already opt out (the two rules above this one); the leaf was simply
+   missed. It matters more now that the panel's own section headings are uppercase:
+   with both shouting, a state row read as the start of a new section instead of a
+   row inside one. Uppercase means exactly one thing here — a section heading — and
+   a provider's state name gets printed the way the provider wrote it. */
+.ik-groups .tk-bucket-name {
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .ik-group-detail {

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -493,10 +493,14 @@ when it is deep-linked one — so every old link keeps working, including the
 **Configure** button on a Connections card (the server's `settings_screen`
 values) and the welcome tour's setup slides.
 
-**One anatomy, three tabs** (`components/intake/kit.tsx`): a master switch and its
-one-line status → a list of collapsible **source cards** with **+ Add** → a
-**work list grouped by source**, each row carrying why auto-pickup did or didn't
-take it. They used to be three dialects of that shape; ticketing had the good one
+**One anatomy, three tabs** (`components/intake/kit.tsx`): a master switch → a
+list of collapsible **source cards** with **+ Add** → a **work list grouped by
+source**, each row carrying why auto-pickup did or didn't take it. Each of the
+three is a titled section, and the switch is a banded row; the switch used to be
+followed by a status sentence ("● Active — polling 1 source…", "‖ Paused — 1
+source kept…") and no longer is — with the toggle beside it and the sources it
+counted listed directly below, the line only restated what was on screen. Its one
+subtitle is the state a switch cannot show: nothing connected yet. They used to be three dialects of that shape; ticketing had the good one
 (add/remove cards, each with its own credentials, repo and agent), so the other
 two were rebuilt onto it — a ticketing source and a watched repo are both just
 *sources* now. What legitimately differs stays in the tabs: only tickets have

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -179,7 +179,9 @@ export function TopBar() {
             className="tb-item"
             type="button"
             title="Intake — tickets, pull requests and issues waiting to become sessions (Alt+I)"
-            aria-label="Open work"
+            /* No aria-label: the visible "Intake" IS the name. The old one still
+               said "Open work", the surface's name two renames ago, so a screen
+               reader announced a button nobody could see. */
             onClick={() => ui.openDialogFor("intake")}
           >
             Intake

--- a/frontend/src/components/intake/IntakeDialog.css
+++ b/frontend/src/components/intake/IntakeDialog.css
@@ -5,11 +5,16 @@
  * navigation is a horizontal strip with live counts and the panel gets the full
  * width. Wider than Settings too (780 vs 640) because a work row carries a
  * reference, a title, chips and a button on one line. */
+/* Sized to its content, not to the viewport. A flat `height: 84vh` made every
+   tab as tall as the tallest one could ever be, so a panel that ended at the
+   Assigned-tickets hint still drew ~90px of empty box under it and the whole
+   dialog read as half-finished. Floor keeps a sparse tab (no sources yet) from
+   collapsing into a strip; the body scrolls once content passes the ceiling. */
 #intake-panel {
   width: 780px;
   max-width: 94vw;
-  height: 84vh;
-  max-height: 760px;
+  min-height: min(420px, 84vh);
+  max-height: min(84vh, 760px);
   padding: 18px 22px 20px;
   border-radius: 12px;
   background: var(--panel);
@@ -101,15 +106,43 @@
 }
 
 /* Same display contract as .set-screen, because capsGate.css hides the direct
-   children of a gated panel and reveals its .caps-gate — see the rules there. */
+   children of a gated panel and reveals its .caps-gate — see the rules there.
+
+   The gap is the tab's whole vertical rhythm: three sections (switch, sources,
+   work list), each already fenced by its own heading rule or border, so 16px
+   between them was spacing a boundary that was drawn anyway. */
 .ik-panel {
   display: none;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .ik-panel.active {
   display: flex;
+}
+
+/* The intro paragraph carries its own <p> margins from .set-block-hint; here the
+   flex gap above already spaces it, and doubling the two pushed the master
+   switch a third of the way down the panel. */
+.ik-panel > .set-block-hint {
+  margin: 0;
+}
+
+/* Section headings — "Sources", "Repositories", "Assigned tickets", "Open pull
+   requests". As a plain 13px label these sat at body weight and read as another
+   line of prose, which is what made a structurally-fine panel feel like an
+   undifferentiated column. Same treatment as .set-section-title, so the three
+   tabs and Settings agree on what "a section starts here" looks like. Direct
+   children only: the labels *inside* a source card (Provider, Repo URL) are
+   field labels, not sections. */
+.ik-panel > .set-row > .set-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
 }
 
 .ik-panel > .set-section-title:first-child {
@@ -122,11 +155,49 @@
   padding-top: 10px;
 }
 
+/* The master switch (AutomationSwitch) ------------------------------------- */
+
+/* A banded row rather than a bare label-and-toggle pair. It is the one control
+   that governs everything below it, and the band both says so and gives it a
+   definite edge — the same --panel-2 fill a source group heading wears, so the
+   tab reads as bands-with-content instead of floating text.
+   Deliberately NOT .set-switch-row: that class nudges its label up 10px for the
+   desktop font, which on this surface just left the label hanging above its own
+   switch. Here the row centers them honestly. */
+.ik-switch {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 9px 12px;
+}
+
+/* Label over optional subtitle. min-width:0 so a long "nothing connected yet"
+   note ellipsizes/wraps inside the row instead of shoving the switch off it. */
+.ik-switch-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
 /* Source cards stack in their own column so the "+ Add" button below them is
    not mistaken for part of the last card. */
 .ik-cards {
   display: flex;
   flex-direction: column;
+  gap: 8px;
+}
+
+/* The card's own bottom margin is for the Settings screens it came from; inside
+   .ik-cards the flex gap spaces them, and both together left a dead 12px strip
+   between the last card and + Add source. */
+.ik-cards > .tk-source {
+  margin-bottom: 0;
 }
 
 /* Size the add button to its label instead of letting the .set-row flex column
@@ -225,6 +296,18 @@
   text-transform: none;
   letter-spacing: 0;
   color: var(--text);
+}
+
+/* The leaf level — one provider workflow state ("Ready for review", "Deferred").
+   .tk-bucket-name shouts in uppercase for historical reasons, and the two levels
+   above it already opt out (the two rules above this one); the leaf was simply
+   missed. It matters more now that the panel's own section headings are uppercase:
+   with both shouting, a state row read as the start of a new section instead of a
+   row inside one. Uppercase means exactly one thing here — a section heading — and
+   a provider's state name gets printed the way the provider wrote it. */
+.ik-groups .tk-bucket-name {
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .ik-group-detail {

--- a/frontend/src/components/intake/IssuesTab.tsx
+++ b/frontend/src/components/intake/IssuesTab.tsx
@@ -140,14 +140,7 @@ export function IssuesTab({ gotoTab }: TabProps) {
             next ? "Automated issue handling on" : "Automated issue handling off"
           )
         }
-        tone={n > 0 && enabled ? "on" : n > 0 ? "paused" : ""}
-        status={
-          !n
-            ? "○ Add a repository below, then turn Automated handling on"
-            : enabled
-              ? `● Active — handling new issues in ${n} ${n === 1 ? "repository" : "repositories"}`
-              : `‖ Off — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated handling on to start`
-        }
+        note={n ? undefined : "Add a repository below and this starts handling its new issues"}
       />
 
       <RepoSourceList
@@ -187,9 +180,8 @@ export function IssuesTab({ gotoTab }: TabProps) {
         listId="gh-issues-list"
         hint={
           <>
-            Every open issue on the repositories above
-, grouped by repository, with why auto handling has or hasn't
-            picked it up. <strong>Start work</strong> spins up a session for that issue right
+            Every open issue on the repositories above, grouped by repository, with why
+            auto handling has or hasn't picked it up. <strong>Start work</strong> spins up a session for that issue right
             now, bypassing the age / already-handled filters.
           </>
         }

--- a/frontend/src/components/intake/PullRequestsTab.tsx
+++ b/frontend/src/components/intake/PullRequestsTab.tsx
@@ -156,14 +156,7 @@ export function PullRequestsTab({ gotoTab }: TabProps) {
             next ? "Automated review on" : "Automated review paused"
           )
         }
-        tone={n > 0 && enabled ? "on" : n > 0 ? "paused" : ""}
-        status={
-          !n
-            ? "○ Add a repository below to start reviewing your PRs"
-            : enabled
-              ? `● Active — reviewing PRs in ${n} ${n === 1 ? "repository" : "repositories"}`
-              : `‖ Paused — ${n} ${n === 1 ? "repository" : "repositories"} kept; turn Automated review on to resume`
-        }
+        note={n ? undefined : "Add a repository below and this starts reviewing your PRs on it"}
       />
 
       <RepoSourceList

--- a/frontend/src/components/intake/TicketsTab.tsx
+++ b/frontend/src/components/intake/TicketsTab.tsx
@@ -105,7 +105,6 @@ function IngestionToggle({ sourceCount }: { sourceCount: number }) {
     }
   };
 
-  const n = sourceCount;
   return (
     <AutomationSwitch
       label="Automated ingestion"
@@ -115,14 +114,7 @@ function IngestionToggle({ sourceCount }: { sourceCount: number }) {
       statusId="tk-ingestion-status"
       checked={desired}
       onChange={(next) => { if (!busy) toggle(next); }}
-      tone={n > 0 && desired ? "on" : n > 0 ? "paused" : ""}
-      status={
-        !n
-          ? "○ Add a ticketing source below to start turning tickets into sessions"
-          : desired
-            ? `● Active — polling ${n} ${n === 1 ? "source" : "sources"} for tickets assigned to you`
-            : `‖ Paused — ${n} ${n === 1 ? "source" : "sources"} kept; turn Automated ingestion on to resume`
-      }
+      note={sourceCount ? undefined : "Add a ticketing source below and this starts polling it"}
     />
   );
 }

--- a/frontend/src/components/intake/kit.tsx
+++ b/frontend/src/components/intake/kit.tsx
@@ -58,11 +58,19 @@ export function panelNote(opts: {
   return opts.loaded ? "Refreshing…" : "Loading…";
 }
 
-/** Master on/off switch plus the one-line status underneath it.
+/** The master on/off switch at the top of a tab: one banded row, the automation
+ * named on the left and the switch on the right.
  *
- * The two are one component because the status is only ever a readout of the
- * switch and the source count; keeping them together is what stops the three
- * tabs from describing the same three states in three ways. */
+ * There used to be a status sentence under it — "● Active — polling 1 source for
+ * tickets assigned to you", "‖ Paused — 1 source kept; turn Automated ingestion
+ * on to resume" — and it has been dropped. With the switch a finger-width to the
+ * right and the sources it counts listed directly below, the line restated two
+ * things already on screen, in a third colour, and cost a full row of panel
+ * height in each of the three tabs.
+ *
+ * The one state a switch genuinely cannot show is "there is nothing to turn on
+ * yet", so that survives as `note` — and it sits *inside* the row as a subtitle,
+ * where it reads as part of the control rather than as a stray line of copy. */
 export function AutomationSwitch({
   label,
   title,
@@ -71,8 +79,7 @@ export function AutomationSwitch({
   statusId,
   checked,
   onChange,
-  status,
-  tone,
+  note,
 }: {
   label: string;
   title: string;
@@ -81,30 +88,31 @@ export function AutomationSwitch({
   statusId?: string;
   checked: boolean;
   onChange(next: boolean): void;
-  /** The status sentence. Convention: "● " active, "‖ " paused, "○ " not set up. */
-  status: string;
-  /** "on" tints it live, "paused" tints it muted, "" is the not-yet-set-up grey. */
-  tone: "on" | "paused" | "";
+  /** Subtitle inside the row, for what the switch can't say itself. Pass it only
+   * when the tab has no sources yet — never to narrate on/off. */
+  note?: string;
 }) {
   return (
-    <>
-      <div className="set-row set-switch-row" id={rowId} title={title}>
+    <div className="ik-switch" id={rowId} title={title}>
+      <span className="ik-switch-text">
         <span className="set-label">{label}</span>
-        {/* label wraps only the switch, so clicking the row text never flips it */}
-        <label className="ca-switch">
-          <input
-            type="checkbox"
-            id={inputId}
-            checked={checked}
-            onChange={(e) => onChange(e.target.checked)}
-          />
-          <span className="ca-slider" />
-        </label>
-      </div>
-      <div id={statusId} className={"pr-status" + (tone ? " " + tone : "")}>
-        {status}
-      </div>
-    </>
+        {note ? (
+          <span className="set-hint" id={statusId}>
+            {note}
+          </span>
+        ) : null}
+      </span>
+      {/* label wraps only the switch, so clicking the row text never flips it */}
+      <label className="ca-switch">
+        <input
+          type="checkbox"
+          id={inputId}
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <span className="ca-slider" />
+      </label>
+    </div>
   );
 }
 

--- a/frontend/src/components/settings/screens/screens.css
+++ b/frontend/src/components/settings/screens/screens.css
@@ -141,22 +141,6 @@
   line-height: 1.5;
 }
 
-/* Automated PR review status line: no on/off toggle — the repo list is the
-   switch, and this line reflects it. */
-.pr-status {
-  font-size: 13px;
-  color: var(--muted);
-  margin: 2px 0 8px;
-}
-
-.pr-status.on {
-  color: var(--green);
-}
-
-.pr-status.paused {
-  color: var(--amber, #d9a441);
-}
-
 /* Advanced options fold (tuning fields hidden by default so "add a repo" is
    the clear primary action). */
 .pr-advanced {

--- a/tests/unit/test_pr_review_settings.py
+++ b/tests/unit/test_pr_review_settings.py
@@ -240,9 +240,15 @@ def test_app_js_wires_pr_review_repos_and_toggle():
     # …and the per-repo override map saved alongside it, which is what makes a
     # card's own agent / base branch / grace period mean anything.
     assert "repo_settings:" in js
-    # Explicit pause toggle owns github.enabled; a 3-state status line reflects it.
-    assert "Paused —" in js
+    # Explicit pause toggle owns github.enabled, and pausing is what it says in
+    # the toast. There is deliberately no "● Active / ‖ Paused" status line under
+    # the switch any more: with the switch itself right there and the repos it
+    # counts listed below, it only restated what was already on screen (see
+    # AutomationSwitch in intake/kit.tsx). The switch's only subtitle is the one
+    # state a switch can't show — nothing connected yet.
+    assert "Paused —" not in js
     assert "Automated review paused" in js
+    assert "Add a repository below and this starts reviewing your PRs on it" in js
 
 
 def test_style_has_feature_and_repo_rules():


### PR DESCRIPTION
The three Intake tabs were structurally right and visually loud. Reported as
"structurally good but look a little strange with all of the space", and "the
active polling or the pause or whatever feels very unnecessary to show there".

## The status line is gone

`AutomationSwitch` no longer renders `● Active — polling 1 source for tickets
assigned to you` / `‖ Paused — 1 source kept; turn Automated ingestion on to
resume`. It occupied its own row, under a switch that was already green,
immediately above the list of sources it was counting — three statements of one
fact, in three type colours, costing a full row in each of the three tabs.

The switch keeps a subtitle only for the state it genuinely cannot express —
nothing connected yet ("Add a repository below and this starts reviewing your PRs
on it") — and that subtitle sits *inside* the row, so it reads as part of the
control rather than as a stray line of copy.

## And the space

- The dialog was a flat `height: 84vh` whatever it held, so a tab that ended
  early still drew an empty box under its last line. It sizes to content between
  a floor and a ceiling now: **Issues is 581px, not a forced 760**.
- Panel section gap 16px → 12px; removed the doubled `<p>` margin on each tab's
  intro paragraph, and a dead 12px strip between the last source card and
  **+ Add source**.
- Section labels (**Sources**, **Repositories**, **Assigned tickets**, **Open
  issues**) sat at body weight and read as more prose. They take the same
  treatment as a Settings section title.
- Which made the leaf workflow-state rows the second thing shouting in uppercase
  — a level the two groups above them had already opted out of. Uppercase now
  means exactly one thing on this surface: a section heading. Provider state
  names print as the provider wrote them (`Ready for Review`, not `READY FOR
  REVIEW`).
- The switch is no longer a `.set-switch-row`. That class lifts its label 10px to
  compensate for the desktop app's font; against a 20px switch on a centered row
  it simply left label and toggle misaligned — measured delta is 0 now.

Everything lands in `intake/kit.tsx` + `IntakeDialog.css`, so Tickets, Pull
requests and Issues move together. Removed the now-dead `.pr-status` rules and
updated `docs/web-ui.md`, which still described the anatomy as "a master switch
and its one-line status".

Two strays fixed in passing: the Intake top-bar button announced itself as
**"Open work"** to a screen reader (its name two renames ago), and a JSX line
break was rendering "repositories above , grouped by".

## Verification

Driven in a headless browser against the built bundle — all three tabs, both
themes — not just read off the CSS.

- `pytest tests/` — 3799 passed
- `npm test` — 157 passed
- `npm run build` — bundle rebuilt and committed (`tsc --noEmit` clean)

One assertion in `test_pr_review_settings.py` pinned the removed status line
(`assert "Paused —" in js`); it is inverted to `not in` with the reasoning, plus
a check for the new subtitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
