### PR TITLE
Release 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-08-04
+
 ### Changed
 
 - **The Intake tabs dropped the status line under their master switch, and
@@ -946,7 +948,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.10...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.11...HEAD
+[0.1.11]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.11
 [0.1.10]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.10
 [0.1.9]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.9
 [0.1.8]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.8

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.10"
+version = "0.1.11"
 description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump only — `bump-version.py patch` across the four manifests plus the CHANGELOG roll ([Unreleased] → [0.1.11] - 2026-08-04, links retargeted).

Ships what landed since v0.1.10:

- **Intake tabs quieted down** (#45) — the master switch status line is gone, the dialog sizes to its content instead of a flat `84vh`, section labels read as headings, and workflow-state rows keep the provider's own casing.
- **A commit message the pre-commit hooks rejected is offered back** (#43) instead of being retyped, and clicking outside the Commit dialog closes it.

## Verification

- `bump-version.py --check` — ok: all manifests at 0.1.11
- `check-bundle-fresh.sh` — bundle is current (the version bump does not touch it)
- `pytest tests/` — 3799 passed on the merge parent

Tag goes on the merged commit, which is what triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)