### PR TITLE
Get a new user to a running agent faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`mindflock init` — a guided first-run setup.** Getting to a first session
+  meant discovering and sequencing four commands from the README. `init` runs the
+  doctor, offers to run each fix for you (including logging your agent CLI in),
+  then shows the git repos it found on this machine as a numbered list and
+  remembers the one you pick, so the New Session dialog opens on it. `mindflock
+  serve --setup` runs the same wizard before binding.
+
+- **A first `serve` now prints what this machine actually needs.** It used to
+  print the same three-step blurb to everyone; it now names the dependencies that
+  are missing with their one-line fixes, lists the folders you could work in, and
+  gives you the exact next command. It builds that off the main thread — a first
+  run is the desktop app's very first launch, which is polling for the port.
+
+- **The New Session dialog offers the repos you actually use.** A new
+  `GET /api/repos/suggest` ranks the folder your last session used, the live
+  sessions' repos, the server's own working directory, and a shallow scan for git
+  repos under your home — and the dialog pre-selects the top one as a chip row
+  instead of dropping you in `$HOME` to go hunting. `GET /api/repos/check` backs a
+  quiet line that appears when the chosen folder is *not* a git repo, saying diff,
+  commit and PR will be off, with a one-click "create one here" that drives the
+  checkbox that was buried in **More options**.
+
+### Changed
+
+- **The folder browser selects like Finder.** A click used to navigate and only
+  the per-row **select** button committed a folder, which read backwards. A single
+  click now selects (and shows the folder in the field), a double click descends,
+  the redundant button is gone, and Escape cancels the whole browse rather than
+  leaving the field on the last directory you merely passed through.
+
+- **The doctor's agent-auth check now covers every coding CLI, not just Claude.**
+  It reported "no auth probe for `codex` — skipped" for anything else, so a user
+  on Codex, opencode or aider learned their CLI was logged out when their first
+  session failed. It reads each provider's own declared credential locations now.
+  A provider that declares none stays quiet — absence of evidence is not evidence
+  of absence — and it only offers to run a login command the provider actually
+  declares, so `doctor --fix` can no longer drop you into an agent REPL that
+  cannot resolve the check.
+
+- **One first-run signal instead of three.** The welcome tour and the setup
+  checklist each kept their own browser-local flag beside the server's
+  `onboarded`, so clearing a profile or opening the desktop app on a second
+  machine replayed the whole 12-slide tour at someone who plainly was not new. The
+  server's flag is the only rule now, and it still means what it always meant: you
+  have created a session.
+
+### Fixed
+
+- **A todo you clicked to edit closed again immediately.** The text box opened and
+  reverted within a frame: the poll callback's dependencies changed the moment an
+  edit began, which re-ran the effect that focuses the Add box, and that blur
+  committed the edit before you could type. The initial focus is tied to the
+  dialog opening now, not to unrelated re-renders.
+
+- **The doctor told logged-in macOS users they were logged out.** Claude Code
+  keeps its credentials in the login Keychain there rather than in
+  `~/.claude/.credentials.json`, which the probe never looked at — so every Mac
+  saw "CLI is installed but no sign of a login was found" on every run. It checks
+  the Keychain now, after the cheap file reads, so it never shells out to
+  `security` when a file already answered.
+
+- **The sidebar's resize handle painted over every open dialog.** The `.modal`
+  backdrop is fixed with no `z-index` of its own, so the handle's `z-index: 40`
+  drew its accent line across the dimmed page and kept answering `:hover` — and
+  the drag still worked through the backdrop, resizing a sidebar nobody could
+  see. It hides while any modal is mounted, keyed off the overlay element so the
+  command palette and the welcome tour are covered too.
+
 ## [0.1.11] - 2026-08-04
 
 ### Changed

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -5,6 +5,9 @@ Installed via ``[project.scripts]``::
     mindflock                     # serve (localhost only, port 8765)
     mindflock serve tailscale     # serve on the tailnet (phone access)
     mindflock serve --port 9000   # custom port
+    mindflock serve --setup       # …run the guided setup first, then serve
+    mindflock init                # guided first run: deps, agent login, repo
+    mindflock init --yes          # …taking every default, for scripts
     mindflock doctor              # dependency preflight (exit 1 on failures)
     mindflock doctor --fix        # …and offer to run each fix command
 
@@ -20,7 +23,10 @@ Installed via ``[project.scripts]``::
 
 ``serve`` delegates to :func:`backend.web.run.main` (the same code path as
 ``./backend/web/run.sh``); ``doctor`` runs the same checks as
-``GET /api/doctor`` and prints them with per-platform fixes. The session
+``GET /api/doctor`` and prints them with per-platform fixes; ``init``
+(:mod:`backend.init_wizard`) walks a brand-new user through those checks, offers
+the doctor's own fix commands, and remembers the repo they pick — none of the
+three needs a running server. The session
 commands (J1) are thin clients over a *running* server's HTTP API — discovery
 order is ``--host``/``--port`` → ``MINDFLOCK_HOST``/``MINDFLOCK_PORT`` →
 probe 127.0.0.1:8765 (see :mod:`backend.client`). They never spawn an
@@ -37,14 +43,14 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional, TextIO
 
 from backend import __version__, client
 
 if TYPE_CHECKING:
     from backend.doctor import Check
 
-__all__ = ["main"]
+__all__ = ["main", "print_checks"]
 
 # Terminal glyph per doctor status (see backend.doctor for the semantics).
 _GLYPHS = {"ok": "✓", "info": "-", "warn": "!", "fail": "✗"}
@@ -79,6 +85,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="local = bind 127.0.0.1 (default); tailscale = bind 0.0.0.0 (phone/tailnet access, auth gate on)",
     )
     serve.add_argument("--port", type=int, default=None, help="port (default 8765)")
+    serve.add_argument(
+        "--setup",
+        action="store_true",
+        help="run the guided first-run setup (see `mindflock init`) before binding the port",
+    )
+
+    init_p = sub.add_parser(
+        "init",
+        help="guided first-run setup: check dependencies, log in your agent CLI, pick your repo",
+    )
+    init_p.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="take every default without prompting (for scripts)",
+    )
 
     doctor_p = sub.add_parser(
         "doctor",
@@ -221,7 +243,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _cmd_serve(mode: Optional[str], port: Optional[int]) -> int:
+def _cmd_serve(mode: Optional[str], port: Optional[int], setup: bool = False) -> int:
     from backend.web.run import main as serve_main
 
     argv: List[str] = []
@@ -229,8 +251,38 @@ def _cmd_serve(mode: Optional[str], port: Optional[int]) -> int:
         argv.append(mode)
     if port is not None:
         argv.append(str(port))
+    if setup:
+        # run.py owns the ordering (setup runs after its double-launch guard,
+        # before the bind), so pass the intent along as one of its tokens.
+        argv.append("--setup")
     serve_main(argv)  # prints the friendly web-deps hint itself if they're missing
     return 0
+
+
+def print_checks(checks: list[Check], stream: Optional[TextIO] = None) -> None:
+    """Render doctor results the one way MindFlock renders them: a glyph column,
+    label-aligned details, and the fix line under anything that needs attention.
+
+    Shared by ``mindflock doctor`` and the first-run wizard
+    (:mod:`backend.init_wizard`) so the two can never drift into two dialects of
+    the same table. An empty list prints nothing — the wizard's report passes
+    only the checks that need attention, and on a healthy machine that is none.
+    """
+    out = stream if stream is not None else sys.stdout
+    if not checks:
+        return
+    width = max(len(c.label) for c in checks)
+    for c in checks:
+        glyph = _GLYPHS.get(c.status, "?")
+        print(f"  {glyph} {c.label.ljust(width)}  {c.detail}", file=out)
+        if c.fix and c.status in ("warn", "fail"):
+            print(f"    {' ' * width}  fix: {c.fix}", file=out)
+
+
+def _cmd_init(assume_yes: bool = False) -> int:
+    from backend import init_wizard
+
+    return init_wizard.run(assume_yes=assume_yes)
 
 
 def _cmd_doctor(fix: bool = False) -> int:
@@ -239,12 +291,7 @@ def _cmd_doctor(fix: bool = False) -> int:
     checks = doctor.run_checks()
     print("MindFlock doctor")
     print()
-    width = max(len(c.label) for c in checks)
-    for c in checks:
-        glyph = _GLYPHS.get(c.status, "?")
-        print(f"  {glyph} {c.label.ljust(width)}  {c.detail}")
-        if c.fix and c.status in ("warn", "fail"):
-            print(f"    {' ' * width}  fix: {c.fix}")
+    print_checks(checks)
     if fix:
         checks = _fix_checks(checks)
     failed = [c for c in checks if c.status == "fail"]
@@ -685,6 +732,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = _build_parser().parse_args(sys.argv[1:] if argv is None else argv)
     if args.command == "doctor":
         return _cmd_doctor(fix=args.fix)
+    if args.command == "init":
+        # Like doctor and uninstall, not a session command: init is what you run
+        # *before* there is a server, so it must never go through the
+        # ServerNotFound handler below.
+        return _cmd_init(assume_yes=args.yes)
     if args.command == "uninstall":
         # Not a session command: it works offline against state.json (and
         # refuses to run while a server is up), so it must never be wrapped in
@@ -705,7 +757,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     # Default (no subcommand) = serve with defaults.
     mode = getattr(args, "mode", None)
     port = getattr(args, "port", None)
-    return _cmd_serve(mode, port)
+    return _cmd_serve(mode, port, setup=bool(getattr(args, "setup", False)))
 
 
 if __name__ == "__main__":

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -608,6 +608,14 @@ class GeneralSettings:
     first-run checklist). Gates the first-run setup card so it only auto-shows
     for a brand-new install, not every time the grid happens to be empty.
 
+    ``last_repo_path``: the folder the most recent session (or init-wizard run)
+    was based on, written by the create-session path. It seeds the New Session
+    dialog's folder field and tops the repo-suggestion list
+    (:mod:`backend.web.core.repo_picker`), so the second session in a repo is one
+    click instead of another walk down the folder tree. Purely a convenience
+    hint — nothing resolves through it, and a stale path is dropped rather than
+    offered once the folder is gone.
+
     ``remote_control``: whether OTHER MindFlock devices on the tailnet may
     control this one (:mod:`backend.web.core.remote`) — ``"on"`` allows it,
     ``""``/``"off"`` (the default) refuses remote-flagged requests and
@@ -642,6 +650,7 @@ class GeneralSettings:
     auth_token: str = ""  # SECRET
     auth_mode: str = ""  # "" / "auto" | "on" | "off"
     onboarded: bool = False
+    last_repo_path: str = ""
     remote_control: str = ""  # "" / "off" | "on"
     serve_mode: str = ""  # "" / "local" | "tailscale"
     ingestion_autostart: Optional[bool] = None
@@ -659,6 +668,8 @@ class GeneralSettings:
             d["auth_mode"] = self.auth_mode
         if self.onboarded:
             d["onboarded"] = True
+        if self.last_repo_path:
+            d["last_repo_path"] = self.last_repo_path
         if self.remote_control:
             d["remote_control"] = self.remote_control
         if self.serve_mode:
@@ -677,6 +688,7 @@ class GeneralSettings:
             auth_token=str(d.get("auth_token", "") or ""),
             auth_mode=str(d.get("auth_mode", "") or "").strip().lower(),
             onboarded=bool(d.get("onboarded", False)),
+            last_repo_path=str(d.get("last_repo_path", "") or ""),
             remote_control=str(d.get("remote_control", "") or "").strip().lower(),
             serve_mode=str(d.get("serve_mode", "") or "").strip().lower(),
             ingestion_autostart=_opt_bool(d.get("ingestion_autostart")),

--- a/backend/doctor.py
+++ b/backend/doctor.py
@@ -310,53 +310,157 @@ def check_agent_cli() -> Check:
     )
 
 
-def _claude_login_evidence() -> str:
-    """Best-effort probe for a Claude Code login. Returns a human detail string
-    when some credential source is found, else ``""``. Never raises."""
-    candidates: List[Path] = []
-    cfg = os.environ.get("CLAUDE_CONFIG_DIR")
-    if cfg:
-        candidates += [Path(cfg) / ".claude.json", Path(cfg) / ".credentials.json"]
-    home = Path.home()
-    candidates += [home / ".claude.json", home / ".claude" / ".credentials.json"]
-    for path in candidates:
-        try:
-            text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        for marker in ("oauthAccount", "primaryApiKey", "claudeAiOauth"):
-            if marker in text:
-                return f"login state found in {path}"
-    if os.environ.get("ANTHROPIC_API_KEY"):
-        return "ANTHROPIC_API_KEY is set"
-    return ""
+def _agent_provider(name: str):
+    """The registered provider object for ``name``, or ``None`` when the registry
+    cannot produce one (a stale provider name in settings, a user TOML that was
+    deleted, an import that failed). Never raises — the auth check has to say
+    something useful even when the registry is unhappy."""
+    try:
+        from backend import providers
+
+        return providers.get(name)
+    except Exception:  # noqa: BLE001 — a broken registry must not break the doctor
+        return None
+
+
+def _declares_auth_sources(provider) -> bool:
+    """Whether ``provider`` has told us where its credentials could live.
+
+    This is what separates the two meanings of "no evidence". A CLI that named
+    its credential files or env vars and has none of them is probably logged
+    out, which is worth a nudge; a CLI that named nothing keeps its token
+    somewhere we never look, so its absence proves nothing and warning about it
+    would nag on every doctor run forever (antigravity, cline, goose). Config-
+    driven providers declare it as data; the hand-written ones (claude) carry no
+    ``cfg``, so overriding the base no-op probe IS their declaration.
+    """
+    cfg = getattr(provider, "cfg", None)
+    if cfg is not None:
+        return bool(getattr(cfg, "auth_files", ()) or getattr(cfg, "auth_env", ()))
+    try:
+        from backend.providers.base import BaseProvider
+
+        return type(provider).auth_evidence is not BaseProvider.auth_evidence
+    except Exception:  # noqa: BLE001 — unknowable, so claim nothing and stay quiet
+        return False
+
+
+def _auth_evidence(provider) -> str:
+    """The provider's own login evidence, or ``""``.
+
+    Same doctrine as Settings → Providers (:func:`backend.web.addons.settings.
+    _provider_status`): a probe that finds nothing — or blows up — means "login
+    status unknown", never "logged out"."""
+    try:
+        return provider.auth_evidence() or ""
+    except Exception:  # noqa: BLE001 — a broken probe is no evidence, not a 500
+        return ""
+
+
+def _declared_login_command(provider) -> str:
+    """The login command ``provider`` EXPLICITLY declares, or ``""``.
+
+    :meth:`BaseProvider.login_command` never answers nothing — with no login
+    flow to name it hands back the bare program name — and taking that at face
+    value made the doctor offer to run the agent itself: ``doctor --fix`` and
+    the ``mindflock init`` wizard printed "agent auth (aider): run `aider`?" and
+    Enter replaced the wizard with aider's own REPL in whatever directory it was
+    started in, having authenticated nothing. So a bare program name only counts
+    when a provider means it: config-driven providers declare it as data
+    (``cfg.login_command``), and the hand-written ones declare it by overriding
+    the base method — which claude does deliberately, because the ``claude`` CLI
+    really does prompt to sign in on first run.
+    """
+    cfg = getattr(provider, "cfg", None)
+    if cfg is not None:
+        return str(getattr(cfg, "login_command", "") or "")
+    try:
+        from backend.providers.base import BaseProvider
+
+        if type(provider).login_command is BaseProvider.login_command:
+            return ""
+        return provider.login_command() or ""
+    except Exception:  # noqa: BLE001 — a provider must never break the doctor
+        return ""
+
+
+def _login_fix(provider, base: str) -> Tuple[str, str]:
+    """``(fix line, runnable command)`` for a CLI that looks logged out.
+
+    The command comes from the provider itself, so each CLI is pointed at its own
+    flow instead of everyone being told to run ``claude``. One that already says
+    "login" (``codex login``) reads as an instruction on its own, while a bare
+    program name (``claude``) needs the "once to log in" tail to explain why you
+    would run it at all. A provider that declares no flow gets a human fix line
+    and no runnable command at all — naming the API keys it reads is remediation,
+    dropping the user into an agent REPL is not.
+    """
+    cmd = _declared_login_command(provider)
+    if "login" in cmd:
+        return f"run `{cmd}`", cmd
+    if cmd:
+        return f"run `{cmd}` once to log in", cmd
+    cfg = getattr(provider, "cfg", None)
+    env = [str(v) for v in (getattr(cfg, "auth_env", ()) or ())]
+    if env:
+        keys = ", ".join(env[:3])
+        return f"set one of the API keys `{base}` reads ({keys})", ""
+    return f"log `{base}` in from inside the CLI itself", ""
 
 
 def check_agent_auth() -> Check:
-    """Auth probe for the agent CLI (implemented for the claude family)."""
+    """Auth probe for the configured coding-agent CLI, asked of the provider.
+
+    Every provider already knows where its own credentials live
+    (``auth_evidence``), so routing through the registry makes this work for
+    codex/opencode/aider too. Before that, anything but claude got "no auth probe
+    — skipped" and a logged-out CLI was discovered the hard way: the first
+    session started and died silently.
+
+    The three-way verdict is the whole point. Evidence is ``ok``. No evidence
+    from a provider that DID tell us where to look is a ``warn`` carrying that
+    provider's own login command as ``cmd`` — but only a login command it
+    actually declared (see :func:`_declared_login_command`), so ``doctor --fix``
+    never offers to run an agent that has no login flow. A provider that
+    declares no credential sources at all is ``info``:
+    there is nothing to probe, so silence is the honest report rather than a
+    warning the user can never clear.
+    """
     name = _default_provider_name()
     binary = _resolve_agent_binary(name)
     base = Path(binary).name
     label = f"agent auth ({name})"
-    if base != "claude" and name != "claude":
+    provider = _agent_provider(name)
+    if provider is None:
         return Check(
-            "agent-auth", label, "info", f"no auth probe for `{name}` — skipped"
+            "agent-auth",
+            label,
+            "info",
+            f"`{name}` is not a registered provider — no login probe",
         )
-    evidence = _claude_login_evidence()
+    evidence = _auth_evidence(provider)
     if evidence:
         return Check("agent-auth", label, "ok", evidence)
+    if not _declares_auth_sources(provider):
+        return Check(
+            "agent-auth",
+            label,
+            "info",
+            f"there is no login probe for `{base}` — check its status inside the CLI itself",
+        )
     if not shutil.which(base) and os.sep not in binary:
         return Check(
             "agent-auth", label, "warn", "agent CLI not installed — cannot probe auth"
         )
+    fix, cmd = _login_fix(provider, base)
     return Check(
         "agent-auth",
         label,
         "warn",
         "CLI is installed but no sign of a login was found",
-        "run `claude` once to log in",
-        docs=_DOCS["claude"],
-        cmd="claude",
+        fix,
+        docs=_DOCS["claude"] if base == "claude" else "",
+        cmd=cmd,
     )
 
 

--- a/backend/init_wizard.py
+++ b/backend/init_wizard.py
@@ -1,0 +1,438 @@
+"""``mindflock init`` — the guided first run, so nobody has to sequence it by hand.
+
+Getting from a fresh install to a first agent session takes four things, in
+order: the host dependencies (tmux, a coding-agent CLI), that CLI actually
+*logged in*, a folder to work in, and a running server. The README spells them
+out as prose, which leaves a stranger to work out which of them are already
+true on their machine — and the one that hurts most is invisible: an agent CLI
+that is installed but never authenticated starts a session whose terminal sits
+on a login screen forever, looking like MindFlock hung.
+
+Two entry points, and the split between them is the point of this module:
+
+:func:`report` is non-interactive. It is what a first ``mindflock serve``
+prints (see :mod:`backend.web.run`): the user's *actual* missing dependencies
+with their one-line fixes, the folders we can see, and the exact next commands.
+That call site sets the rules — the desktop app auto-starts the server and polls
+its port, so run.py prints this from a background thread that cannot delay the
+bind, and nothing here prompts (nobody is watching that thread's stdin) or raises
+(a report that blew up would throw a traceback across the boot banner). The
+swallow in :func:`report` is the only place that degrades this text: the boot path
+deliberately keeps no fallback copy of it to rot out of sync.
+
+:func:`run` is the interactive wizard behind ``mindflock init`` (and
+``mindflock serve --setup``). It reuses the doctor's own fix loop
+(:func:`backend.cli._fix_checks`) instead of re-implementing "install tmux",
+"install the agent CLI" and "log the agent CLI in": each of those is a doctor
+check that already carries a runnable command, and a second copy of that
+confirm-run-re-probe dance would drift from the first one the day a fix line
+changes.
+
+Nothing here sets ``general.onboarded``. In this codebase that flag means "has
+created a session" and gates the desktop app's own first-run surfaces; setting
+it at the end of a wizard would silently suppress the welcome tour for someone
+who has not started anything yet.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING, List, Optional, TextIO
+
+if TYPE_CHECKING:
+    from backend.doctor import Check
+
+__all__ = ["report", "run"]
+
+#: How many folders the wizard offers to choose from, and how many the
+#: (much terser) first-run report lists. Long enough to contain the repo the
+#: user meant, short enough to stay a glance rather than a page.
+_MAX_CANDIDATES = 8
+_REPORT_CANDIDATES = 5
+
+#: Stop re-asking which folder to use after this many unusable answers, so a
+#: scripted stdin that keeps answering nonsense can never trap the wizard in a
+#: loop nobody is watching.
+_MAX_REPO_PROMPTS = 5
+
+#: Stand-in seed prompt for the copy-pasteable ``mindflock new`` line. A concrete
+#: task reads as an example; ``-p "…"`` reads as syntax to decode.
+_EXAMPLE_PROMPT = "add a test for the login flow"
+
+
+# --------------------------------------------------------------------------- #
+# Probes — every one of these degrades instead of raising, because both entry
+# points run on paths (a server boot, a CLI a stranger just installed) where an
+# exception costs far more than a missing line of advice.
+# --------------------------------------------------------------------------- #
+def _stdin_is_tty() -> bool:
+    """True when stdin can be prompted at all.
+
+    Mirrors the guard in :func:`backend.cli._fix_checks`: without it a piped or
+    closed stdin turns every prompt into an instant EOF, and a stdin that is
+    open but unattended (the desktop app's spawn) turns it into a wait with
+    nothing on screen to explain what it is waiting for."""
+    try:
+        return bool(sys.stdin.isatty())
+    except Exception:  # noqa: BLE001 — exotic stdin replacements
+        return False
+
+
+def _doctor_checks() -> List["Check"]:
+    """Every doctor result, or ``[]`` when the doctor itself could not run.
+
+    The wizard reports what it can: a broken import or a probe that blows up
+    costs the dependency table, not the rest of the setup."""
+    try:
+        from backend import doctor
+
+        return list(doctor.run_checks())
+    except Exception:  # noqa: BLE001 — no checks is survivable; a traceback isn't
+        return []
+
+
+def _needs_attention(checks: List["Check"]) -> List["Check"]:
+    """The ``warn``/``fail`` checks — the only ones a first-run summary should
+    spend lines on. An ``ok`` or ``info`` check is precisely what the user does
+    not need to read about."""
+    return [c for c in checks if c.status in ("warn", "fail")]
+
+
+def _remembered_repo() -> str:
+    """``general.last_repo_path`` — the folder the most recent session or wizard
+    run used — or ``""``. Never raises: an unreadable settings store just means
+    we have no memory to rank the suggestions with."""
+    try:
+        from backend.config.settings import load_settings
+
+        return str(load_settings().general.last_repo_path or "")
+    except Exception:  # noqa: BLE001 — advisory only
+        return ""
+
+
+def _remember_repo(path: str) -> None:
+    """Persist the picked folder as ``general.last_repo_path`` so the New Session
+    dialog and the ``/api/repos/suggest`` ranking both start where the user just
+    said they work. Never raises — a read-only settings store costs the memory,
+    not the setup that earned it."""
+    try:
+        from backend.config import settings as settings_mod
+
+        settings_mod.update_settings(general={"last_repo_path": path})
+    except Exception:  # noqa: BLE001 — a store we can't write is not a setup failure
+        pass
+
+
+def _is_git_worktree(path: str) -> bool:
+    """True when MindFlock will treat ``path`` as a git-backed folder.
+
+    Asks git itself (``rev-parse --is-inside-work-tree``, via
+    :mod:`backend.web.core.git_ops`) because that is the same question the
+    session-create path asks (:func:`backend.web.core.plain_repo._prepare_plain_repo`
+    calls the very same probe). A SUBDIRECTORY of a repo carries no ``.git`` of
+    its own, so testing for that entry would tell someone standing in
+    ``~/code/foo/src`` that diff, commit and PR are off — and then hand them a
+    session with all three on. The probe lives under the web extras like the
+    picker does, so its absence degrades to the cheap existence test rather than
+    to no answer at all."""
+    try:
+        from backend.web.core.git_ops import _is_git_repo
+
+        return bool(_is_git_repo(path))
+    except Exception:  # noqa: BLE001 — no web extras, or git itself unlaunchable
+        return os.path.exists(os.path.join(path, ".git"))
+
+
+def _candidate_repos(limit: int = _MAX_CANDIDATES) -> List[dict]:
+    """Folders to offer as the working repo, best first. Never raises.
+
+    The picker backs ``GET /api/repos/suggest`` and therefore lives under
+    :mod:`backend.web.core`, so it is imported lazily and its absence is
+    survivable: an install without the web extras must still be able to finish
+    this wizard, and "the folder you are standing in" is enough to do that."""
+    remembered = _remembered_repo()
+    recent = [remembered] if remembered else []
+    found: List[dict] = []
+    try:
+        from backend.web.core.repo_picker import suggest_repos
+
+        found = [
+            dict(s)
+            for s in suggest_repos(recent_paths=recent, cwd=os.getcwd(), limit=limit)
+        ]
+    except Exception:  # noqa: BLE001 — no web extras, or a scan that hit a bad mount
+        found = []
+    return found[:limit] if found else _fallback_candidates(recent)
+
+
+def _fallback_candidates(recent: List[str]) -> List[dict]:
+    """The suggestion list we can build without the picker: the remembered folder
+    and the current directory, in the picker's own wire shape so callers never
+    have to care which one they got. ``is_git`` comes from the same probe the
+    picker uses, so a folder does not change its answer depending on which of the
+    two lists the user is looking at."""
+    out: List[dict] = []
+    seen: set[str] = set()
+    for raw, source in [(p, "recent") for p in recent] + [(os.getcwd(), "cwd")]:
+        try:
+            path = os.path.realpath(os.path.expanduser(raw))
+        except Exception:  # noqa: BLE001 — an unresolvable path is simply not offered
+            continue
+        if path in seen or not os.path.isdir(path):
+            continue
+        seen.add(path)
+        out.append(
+            {
+                "path": path,
+                "name": os.path.basename(path) or path,
+                "is_git": _is_git_worktree(path),
+                "source": source,
+            }
+        )
+    return out
+
+
+def _git_note(candidate: dict) -> str:
+    """The one-word status shown beside a candidate folder. Plain "no git yet"
+    rather than silence, because a non-git folder still works — it just works
+    without diff, commit and PR."""
+    return "git repo" if candidate.get("is_git") else "no git yet"
+
+
+# --------------------------------------------------------------------------- #
+# Non-interactive report (the first-serve banner)
+# --------------------------------------------------------------------------- #
+def report(stream: Optional[TextIO] = None, *, serving: bool = False) -> None:
+    """Print a first-run summary: what this machine is missing, which folders it
+    could work in, and the commands that come next.
+
+    Never prompts, never blocks, never raises — see the module docstring for why
+    the server boot path cannot tolerate any of the three.
+
+    ``stream`` is resolved at call time rather than bound as a default so a
+    caller that swapped ``sys.stdout`` (a test capture, the desktop app's log
+    pipe) is honored. ``serving`` drops the ``mindflock serve`` line: this text
+    is printed *by* the server that line would start, and telling someone to
+    start what they just started is how a first-run hint loses its credibility.
+    """
+    out = stream if stream is not None else sys.stdout
+    try:
+        _print_report(out, serving=serving)
+    except Exception:  # noqa: BLE001 — advisory text must never break its caller
+        pass
+
+
+def _print_report(out: TextIO, *, serving: bool) -> None:
+    from backend import cli
+
+    print("First run — here is where this machine actually stands:", file=out)
+    print("", file=out)
+    checks = _doctor_checks()
+    attention = _needs_attention(checks)
+    if attention:
+        cli.print_checks(attention, stream=out)
+        print("", file=out)
+        print(
+            "  `mindflock init` walks through those and can run each fix for you.",
+            file=out,
+        )
+    elif checks:
+        print(
+            "  Dependencies look good — `mindflock doctor` prints the full list.",
+            file=out,
+        )
+    else:
+        print(
+            "  Dependency check unavailable — `mindflock doctor` has the details.",
+            file=out,
+        )
+
+    candidates = _candidate_repos(_REPORT_CANDIDATES)
+    if candidates:
+        print("", file=out)
+        print("  Folders you could work in:", file=out)
+        width = max(len(c["path"]) for c in candidates)
+        for c in candidates:
+            print("    %s  %s" % (c["path"].ljust(width), _git_note(c)), file=out)
+
+    target = candidates[0]["path"] if candidates else os.getcwd()
+    print("", file=out)
+    print("  Next:", file=out)
+    print(
+        "    mindflock init          # guided setup: dependencies, agent login, your repo",
+        file=out,
+    )
+    if not serving:
+        print(
+            "    mindflock serve         # start the server (the desktop app starts one for you)",
+            file=out,
+        )
+    print('    mindflock new %s -p "%s"' % (target, _EXAMPLE_PROMPT), file=out)
+    print(
+        "      (a session = an isolated git worktree + a tmux session running your agent)",
+        file=out,
+    )
+    print(
+        '  …or open the MindFlock desktop app and click "+ New" — same session, from the GUI.',
+        file=out,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Interactive wizard (`mindflock init`, `mindflock serve --setup`)
+# --------------------------------------------------------------------------- #
+def run(assume_yes: bool = False, *, serving: bool = False) -> int:
+    """Walk the user through first-run setup; return a process exit code.
+
+    Four steps, each one skippable: print the doctor's checks, offer to run the
+    fix command for every check that carries one, pick the folder to work in
+    (remembered for next time), and print the commands that start the first
+    session. The single :func:`backend.cli._fix_checks` call is also how tmux
+    gets installed and how the agent CLI gets logged in — both are doctor checks
+    carrying runnable commands — so none of that is hand-rolled here.
+
+    Exit code 0 when setup finished, 1 when a required dependency is still
+    missing, matching ``mindflock doctor``: that makes
+    ``mindflock init && mindflock serve`` stop at the honest place.
+
+    ``assume_yes`` takes every default without asking, for scripts and for our
+    own tests. It deliberately does *not* accept the fix offers: shelling out to
+    package installers nobody is watching is not a default anyone should be able
+    to take by accident, so under ``--yes`` the fix lines are printed and the
+    wizard moves on. A non-TTY stdin degrades to :func:`report` rather than
+    prompting into the void.
+
+    ``serving`` says the calling process is the server (``mindflock serve
+    --setup``, see :mod:`backend.web.run`) and is threaded through to
+    :func:`report` and the closing commands: both of them otherwise end on
+    "``mindflock serve`` — start the server", printed by the process that binds
+    the port the moment this call returns.
+    """
+    from backend import cli
+
+    if not assume_yes and not _stdin_is_tty():
+        # Piped or closed stdin (an installer script, CI, the desktop app's
+        # spawn): every prompt below would come straight back as EOF, so print
+        # the same facts and name the door instead of pretending to ask.
+        report(serving=serving)
+        print()
+        print(
+            "That is the non-interactive summary — run `mindflock init` in a "
+            "terminal to be walked through it."
+        )
+        return 0
+
+    print("MindFlock setup")
+    print()
+    print("What this machine has:")
+    checks = _doctor_checks()
+    if checks:
+        cli.print_checks(checks)
+    else:
+        print(
+            "  (the dependency check could not run — `mindflock doctor` has the details)"
+        )
+
+    if not assume_yes:
+        checks = cli._fix_checks(checks)
+    elif _needs_attention(checks):
+        print()
+        print(
+            "  --yes never runs an installer unwatched — the fix lines above are the list."
+        )
+
+    print()
+    repo = _pick_repo(_candidate_repos(), assume_yes)
+    if repo:
+        _remember_repo(repo)
+        print()
+        print("Working folder: %s" % repo)
+        if not _is_git_worktree(repo):
+            # Inform, never silently degrade: a session here still runs, it just
+            # runs without the git-backed half of MindFlock.
+            print("  Not a git repo, so diff, commit and PR are off. `git init` here —")
+            print('  or tick "Create a git repo in this folder" when you create the')
+            print("  session — turns them on.")
+    else:
+        print()
+        print("No folder picked — name one when you start: mindflock new /path/to/repo")
+
+    failed = [c for c in checks if c.status == "fail"]
+    print()
+    if serving:
+        # This process binds the port as soon as we return, so the only command
+        # left is the one that starts a session.
+        print("You're set. One command:")
+    else:
+        print("You're set. Two commands:")
+        print("  mindflock serve")
+    print('  mindflock new %s -p "%s"' % (repo or "/path/to/repo", _EXAMPLE_PROMPT))
+    print(
+        '  (or open the MindFlock desktop app — it starts the server itself, and "+ New"'
+        " does the same thing)"
+    )
+    if failed:
+        print()
+        print(
+            "%d required dependenc%s still missing — the fix lines above are what's left."
+            % (len(failed), "y" if len(failed) == 1 else "ies")
+        )
+        return 1
+    return 0
+
+
+def _pick_repo(candidates: List[dict], assume_yes: bool = False) -> str:
+    """Ask which folder MindFlock should work in; return an absolute path.
+
+    A number picks from the printed list, anything else is read as a path, and an
+    empty answer keeps the top suggestion — which is the folder the last session
+    used, so the common case is one keystroke. Returns ``""`` only when there was
+    nothing to suggest and nobody answered with a path."""
+    top = candidates[0]["path"] if candidates else ""
+    if candidates:
+        print("Which folder should MindFlock work in?")
+        print()
+        width = max(len(c["path"]) for c in candidates)
+        for n, c in enumerate(candidates, 1):
+            note = _git_note(c)
+            if c.get("source") == "recent":
+                note += ", used most recently"
+            print("  %d  %s  %s" % (n, c["path"].ljust(width), note))
+    else:
+        print("I could not find a folder to suggest.")
+    if assume_yes:
+        return top
+
+    # Leading newline in the prompt, like the doctor's fix loop: it spaces the
+    # question off the list without leaving a stray blank line behind when
+    # there is no question to ask.
+    prompt = (
+        "\n  Enter = 1, or type a number or a path: "
+        if candidates
+        else "\n  Type the path to your repo: "
+    )
+    for _ in range(_MAX_REPO_PROMPTS):
+        try:
+            answer = input(prompt).strip()
+        except (EOFError, KeyboardInterrupt):
+            print()  # leave the shell prompt on a line of its own
+            return top
+        if not answer:
+            return top
+        if answer.isdigit() and candidates:
+            n = int(answer)
+            if 1 <= n <= len(candidates):
+                return candidates[n - 1]["path"]
+            print(
+                "  there is no %d in that list — pick 1-%d, or type a path"
+                % (n, len(candidates))
+            )
+            continue
+        path = os.path.realpath(os.path.expanduser(answer))
+        if os.path.isdir(path):
+            return path
+        print(
+            "  %s is not a folder yet — create it first, or pick from the list" % path
+        )
+    return top

--- a/backend/providers/claude.py
+++ b/backend/providers/claude.py
@@ -159,7 +159,18 @@ class ClaudeProvider(BaseProvider):
 
     def auth_evidence(self) -> str:
         """Probe the known Claude Code credential locations (honoring
-        ``CLAUDE_CONFIG_DIR``) for a stored login / API key. Never raises."""
+        ``CLAUDE_CONFIG_DIR``) for a stored login / API key. Never raises.
+
+        The macOS login Keychain is one of those locations: there Claude Code
+        keeps its OAuth credentials in the Keychain instead of
+        ``~/.claude/.credentials.json`` (see
+        :func:`backend.providers.claude_usage_api._keychain_doc`), so the file
+        scan below finds nothing and a fully logged-in Mac was told "no sign of a
+        login was found" by the doctor on every single run. It is consulted only
+        after the files come up empty, because that lookup shells out to
+        ``security`` and may raise a one-time keychain prompt — nobody should pay
+        for either when a file already answered the question.
+        """
         import os
         from pathlib import Path
 
@@ -177,6 +188,8 @@ class ClaudeProvider(BaseProvider):
             for marker in ("oauthAccount", "primaryApiKey", "claudeAiOauth"):
                 if marker in text:
                     return "login state found in %s" % path
+        if _keychain_login_evidence():
+            return "login state found in the macOS Keychain"
         if os.environ.get("ANTHROPIC_API_KEY"):
             return "ANTHROPIC_API_KEY is set"
         return ""
@@ -344,6 +357,25 @@ class ClaudeProvider(BaseProvider):
 
     def last_turn_snippet(self, session_name: str, workdir: str) -> Optional[str]:
         return _claude_last_turn_snippet(workdir)
+
+
+def _keychain_login_evidence() -> bool:
+    """Whether the macOS login Keychain holds Claude Code's credentials.
+
+    Delegates to the lookup :mod:`claude_usage_api` already needs for the live
+    usage token — it is darwin-only and timeout-bounded, so this costs nothing on
+    Linux/WSL — and is imported lazily so an auth probe never drags the usage/HTTP
+    module in just to answer "is this CLI logged in?". Any failure (no
+    ``security`` binary, a denied keychain prompt, a headless session where no
+    prompt can be answered) counts as no evidence: this is a hint for the doctor,
+    never a gate on anything.
+    """
+    try:
+        from . import claude_usage_api
+
+        return bool(claude_usage_api._keychain_doc())
+    except Exception:  # noqa: BLE001 — no evidence is the whole failure mode here
+        return False
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/web/core/repo_picker.py
+++ b/backend/web/core/repo_picker.py
@@ -1,0 +1,244 @@
+"""Ranked repo suggestions for the folder picker: "which repo did you mean?".
+
+The New Session dialog used to open on the HOME directory and leave a brand-new
+user to Browse down a folder tree to reach their own project — several clicks of
+navigation before the first session can even start. This module answers the
+question that picker is really asking: of all the folders on this machine, which
+few is the user most likely to mean? Repos their recent sessions used (most
+recent first), the repo the server itself was launched from, then a SHALLOW
+sweep of the handful of places people keep code.
+
+Deliberately pure — no FastAPI, no engine, no state imports — so the CLI's init
+wizard (which has no server to ask) can offer the same list, and so the ranking
+is testable without a running app. The caller supplies the "recent" paths in the
+order it wants them ranked, because only the caller knows the history (the
+settings store, the live session registry, the closed-session undo store).
+
+Nothing in here raises. A suggestion list is a convenience: an unreadable
+directory, a repo that has since been deleted, or a home directory full of
+symlinks into a dead network mount must all degrade to a shorter list, never to
+an error toast in front of someone who is merely trying to start a session.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional
+
+from backend.web.core.git_ops import _git_has_commits, _is_git_repo
+
+# Where people actually keep repos. The home directory itself is a root too —
+# plenty of machines have ~/myproject and nothing else.
+_SCAN_SUBDIRS = (
+    "code",
+    "projects",
+    "dev",
+    "src",
+    "repos",
+    "work",
+    "git",
+    "workspace",
+    "Development",
+    "Documents",
+)
+
+# Never the repo the user meant, yet present in bulk on real machines. Dotted
+# names are skipped wholesale (``.venv`` is listed anyway so the intent reads
+# plainly); ``Library`` is the macOS one, which alone holds thousands of dirs.
+_SKIP_NAMES = frozenset({"node_modules", "venv", ".venv", "__pycache__", "Library"})
+
+# Hard work bounds. This list is built while the user waits on a dialog, and a
+# home directory can hold thousands of folders (a well-used Documents, a
+# downloads-turned-junk-drawer): examine at most _MAX_PER_ROOT names under any
+# one root and _MAX_SCANNED across all of them, then stop with what we have. A
+# missed suggestion costs the user one Browse click; a scan that takes ten
+# seconds reads as a broken dialog, which is the failure we are here to remove.
+_MAX_PER_ROOT = 60
+_MAX_SCANNED = 400
+
+
+def _has_git_dir(path: str) -> bool:
+    """Cheap negative filter: does ``path`` carry a ``.git`` entry at all?
+
+    :func:`_is_git_repo` is the authoritative answer but costs a git subprocess,
+    and the nearby sweep looks at hundreds of folders — spawning git for every
+    one of them would make this endpoint slower than the tree-walking it
+    replaces. Every work tree has a ``.git`` (a directory, or the file a
+    worktree/submodule uses), so a folder without one can be dropped for the
+    price of a stat and the real check saved for the few candidates left.
+    """
+    return os.path.exists(os.path.join(path, ".git"))
+
+
+def _entry(path: str, source: str, *, is_git: bool) -> dict:
+    """One suggestion in the shape the picker consumes."""
+    return {
+        "path": path,
+        "name": os.path.basename(path) or path,
+        "is_git": is_git,
+        "source": source,
+    }
+
+
+def _nearby_candidates(home: str) -> list:
+    """Folders under ``home`` that look like repos, depth 1, within the caps.
+
+    Each root contributes itself plus its DIRECT children — no recursion. A deep
+    walk of a home directory is exactly the kind of thing that makes a dialog
+    feel hung, and a repo nested three levels down is a Browse click, not a
+    reason to stat 20,000 paths. Names are examined in sorted order so the caps
+    truncate deterministically rather than at the mercy of directory order.
+    """
+    roots = [home] + [os.path.join(home, name) for name in _SCAN_SUBDIRS]
+    found: list = []
+    examined = 0
+    for root in roots:
+        if not os.path.isdir(root):
+            continue
+        if _has_git_dir(root):
+            found.append(root)
+        try:
+            names = sorted(os.listdir(root), key=str.lower)
+        except OSError:  # noqa: BLE001 — unreadable or vanished mid-scan: skip it
+            continue
+        # Drop the names we would never offer BEFORE the budget is spent, not
+        # after. "." sorts ahead of every letter and digit, so a home directory
+        # with sixty-odd dotted entries — which is every home directory that has
+        # been used — handed the entire _MAX_PER_ROOT allowance to ~/.cache and
+        # friends and the sweep never reached the repos sitting right beside
+        # them. That returned an empty "nearby" tier to exactly the first-run
+        # user this module exists for, whose other two tiers are empty too.
+        names = [n for n in names if not n.startswith(".") and n not in _SKIP_NAMES]
+        for name in names[:_MAX_PER_ROOT]:
+            examined += 1
+            if examined > _MAX_SCANNED:
+                return found
+            full = os.path.join(root, name)
+            if os.path.isdir(full) and _has_git_dir(full):
+                found.append(full)
+    return found
+
+
+def suggest_repos(
+    recent_paths: Iterable[str] = (),
+    cwd: Optional[str] = None,
+    limit: int = 12,
+) -> list:
+    """The ranked candidate folders for the picker, best guess first.
+
+    Three tiers, in this order: ``recent`` (``recent_paths`` verbatim — the
+    caller has already put them in recency order), ``cwd`` (the directory the
+    server was started in, when it is a git repo: very often *the* repo the user
+    wants), then ``nearby`` (the depth-1 sweep, alphabetical by folder name).
+
+    Deduped by ``os.path.realpath`` keeping the highest-priority occurrence, so
+    a repo that is both the launch directory and the last session's folder shows
+    once, as "recent". Paths are reported resolved for the same reason: a
+    symlinked ~/code/foo and its target are one suggestion, not two. A recent
+    path that no longer exists is dropped rather than offered — a suggestion the
+    user cannot pick is worse than a shorter list.
+    """
+    if limit <= 0:
+        return []
+    out: list = []
+    seen: set = set()
+
+    def _add(path: str, source: str, *, is_git: bool) -> None:
+        if path in seen:
+            return
+        seen.add(path)
+        out.append(_entry(path, source, is_git=is_git))
+
+    for raw in recent_paths or ():
+        if len(out) >= limit:
+            return out
+        text = str(raw or "").strip()
+        if not text:
+            continue
+        full = os.path.realpath(os.path.expanduser(text))
+        if full in seen:
+            # Dedup before the git probe, not inside _add. The caller's recency
+            # list repeats one path per live session and one per closed one, so a
+            # user who works in a single checkout hands us that folder forty
+            # times; probing as an argument to _add spawned a rev-parse
+            # subprocess for every copy — forty of them, every time the New
+            # Session dialog opened, to produce one suggestion.
+            continue
+        if not os.path.isdir(full):
+            continue
+        _add(full, "recent", is_git=_is_git_repo(full))
+
+    if cwd and len(out) < limit:
+        full = os.path.realpath(os.path.expanduser(str(cwd)))
+        # A non-repo cwd is noise (someone ran `mindflock serve` from ~), so the
+        # launch directory earns its slot only when it is really a repo.
+        if os.path.isdir(full) and _is_git_repo(full):
+            _add(full, "cwd", is_git=True)
+
+    if len(out) < limit:
+        candidates = _nearby_candidates(os.path.expanduser("~"))
+        candidates.sort(key=lambda p: (os.path.basename(p).lower(), p))
+        for cand in candidates:
+            if len(out) >= limit:
+                break
+            full = os.path.realpath(cand)
+            if full in seen:
+                continue
+            # The authoritative (subprocess) check runs only on candidates that
+            # can still make the list — see _has_git_dir for why that matters.
+            if not _is_git_repo(full):
+                continue
+            _add(full, "nearby", is_git=True)
+    return out
+
+
+def check_repo(path: str) -> dict:
+    """Report what one folder the user typed actually is, without judging it.
+
+    The picker calls this on every keystroke, so a path that does not exist yet
+    is a normal answer (``exists: False``) and not an error: the user is
+    mid-word, or is about to have MindFlock create the folder. ``is_git`` and
+    ``has_commits`` are what lets the dialog say up front whether the session
+    gets the worktree/diff/PR features, or is a fresh ``git init`` with no HEAD
+    to fork a worktree from (see
+    :func:`backend.web.core.plain_repo._prepare_plain_repo`, which draws exactly
+    that distinction when the session is created).
+    """
+    text = str(path or "").strip()
+    if not text:
+        # ``realpath("")`` is the process working directory, so answering a blank
+        # path would report on a folder nobody asked about.
+        return {
+            "path": "",
+            "exists": False,
+            "is_dir": False,
+            "is_git": False,
+            "has_commits": False,
+        }
+    try:
+        # Expanduser and nothing more, because that is exactly what the folder is
+        # later CREATED with: /api/browse and
+        # :func:`backend.web.core.plain_repo._prepare_plain_repo` both stop at
+        # expanduser. Expanding ``$HOME/MindFlock`` here reported "exists, git
+        # repo, has commits" about one directory while Create resolved the same
+        # typed string literally and made a ``$HOME`` folder tree under the
+        # server's cwd — a git-less session in a directory nobody asked for,
+        # announced as a repo.
+        full = os.path.realpath(os.path.expanduser(text))
+    except (OSError, ValueError):  # a path too malformed to resolve is not a crash
+        return {
+            "path": text,
+            "exists": False,
+            "is_dir": False,
+            "is_git": False,
+            "has_commits": False,
+        }
+    is_dir = os.path.isdir(full)
+    is_git = is_dir and _is_git_repo(full)
+    return {
+        "path": full,
+        "exists": os.path.exists(full),
+        "is_dir": is_dir,
+        "is_git": is_git,
+        "has_commits": is_git and _git_has_commits(full),
+    }

--- a/backend/web/run.py
+++ b/backend/web/run.py
@@ -6,6 +6,7 @@
     python backend/web/run.py tailscale    # bind 0.0.0.0 for phone/tailnet access
     python backend/web/run.py 9000         # custom port (still local mode)
     python backend/web/run.py tailscale 9000   # tailnet access, custom port
+    python backend/web/run.py --setup      # guided first-run setup, then serve
 
 Mode and port may be given in either order; env vars also work
 (``CS_WEB_MODE=tailscale``, ``PORT=9000``).
@@ -27,6 +28,7 @@ gets 401.
 
 from __future__ import annotations
 
+import io
 import os
 import sys
 import threading
@@ -146,12 +148,17 @@ def main(argv: Optional[List[str]] = None) -> None:
     # auto-enables the auth gate.
     mode = _norm_mode(os.environ.get("CS_WEB_MODE"))
     port = int(os.environ.get("PORT") or os.environ.get("UVICORN_PORT") or 8765)
+    setup = False
     for arg in (sys.argv[1:] if argv is None else argv):
         a = arg.strip().lower()
         if a in ("local", "localhost"):
             mode = "local"
         elif a in ("tailscale", "ts", "all"):
             mode = "tailscale"
+        elif a in ("--setup", "setup"):
+            # Accepted bare as well as flagged, like the mode words above:
+            # this parser has never insisted on dashes.
+            setup = True
         elif a.isdigit():
             port = int(a)
         # anything else is ignored (keeps the launcher forgiving)
@@ -178,6 +185,23 @@ def main(argv: Optional[List[str]] = None) -> None:
             file=sys.stderr,
         )
         raise SystemExit(1)
+    if setup:
+        # Guided setup before the bind: what it fixes (tmux, the agent CLI and
+        # its login) is exactly what a session can't start without, and after
+        # uvicorn.run() below there is no coming back here. It runs *after* the
+        # double-launch guard above so nobody is walked through setup for a
+        # server that then refuses the port. Its exit code is deliberately
+        # ignored — the user asked to serve, and declining an install is not a
+        # reason to refuse them a server.
+        try:
+            from backend import init_wizard
+
+            # serving=True: this process is the server the wizard would otherwise
+            # sign off by telling the user to start.
+            init_wizard.run(serving=True)
+        except Exception:  # noqa: BLE001 — setup is a courtesy, serving is the job
+            pass
+        print()
     # Export the resolved mode + port (CLI args win over the env) so the
     # server's startup banner knows local mode — skipping the tailnet URLs +
     # QR that a 127.0.0.1 bind can never serve (F7) — and prints the right
@@ -218,26 +242,44 @@ def main(argv: Optional[List[str]] = None) -> None:
             "note: managing the MindFlock repo itself — cd into your project "
             "first if this isn't what you want."
         )
-    if not _is_onboarded():
-        # First run (no session ever created): print the 3-step getting
-        # started instead of leaving a stranger staring at a bare address.
-        # The desktop app shows the same checklist as a setup card.
-        print()
-        print("First run? Three steps:")
-        print("  1. open the MindFlock desktop app — it connects to this")
-        print("     server automatically (to get it: electron/README.md)")
-        print('  2. click "+ New" — that creates a session: an isolated git')
-        print("     worktree + a tmux session running your coding agent")
-        print("  3. click the session tile and type to talk to the agent")
-        print("  (if anything is missing, `mindflock doctor` prints the fix)")
     print("Press Ctrl-C to stop.")
 
-    # Fast preflight (background thread so binding isn't delayed): the checks
-    # a session can't start without. A failure prints what's wrong, why the
-    # tool needs it, and the one command that fixes it — instead of a cryptic
-    # FileNotFoundError at first session-create.
-    def _fast_preflight() -> None:
+    # First run = no session has ever been created. Such a boot earns the
+    # wizard's *report* (what this machine is actually missing with the one-line
+    # fix for each, the folders it can see, the commands that come next) instead
+    # of leaving a stranger staring at a bare address. Deliberately the report
+    # and not the wizard: the desktop app auto-starts this server, and a serve
+    # that waited on stdin before binding its port would look like a hung app.
+    # `mindflock init` — named in the report — is the interactive door, and
+    # `mindflock serve --setup` opens it above, which is why that case is
+    # excluded here.
+    first_run = not _is_onboarded() and not setup
+
+    # Everything below runs on a background thread so binding isn't delayed: the
+    # report walks the full doctor (ten checks, each capped at a 5s subprocess)
+    # and scans for repo suggestions (a git probe per candidate, capped at 30s),
+    # and even the short check list shells out three times. On a cold box or a
+    # stalled network mount that is tens of seconds in which the desktop app is
+    # polling a port nobody has opened yet and retrying onto offline.html.
+    def _preflight() -> None:
         try:
+            if first_run:
+                from backend import init_wizard
+
+                # Rendered into a buffer and written once: the "Press Ctrl-C"
+                # line above is racing this thread, and a report printed line by
+                # line would let that line land in the middle of the block. The
+                # report's own doctor pass already covers git, tmux and the agent
+                # CLI with their fix lines, so it stands in for the short list
+                # below rather than running those probes a second time.
+                buf = io.StringIO()
+                init_wizard.report(buf, serving=True)
+                sys.stdout.write("\n" + buf.getvalue())
+                return
+            # Every other boot gets just the checks a session can't start
+            # without. A failure prints what's wrong, why the tool needs it, and
+            # the one command that fixes it — instead of a cryptic
+            # FileNotFoundError at first session-create.
             from backend import doctor
 
             for fn in (doctor.check_git, doctor.check_tmux, doctor.check_agent_cli):
@@ -247,9 +289,14 @@ def main(argv: Optional[List[str]] = None) -> None:
                     if c.fix:
                         print(f"  fix: {c.fix}", file=sys.stderr)
         except Exception:  # noqa: BLE001 — preflight must never break serving
+            # Silence, not a substitute message: init_wizard.report is the one
+            # layer that owns degrading the first-run text, and a second copy of
+            # its wording here would only rot out of sync with it. This catch is
+            # what keeps an unwritable stdout or a failed import from throwing a
+            # thread traceback across the banner.
             pass
 
-    threading.Thread(target=_fast_preflight, daemon=True).start()
+    threading.Thread(target=_preflight, daemon=True).start()
 
     # This process is now the server, and nothing else is: the only place that
     # can honestly say so is right here, one line before uvicorn takes over.

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -40,6 +40,7 @@ short-TTL probe memo they share. Helper logic lives in focused modules under
     prompt_queue     the per-session prompt queue store
     recently_closed  the undo store behind reopen / Ctrl+Z
     remote           tailnet multi-device discovery + proxying
+    repo_picker      ranked repo suggestions for the New Session folder field
     session_stats    token/cost telemetry + transcript history rendering
     snapshot         per-session JSON descriptors (labels, diff stat)
     system_logs      log-tail sources for Settings → System logs
@@ -191,6 +192,10 @@ from backend.web.core.recently_closed import (
     _record_closed,
     _recently_closed_path,
     _save_recently_closed,
+)
+from backend.web.core.repo_picker import (
+    check_repo,
+    suggest_repos,
 )
 from backend.web.core.workspaces import (
     _base_clone_references,
@@ -2233,6 +2238,93 @@ def browse(path: str = "") -> JSONResponse:
     )
 
 
+@app.get("/api/repos/suggest")
+async def repo_suggestions() -> JSONResponse:
+    """Folders the New Session dialog can offer instead of a bare folder tree.
+
+    The dialog used to open on HOME and leave a first-time user to Browse down
+    to their own project, so this answers "which repo did you mean?" up front:
+    the repos recent sessions ran in, the repo the server was launched from, then
+    a shallow sweep of the usual code directories (see
+    :mod:`backend.web.core.repo_picker`). ``home`` rides along because the picker
+    renders paths relative to it and falls back to it when nothing is suggested.
+    """
+
+    def _touched_at(inst) -> float:
+        """Sort key for live sessions: last-touched epoch, 0 when unknown."""
+        try:
+            return inst.UpdatedAt.timestamp()
+        except Exception:  # noqa: BLE001 — an unset/odd timestamp just sorts last
+            return 0.0
+
+    def _gather() -> list:
+        # Most-recent first: the folder the last session (or wizard run) used,
+        # then live sessions newest-touched first, then the closed-session undo
+        # store — which is already newest-first. Every tier is best-effort, so a
+        # broken one costs its own suggestions and not the whole list.
+        recent: list = []
+        try:
+            from backend.config import settings as _settings
+
+            recent.append(_settings.load_settings().general.last_repo_path)
+        except Exception:  # noqa: BLE001 — no settings store yet is not an error
+            pass
+        try:
+            for inst in sorted(
+                list(ENGINE.instances.values()), key=_touched_at, reverse=True
+            ):
+                recent.append(getattr(inst, "Path", "") or "")
+        except Exception:  # noqa: BLE001 — a registry mutating mid-read just skips it
+            pass
+        try:
+            for closed in _load_recently_closed():
+                if not isinstance(closed, dict):
+                    continue
+                # The session's repo lives in the serialized instance data; the
+                # top-level "folder" is its worktree, which is only the same
+                # directory for an in-place session — hence the fallback order.
+                data = closed.get("data")
+                path = (data or {}).get("path") if isinstance(data, dict) else ""
+                recent.append(str(path or closed.get("folder") or ""))
+        except Exception:  # noqa: BLE001 — an unreadable history simply adds nothing
+            pass
+        # Blocking work (a readdir per scan root plus a git probe per surviving
+        # candidate) — threaded like paste_image's _store so a cold disk or a
+        # stalled network mount can't hold up every other request.
+        return suggest_repos(recent_paths=recent, cwd=os.getcwd())
+
+    return JSONResponse(
+        {
+            "suggestions": await asyncio.to_thread(_gather),
+            "home": os.path.expanduser("~"),
+        }
+    )
+
+
+@app.get("/api/repos/check")
+async def repo_check(path: str = "") -> JSONResponse:
+    """Report what the folder the user typed into the picker actually is.
+
+    Called on every keystroke, so a folder that does not exist yet answers 200
+    with ``exists: false`` — a 4xx per character would light the dialog up red
+    while someone is still typing ``/home/me/co``, and the folder may well be one
+    MindFlock is about to create. A blank path is the one real error: there is
+    nothing to answer about. Threaded for the same reason as
+    :func:`repo_suggestions` — the git probes are subprocesses.
+    """
+    if not (path or "").strip():
+        return JSONResponse({"error": "a path is required"}, status_code=400)
+    return JSONResponse(await asyncio.to_thread(check_repo, path))
+
+
+# There is deliberately no endpoint for the frontend to set general.onboarded.
+# The flag means "has created a session" — create_instance sets it via
+# _mark_onboarded, and backend/init_wizard.py pointedly does not — so letting a
+# UI surface flip it from outside that one event destroyed both first-run helpers
+# (the grid's setup card and the auto-opening dependency checklist) for a user
+# who had created nothing yet and still had, say, no tmux to create it with.
+
+
 # MindFlock automation control (/api/mindflock/*) moved to the MindFlock addon.
 
 
@@ -2434,6 +2526,18 @@ async def create_instance(payload: dict) -> JSONResponse:
     with ENGINE.lock:
         ENGINE.instances[title] = inst
     _mark_onboarded()  # first-ever session ends first-run; setup card won't auto-show again
+    # Remember the folder this session chose so the NEXT New Session dialog opens
+    # on it and the repo suggestions rank it first — the second session in a repo
+    # should not be another walk down the folder tree. "." is the server's own
+    # cwd (a provisioned session with no chosen repo), which the user never
+    # picked, so it isn't worth remembering.
+    if plain_path and plain_path != ".":
+        try:
+            from backend.config import settings as _settings
+
+            _settings.update_settings(general={"last_repo_path": plain_path})
+        except Exception:  # noqa: BLE001 — a convenience hint never fails a create
+            pass
 
     async def _bg_start() -> None:
         try:

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22557,6 +22557,11 @@ const useUi = create((set, get) => ({
     set({ prBaseByRepo: next });
   }
 }));
+function tourDecision(opts) {
+  if (opts.tourDone || !opts.hintsEnabled) return "skip";
+  if (opts.onboarded === void 0) return "wait";
+  return opts.onboarded ? "skip" : "open";
+}
 function errMsg(err) {
   return (err == null ? void 0 : err.message) || "error";
 }
@@ -26008,19 +26013,6 @@ function FooterCustomize() {
     ] })
   ] });
 }
-function dismissSetup() {
-  try {
-    localStorage.setItem("mf_setup_done", "1");
-  } catch {
-  }
-}
-function everCreated() {
-  try {
-    return localStorage.getItem("mf_ever_created") === "1";
-  } catch {
-    return false;
-  }
-}
 const DOCTOR_ICON = { ok: "✓", info: "ℹ", warn: "!", fail: "✗" };
 let lastDoctor = null;
 const useDoctorWarnStore = create((set) => ({
@@ -26034,7 +26026,12 @@ function useDoctorWarn() {
   return useDoctorWarnStore();
 }
 let setupAutoShown = false;
+function shouldAutoShowSetup(opts) {
+  return opts.failing && opts.onboarded === false;
+}
 function useDoctorAutoShow() {
+  const { data: config } = useConfig();
+  const failing = useDoctorWarnStore((s) => s.failing);
   reactExports.useEffect(() => {
     const check = async () => {
       try {
@@ -26043,10 +26040,6 @@ function useDoctorAutoShow() {
         useDoctorWarnStore.getState()._setFailing(!(d && d.ok));
       } catch {
       }
-      if (useDoctorWarnStore.getState().failing && !setupAutoShown) {
-        setupAutoShown = true;
-        useUi.getState().openDialogFor("setup");
-      }
     };
     check();
     const t = setInterval(() => {
@@ -26054,8 +26047,15 @@ function useDoctorAutoShow() {
     }, 3e5);
     return () => clearInterval(t);
   }, []);
+  reactExports.useEffect(() => {
+    if (setupAutoShown) return;
+    const show = shouldAutoShowSetup({ failing, onboarded: config == null ? void 0 : config.onboarded });
+    if (!show) return;
+    setupAutoShown = true;
+    useUi.getState().openDialogFor("setup");
+  }, [failing, config == null ? void 0 : config.onboarded]);
 }
-function DoctorList({ reprobeKey, autoCollapse }) {
+function DoctorList({ reprobeKey }) {
   const [doctor, setDoctor] = reactExports.useState(lastDoctor);
   const [error, setError] = reactExports.useState("");
   reactExports.useEffect(() => {
@@ -26068,7 +26068,6 @@ function DoctorList({ reprobeKey, autoCollapse }) {
         lastDoctor = d;
         setDoctor(d);
         setError("");
-        if (autoCollapse && d.ok && everCreated()) dismissSetup();
       } catch (e) {
         if (live) setError(e.message);
       }
@@ -26076,7 +26075,7 @@ function DoctorList({ reprobeKey, autoCollapse }) {
     return () => {
       live = false;
     };
-  }, [reprobeKey, autoCollapse]);
+  }, [reprobeKey]);
   if (error) return /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "error", children: [
     "doctor failed: ",
     error
@@ -26118,7 +26117,7 @@ async function runGithubTest() {
     return { testing: false, ok: false, msg: e.message };
   }
 }
-function SetupChecklist({ standalone }) {
+function SetupChecklist(_props) {
   const [reprobeKey, setReprobeKey] = reactExports.useState(0);
   const [gh, setGh] = reactExports.useState(idleTest);
   const [sc, setSc] = reactExports.useState(idleTest);
@@ -26185,7 +26184,7 @@ function SetupChecklist({ standalone }) {
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "setup-num", children: "①" }),
         " Dependencies"
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "setup-doctor", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DoctorList, { reprobeKey, autoCollapse: !!standalone }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "setup-doctor", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DoctorList, { reprobeKey }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "setup-actions", children: /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className: "setup-recheck", onClick: (e) => {
         e.stopPropagation();
         setReprobeKey((k) => k + 1);
@@ -28591,13 +28590,67 @@ function FlagChips({
     );
   }) });
 }
+const SUGGEST_SOURCES = [
+  { key: "recent", label: "Recent", hint: "folders your recent sessions ran in" },
+  { key: "cwd", label: "Here", hint: "the folder MindFlock itself was started in" },
+  { key: "nearby", label: "Nearby", hint: "repos and folders sitting under your home directory" }
+];
+const CHECK_DEBOUNCE_MS = 400;
+function leafName(path) {
+  return path.replace(/[/\\]+$/, "").split(/[/\\]/).pop() || path;
+}
+const FOLDER_INIT = {
+  path: "",
+  browsing: false,
+  undo: null,
+  touched: false
+};
+function prefillUndo(s, path) {
+  if (!s.browsing) return s.undo;
+  if (s.undo && s.undo.path) return s.undo;
+  return { path, touched: false };
+}
+function folderReducer(s, a) {
+  switch (a.t) {
+    case "reopen":
+      return { ...s, browsing: false, undo: null, touched: false };
+    case "suggested":
+      if (!a.path || s.touched && s.path) return s;
+      return { ...s, path: a.path, undo: prefillUndo(s, a.path) };
+    case "fallback":
+      if (!a.path || s.path) return s;
+      return { ...s, path: a.path, undo: prefillUndo(s, a.path) };
+    case "user-set":
+      return {
+        ...s,
+        path: a.path,
+        touched: true,
+        undo: s.browsing ? { path: a.path, touched: true } : null
+      };
+    case "browse-open":
+      return { ...s, browsing: true, undo: { path: s.path, touched: s.touched } };
+    case "browse-select":
+      return { ...s, path: a.path, touched: true };
+    case "browse-commit":
+      return { path: a.path, browsing: false, undo: null, touched: true };
+    case "browse-cancel":
+      return {
+        path: s.undo ? s.undo.path : s.path,
+        browsing: false,
+        undo: null,
+        touched: s.undo ? s.undo.touched : s.touched
+      };
+  }
+}
+function mayTakeOpeningFocus(where) {
+  return where.activeIsTarget || !where.activeInsideDialog;
+}
 function NewSessionDialog() {
   const open = useUi((s) => s.openDialog === "new-session");
   const closeDialog = useUi((s) => s.closeDialog);
   const [title, setTitle] = reactExports.useState("");
   const [program, setProgram] = reactExports.useState("");
   const [providers, setProviders] = reactExports.useState([]);
-  const [repoPath, setRepoPath] = reactExports.useState("");
   const [prompt, setPrompt] = reactExports.useState("");
   const [launchArgs, setLaunchArgs] = reactExports.useState("");
   const [provision, setProvision] = reactExports.useState(false);
@@ -28606,16 +28659,21 @@ function NewSessionDialog() {
   const [initRepo, setInitRepo] = reactExports.useState(false);
   const [error, setError] = reactExports.useState("");
   const [advancedOpen, setAdvancedOpen] = reactExports.useState(false);
-  const [browserOpen, setBrowserOpen] = reactExports.useState(false);
   const [templates, setTemplates] = reactExports.useState([]);
   const [activeTemplate, setActiveTemplate] = reactExports.useState("");
   const [provisioningAvailable, setProvisioningAvailable] = reactExports.useState(false);
   const [homePath, setHomePath] = reactExports.useState("");
+  const [suggestions, setSuggestions] = reactExports.useState([]);
+  const [folderCheck, setFolderCheck] = reactExports.useState(null);
   const [presetValue, setPresetValue] = reactExports.useState("");
   const [savedPresets, setSavedPresets] = reactExports.useState([]);
   const launchDefaults = reactExports.useRef({});
   const titleRef = reactExports.useRef(null);
   const launchRef = reactExports.useRef(null);
+  const rootRef = reactExports.useRef(null);
+  const [folder, folderDo] = reactExports.useReducer(folderReducer, FOLDER_INIT);
+  const repoPath = folder.path;
+  const browserOpen = folder.browsing;
   reactExports.useEffect(() => {
     if (!open) return;
     setTitle("");
@@ -28626,10 +28684,23 @@ function NewSessionDialog() {
     setInPlace(true);
     setInitRepo(false);
     setAdvancedOpen(false);
-    setBrowserOpen(false);
+    folderDo({ t: "reopen" });
     setActiveTemplate("");
     setPresetValue("");
     setSavedPresets(loadUserPresets());
+    let live = true;
+    (async () => {
+      var _a2;
+      try {
+        const d = await api("/api/repos/suggest");
+        if (!live) return;
+        const sug = d.suggestions || [];
+        setSuggestions(sug);
+        folderDo({ t: "suggested", path: ((_a2 = sug[0]) == null ? void 0 : _a2.path) || "" });
+      } catch {
+        if (live) setSuggestions([]);
+      }
+    })();
     (async () => {
       var _a2, _b2, _c2, _d2;
       const [cfgR, setR, tplR] = await Promise.allSettled([
@@ -28639,9 +28710,10 @@ function NewSessionDialog() {
         ),
         api("/api/templates")
       ]);
+      if (!live) return;
       const cfg = cfgR.status === "fulfilled" ? cfgR.value : void 0;
       setHomePath((cfg == null ? void 0 : cfg.home) || "");
-      setRepoPath((cfg == null ? void 0 : cfg.home) || "");
+      folderDo({ t: "fallback", path: (cfg == null ? void 0 : cfg.home) || "" });
       setProvisioningAvailable(!!(cfg == null ? void 0 : cfg.provisioning_available));
       let provs = [];
       try {
@@ -28649,6 +28721,7 @@ function NewSessionDialog() {
         provs = d.providers || [];
       } catch {
       }
+      if (!live) return;
       setProviders(provs);
       const prev = (cfg == null ? void 0 : cfg.default_program) || "";
       const lower = prev.toLowerCase();
@@ -28663,12 +28736,44 @@ function NewSessionDialog() {
         launchDefaults.current[k.toLowerCase()] = String(raw[k] || "");
       setLaunchArgs((launchDefaults.current[agent.trim().toLowerCase()] || "").trim());
       setTemplates(tplR.status === "fulfilled" ? ((_d2 = tplR.value) == null ? void 0 : _d2.templates) || [] : []);
-      setTimeout(() => {
-        var _a3;
-        return (_a3 = titleRef.current) == null ? void 0 : _a3.focus();
-      }, 0);
     })();
+    return () => {
+      live = false;
+    };
   }, [open]);
+  reactExports.useEffect(() => {
+    var _a2;
+    if (!open) return;
+    const el = titleRef.current;
+    const active = document.activeElement;
+    if (el && mayTakeOpeningFocus({
+      activeIsTarget: active === el,
+      activeInsideDialog: !!active && !!((_a2 = rootRef.current) == null ? void 0 : _a2.contains(active))
+    }))
+      el.focus();
+  }, [open]);
+  reactExports.useEffect(() => {
+    const asked = repoPath.trim();
+    if (!open || !asked) {
+      setFolderCheck(null);
+      return;
+    }
+    let live = true;
+    const timer = window.setTimeout(async () => {
+      try {
+        const r = await api(
+          "/api/repos/check?path=" + encodeURIComponent(asked)
+        );
+        if (live) setFolderCheck({ asked, plain: !!r.exists && !!r.is_dir && !r.is_git });
+      } catch {
+        if (live) setFolderCheck(null);
+      }
+    }, CHECK_DEBOUNCE_MS);
+    return () => {
+      live = false;
+      window.clearTimeout(timer);
+    };
+  }, [open, repoPath]);
   const setAgent = reactExports.useCallback((value) => {
     const v = (value || "").trim();
     setProgram(v);
@@ -28677,7 +28782,7 @@ function NewSessionDialog() {
   const fillFromTemplate = (t) => {
     var _a2;
     if (t.program) setAgent(t.program);
-    if (t.repo_path) setRepoPath(t.repo_path);
+    if (t.repo_path) folderDo({ t: "user-set", path: t.repo_path });
     if (t.prompt) setPrompt(t.prompt);
     setProvision(!!t.provisioned);
     if (t.workspace_strategy) setStrategy(t.workspace_strategy);
@@ -28688,8 +28793,19 @@ function NewSessionDialog() {
     if (!title.trim()) setTitle(t.name || "");
     (_a2 = titleRef.current) == null ? void 0 : _a2.focus();
   };
+  const armInitRepo = () => {
+    setInitRepo(true);
+    setInPlace(false);
+    setAdvancedOpen(true);
+  };
   if (!open) return null;
-  const offerProvision = provisioningAvailable || !!repoPath.trim();
+  const folderPath = repoPath.trim();
+  const offerProvision = provisioningAvailable || !!folderPath;
+  const plainFolder = (folderCheck == null ? void 0 : folderCheck.asked) === folderPath && !!(folderCheck == null ? void 0 : folderCheck.plain);
+  const suggestRows = SUGGEST_SOURCES.map((g) => ({
+    ...g,
+    items: suggestions.filter((s) => s.source === g.key)
+  })).filter((g) => g.items.length > 0);
   const submit = async () => {
     setError("Creating…");
     const body = {
@@ -28741,13 +28857,14 @@ function NewSessionDialog() {
     {
       id: "new-dialog",
       className: "modal",
+      ref: rootRef,
       onClick: (e) => {
         if (e.target === e.currentTarget) closeDialog();
       },
       onKeyDown: (e) => {
         if (e.key === "Escape") {
           e.preventDefault();
-          if (browserOpen) setBrowserOpen(false);
+          if (browserOpen) folderDo({ t: "browse-cancel" });
           else closeDialog();
         } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
           e.preventDefault();
@@ -28836,7 +28953,7 @@ function NewSessionDialog() {
                             autoComplete: "off",
                             placeholder: "/home/me/projects/foo",
                             value: repoPath,
-                            onChange: (e) => setRepoPath(e.target.value)
+                            onChange: (e) => folderDo({ t: "user-set", path: e.target.value })
                           }
                         ),
                         /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -28844,8 +28961,15 @@ function NewSessionDialog() {
                           {
                             type: "button",
                             id: "repo-browse-btn",
-                            title: "Browse local folders",
-                            onClick: () => setBrowserOpen((v) => !v),
+                            title: browserOpen ? "Close the browser and keep this folder (Esc puts the old one back)" : "Browse local folders",
+                            onClick: () => (
+                              // Toggling the panel shut keeps whatever the field now holds:
+                              // it is on screen, the user has been looking at it, and only
+                              // Escape claims to undo anything.
+                              folderDo(
+                                browserOpen ? { t: "browse-commit", path: repoPath } : { t: "browse-open" }
+                              )
+                            ),
                             children: "Browse…"
                           }
                         )
@@ -28887,14 +29011,55 @@ function NewSessionDialog() {
                 ] })
               ] }),
               /* @__PURE__ */ jsxRuntimeExports.jsx("datalist", { id: "provider-list" }),
+              plainFolder && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "nf-git-nudge", children: initRepo ? /* @__PURE__ */ jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, { children: "A git repo will be created here — diff, commit and PR will work." }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+                "No git repo in this folder, so diff, commit and PR stay off.",
+                " ",
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "button",
+                  {
+                    type: "button",
+                    className: "linklike",
+                    title: "Ticks “Create a git repo in this folder” under More options",
+                    onClick: armInitRepo,
+                    children: "Create one"
+                  }
+                )
+              ] }) }),
+              suggestRows.length > 0 && /* Wears .new-templates as well as its own class on purpose: this is
+              the same chip strip as Templates, filled from a different source,
+              and sharing the class is what stops the two from drifting apart. */
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "new-suggest", className: "new-templates nf-suggest", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "nt-head", children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Folders" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "nf-suggest-legend", children: "📦 git repo · 📁 plain folder" })
+                ] }),
+                suggestRows.map((g) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "nf-suggest-row", children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "nf-suggest-label", title: g.hint, children: g.label }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "nt-list", children: g.items.map((s) => {
+                    const active = folderPath === s.path;
+                    return /* @__PURE__ */ jsxRuntimeExports.jsx(
+                      "button",
+                      {
+                        type: "button",
+                        className: "nt-chip" + (s.is_git ? " is-git" : "") + (active ? " active" : ""),
+                        "data-path": s.path,
+                        "aria-pressed": active,
+                        title: s.path + (s.is_git ? "" : "\nno git repo here yet"),
+                        onClick: () => folderDo({ t: "user-set", path: s.path }),
+                        children: (s.is_git ? "📦 " : "📁 ") + s.name
+                      },
+                      s.path
+                    );
+                  }) })
+                ] }, g.key))
+              ] }),
               browserOpen && /* @__PURE__ */ jsxRuntimeExports.jsx(
                 FolderBrowser,
                 {
-                  initialPath: repoPath.trim() || homePath || "",
-                  onPick: (p) => {
-                    setRepoPath(p);
-                    setBrowserOpen(false);
-                  }
+                  initialPath: folderPath || homePath || "",
+                  selected: folderPath,
+                  onSelect: (p) => folderDo({ t: "browse-select", path: p }),
+                  onPick: (p) => folderDo({ t: "browse-commit", path: p })
                 }
               ),
               /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { children: [
@@ -29098,24 +29263,48 @@ function NewSessionDialog() {
     }
   );
 }
+function focusRowIndex(paths, leaving) {
+  if (!paths.length) return -1;
+  const i = paths.indexOf(leaving);
+  return i >= 0 ? i : 0;
+}
 function FolderBrowser({
   initialPath,
+  selected,
+  onSelect,
   onPick
 }) {
   const [data, setData] = reactExports.useState(null);
   const [error, setError] = reactExports.useState("");
+  const listRef = reactExports.useRef(null);
+  const leaving = reactExports.useRef(null);
   const load2 = reactExports.useCallback(async (path) => {
     setError("");
     try {
       const q = path ? "?path=" + encodeURIComponent(path) : "";
       setData(await api("/api/browse" + q));
     } catch (err) {
+      leaving.current = null;
       setError(err.message);
     }
   }, []);
   reactExports.useEffect(() => {
     load2(initialPath);
   }, []);
+  reactExports.useEffect(() => {
+    var _a2, _b2;
+    const from = leaving.current;
+    if (from === null || !data) return;
+    leaving.current = null;
+    const idx = focusRowIndex((data.entries || []).map((e) => e.path), from);
+    const rows = (_a2 = listRef.current) == null ? void 0 : _a2.querySelectorAll(".rb-item:not(.rb-use)");
+    const row = idx >= 0 ? rows == null ? void 0 : rows[idx] : (_b2 = listRef.current) == null ? void 0 : _b2.querySelector(".rb-use");
+    row == null ? void 0 : row.focus();
+  }, [data]);
+  const keyLoad = (to) => {
+    leaving.current = (data == null ? void 0 : data.path) || "";
+    load2(to);
+  };
   const mkdir = async () => {
     if (!(data == null ? void 0 : data.path)) return;
     const name = window.prompt("New folder name (created in " + data.path + "):", "");
@@ -29126,7 +29315,6 @@ function FolderBrowser({
         json: { path: data.path, name: name.trim() }
       });
       onPick(r.path);
-      load2(r.path);
     } catch (err) {
       setError(err.message);
     }
@@ -29147,31 +29335,56 @@ function FolderBrowser({
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "rb-cwd", className: "rb-cwd", title: (data == null ? void 0 : data.path) || "", children: (data == null ? void 0 : data.path) || "" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "rb-mkdir", title: "Create a new folder here", onClick: mkdir, children: "+ Folder" })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "rb-list", children: [
-      data && /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "div",
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "rb-list", ref: listRef, children: [
+      data && /* Names the folder it means. Child rows are selectable now, so "use
+      this folder" on its own would be ambiguous about which folder — the
+      one you're standing in, or the one you just highlighted. */
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
         {
-          className: "rb-item rb-use" + (data.is_git ? " is-git" : ""),
+          type: "button",
+          className: "rb-item rb-use" + (data.is_git ? " is-git" : "") + (selected === data.path ? " rb-sel" : ""),
+          title: "Use " + data.path + " and close the browser",
           onClick: () => onPick(data.path),
-          children: data.is_git ? "✓ use this repo" : "use this folder"
+          children: (data.is_git ? "✓ use this repo — " : "use this folder — ") + leafName(data.path)
         }
       ),
-      ((data == null ? void 0 : data.entries) || []).map((e) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rb-item" + (e.is_git ? " is-git" : ""), children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rb-name", onClick: () => load2(e.path), children: (e.is_git ? "📦 " : "📁 ") + e.name }),
+      ((data == null ? void 0 : data.entries) || []).map((e) => (
+        // Rows are real buttons: they're the primary control now, so keyboard
+        // reach, Enter/Space activation and a focus ring should come from the
+        // platform rather than a div wearing tabIndex and a key handler.
+        // Selecting is idempotent, which is what makes the double click safe —
+        // its first click writes the same path the second one would, so there
+        // is no second visible effect to notice.
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "button",
           {
             type: "button",
-            className: "rb-pick",
-            onClick: (ev) => {
-              ev.stopPropagation();
-              onPick(e.path);
+            className: "rb-item" + (e.is_git ? " is-git" : "") + (selected === e.path ? " rb-sel" : ""),
+            "aria-pressed": selected === e.path,
+            title: e.path,
+            onClick: () => onSelect(e.path),
+            onDoubleClick: () => {
+              onSelect(e.path);
+              load2(e.path);
             },
-            children: "select"
-          }
+            onKeyDown: (ev) => {
+              if (ev.key === "ArrowRight") {
+                ev.preventDefault();
+                onSelect(e.path);
+                keyLoad(e.path);
+              } else if (ev.key === "ArrowLeft" && (data == null ? void 0 : data.parent)) {
+                ev.preventDefault();
+                keyLoad(data.parent);
+              }
+            },
+            children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rb-name", children: (e.is_git ? "📦 " : "📁 ") + e.name })
+          },
+          e.path
         )
-      ] }, e.path))
+      ))
     ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "rb-hint", children: "Click selects · double-click or → opens · ← up · Esc cancels" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { id: "rb-error", className: "error", children: error })
   ] });
 }
@@ -34086,6 +34299,11 @@ function TodoDialog() {
   const [editingId, setEditingId] = reactExports.useState(null);
   const [editDraft, setEditDraft] = reactExports.useState("");
   const editCancelled = reactExports.useRef(false);
+  const editingRef = reactExports.useRef(null);
+  const setEditing = reactExports.useCallback((id) => {
+    editingRef.current = id;
+    setEditingId(id);
+  }, []);
   const save2 = reactExports.useCallback(async (next) => {
     setTodos(next);
     setState("saving…");
@@ -34101,7 +34319,7 @@ function TodoDialog() {
     }
   }, []);
   const load2 = reactExports.useCallback(async () => {
-    if (dragging.current || document.activeElement === addRef.current || editingId) return;
+    if (dragging.current || document.activeElement === addRef.current || editingRef.current) return;
     try {
       const r = await api("/api/assistant/todos");
       setTodos(r.todos || []);
@@ -34109,17 +34327,21 @@ function TodoDialog() {
     } catch {
       setState("load failed");
     }
-  }, [editingId]);
+  }, []);
+  reactExports.useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => {
+      var _a2;
+      return (_a2 = addRef.current) == null ? void 0 : _a2.focus();
+    }, 0);
+    return () => clearTimeout(t);
+  }, [open]);
   reactExports.useEffect(() => {
     if (!open) return;
     load2();
     const poll = setInterval(() => {
       if (!document.hidden) load2();
     }, 4e3);
-    setTimeout(() => {
-      var _a2;
-      return (_a2 = addRef.current) == null ? void 0 : _a2.focus();
-    }, 0);
     const onKey = (e) => {
       if (e.key === "Escape") closeDialog();
     };
@@ -34137,13 +34359,13 @@ function TodoDialog() {
     save2([...todos, { id: rid(), text, done: false }]);
   };
   const startEdit = (t) => {
-    setEditingId(t.id);
+    setEditing(t.id);
     setEditDraft(t.text);
     editCancelled.current = false;
   };
   const commitEdit = (id) => {
     if (editCancelled.current) return;
-    setEditingId(null);
+    setEditing(null);
     const text = editDraft.trim();
     const cur = todos.find((x) => x.id === id);
     if (!cur || !text || text === cur.text) return;
@@ -34151,7 +34373,7 @@ function TodoDialog() {
   };
   const cancelEdit = () => {
     editCancelled.current = true;
-    setEditingId(null);
+    setEditing(null);
   };
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
     "div",
@@ -34669,9 +34891,18 @@ function App() {
   const { data: instances2 } = useInstances();
   const ui = useUi();
   useDoctorAutoShow();
+  const tourDecided = reactExports.useRef(false);
   reactExports.useEffect(() => {
-    if (!ui.tourDone && ui.hintsEnabled) ui.openTour();
-  }, []);
+    if (tourDecided.current) return;
+    const decision = tourDecision({
+      tourDone: ui.tourDone,
+      hintsEnabled: ui.hintsEnabled,
+      onboarded: config == null ? void 0 : config.onboarded
+    });
+    if (decision === "wait") return;
+    tourDecided.current = true;
+    if (decision === "open") ui.openTour();
+  }, [config == null ? void 0 : config.onboarded, ui.tourDone, ui.hintsEnabled, ui.openTour]);
   reactExports.useEffect(() => {
     const caps2 = config == null ? void 0 : config.caps;
     document.body.classList.toggle("no-git", caps2 ? !caps2.git : false);

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -1075,6 +1075,16 @@ body.sidebar-collapsed .sidebar-resizer {
   display: none;
 }
 
+/* Nothing to resize while a dialog owns the screen, either. The .modal backdrop
+   is fixed with NO z-index (see Pane.css), so this handle's z-index: 40 paints
+   its accent line straight over the dimmed page and still answers :hover — and
+   the drag still works through the backdrop. Keyed off the overlay element
+   rather than a body class so every dialog is covered, including ones that
+   never touch the store's openDialog (command palette, welcome tour). */
+body:has(.modal:not(.hidden)) .sidebar-resizer {
+  display: none;
+}
+
 /* Tools row: session count on the left, a subtle keyboard-shortcuts link on
    the right (status-bar-style help affordance). */
 #sidebar-footer .foot-row.foot-tools {
@@ -5857,6 +5867,76 @@ p.set-hint {
   border-color: var(--accent);
 }
 
+/* The folder-suggestion strip. It also carries .new-templates (see the JSX), so
+   the card, the head and the .nt-chip pills come from the Templates strip in
+   budgetNotifyTemplates.css and stay in step with it; only the per-source label
+   column and the git tint below are its own. The margin pulls it back against
+   the Folder field it belongs to, which .nf-body's 13px gap otherwise separates
+   it from. */
+.nf-suggest {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: -4px 0 0;
+}
+
+.nf-suggest .nt-head {
+  margin-bottom: 0;
+}
+
+.nf-suggest-legend {
+  font-size: 10.5px;
+}
+
+/* Label beside its own chips, in a fixed column so the three reasons line up
+   and the eye can skip whichever ones it doesn't care about. */
+.nf-suggest-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.nf-suggest-label {
+  flex: none;
+  width: 46px;
+  font-size: 11px;
+  color: var(--muted);
+  cursor: help;
+}
+
+.nf-suggest .nt-list {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Long project names would otherwise stretch one chip across the whole row. */
+.nf-suggest .nt-chip {
+  max-width: 190px;
+}
+
+.nf-suggest .nt-chip.is-git {
+  color: #c4b3ff;
+}
+
+/* Which chip filled the field matters more than what kind of folder it holds,
+   so this must stay after .is-git — they're equally specific. */
+.nf-suggest .nt-chip.active {
+  color: var(--accent);
+  background: rgba(var(--accent-rgb), 0.14);
+}
+
+/* The git-features aside. Deliberately not .error: pointing a session at a
+   plain folder is a legal thing to do, and the line is here to explain what
+   will be missing and offer the fix, not to stop anyone. The negative top
+   margin tucks it under the Folder input instead of floating a single line in
+   the middle of .nf-body's 13px gap. */
+.nf-git-nudge {
+  margin: -7px 0 -4px;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
 #repo-browser {
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -5865,7 +5945,9 @@ p.set-hint {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 240px;
+  /* 240px plus the .rb-hint line's height: the legend is chrome, and paying for
+     it out of the list would have cost a visible row. */
+  max-height: 262px;
 }
 
 .rb-head {
@@ -5923,6 +6005,12 @@ p.set-hint {
   gap: 2px;
 }
 
+/* Every row in the list is a <button> — a click on one is the selection, so it
+   had to become a real control. The UA chrome is stripped back so it still
+   reads as a list row, the row spans the full width (clicking the dead space
+   beside a short folder name used to do nothing), and the transparent border
+   reserves the same box .rb-use's dashed one occupies so the list doesn't shift
+   by a pixel between the two. */
 .rb-item {
   display: flex;
   align-items: center;
@@ -5932,10 +6020,24 @@ p.set-hint {
   font-size: 12px;
   color: var(--text);
   cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
 }
 
 .rb-item:hover {
   background: var(--panel-2);
+}
+
+.rb-item:focus-visible {
+  outline: 2px solid var(--accent);
+  /* Inset: the rows sit flush against #rb-list's scroll edge, and an outward
+     ring gets clipped by the overflow. */
+  outline-offset: -2px;
 }
 
 .rb-item.is-git {
@@ -5961,19 +6063,22 @@ p.set-hint {
   font-style: normal;
 }
 
-.rb-pick {
-  border-radius: 5px;
-  padding: 2px 9px;
-  font-size: 11px;
-  cursor: pointer;
-  flex: none;
-  border: 1px solid var(--border);
-  background: var(--panel-2);
-  color: var(--text);
+/* The folder the Folder field currently points at. Carried by a tinted fill and
+   an accent edge rather than a text colour, because .is-git already owns the
+   text colour and both states have to be readable at once. Declared after
+   :hover so pointing at the selected row doesn't undo the highlight. */
+.rb-item.rb-sel {
+  background: rgba(var(--accent-rgb), 0.16);
+  border-color: var(--accent);
 }
 
-.rb-pick:hover {
-  border-color: var(--accent);
+/* Click-selects / double-click-opens is Finder's model, not a web list's, so
+   the list says so once here — cheaper than every user discovering it by
+   accident, and it's the only place the ← / → keys are written down. */
+.rb-hint {
+  margin: 0;
+  font-size: 10.5px;
+  color: var(--muted);
 }
 
 .muted {
@@ -8387,12 +8492,17 @@ body.no-ticketing .ik-panel[data-caps-need~="ticketing"]>.caps-gate[data-caps-ga
   background: rgba(0, 0, 0, 0.05);
 }
 
-/* Light-accent text is too faint on white — use the deeper accent variant. */
+/* Light-accent text is too faint on white — use the deeper accent variant. The
+   folder-suggestion chips take it for both states: a git chip and the chip that
+   filled the field read the same colour on light, and the picked one is told
+   apart by its accent border and tinted fill instead. */
 .light .stagechip.s-agent,
 .light .split-diff .sd-file,
 .light .diff-toolbar .diffstat.file,
 .light .rb-item.is-git,
 .light .rb-use.is-git,
+.light .nf-suggest .nt-chip.is-git,
+.light .nf-suggest .nt-chip.active,
 .light .ws-badge.active {
   color: var(--accent-deep);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,9 @@
  * capability body-classes, activity debounce feed, keymap installation, and
  * which special panes (logs / system logs / assistant chat) are open. */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConfig, useInstances } from "./state/queries";
-import { useUi } from "./state/store";
+import { tourDecision, useUi } from "./state/store";
 import { noteActivity } from "./lib/stage";
 import { installKeymap, type KeymapHost } from "./lib/keymap";
 import { selectSession, instances as instancesSnapshot } from "./lib/sessionActions";
@@ -38,13 +38,33 @@ export default function App() {
   const ui = useUi();
   useDoctorAutoShow();
 
-  // First-run onboarding: pop the welcome walkthrough once, for a fresh user who
-  // still has hints enabled. finishTour() flips tourDone so it never reopens on
+  // First-run onboarding: pop the welcome walkthrough once, for a user who is
+  // new by the SERVER's reckoning and still has hints enabled — tourDecision()
+  // holds the rule. Until /api/config resolves it answers "wait" and this decides
+  // nothing, which is why the flags stay in the deps while the latch is a
+  // separate ref: the config query refetches on its own and re-arming hints from
+  // Settings re-runs this effect, and neither should be able to restart the
+  // twelve slides mid-session. finishTour() flips tourDone so it never reopens on
   // its own — a replay is an explicit action from Settings.
+  //
+  // Watching the tour is deliberately NOT reported back. general.onboarded means
+  // "this user has a session", which is why the server sets it on a create and
+  // nowhere else; a POST from here wrote it for anyone who merely clicked past the
+  // slideshow, and it took both first-run surfaces down with it — the grid's setup
+  // card and the auto-opening dependency checklist — for a user who still had no
+  // tmux and so could not create a session at all.
+  const tourDecided = useRef(false);
   useEffect(() => {
-    if (!ui.tourDone && ui.hintsEnabled) ui.openTour();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (tourDecided.current) return;
+    const decision = tourDecision({
+      tourDone: ui.tourDone,
+      hintsEnabled: ui.hintsEnabled,
+      onboarded: config?.onboarded,
+    });
+    if (decision === "wait") return;
+    tourDecided.current = true;
+    if (decision === "open") ui.openTour();
+  }, [config?.onboarded, ui.tourDone, ui.hintsEnabled, ui.openTour]);
 
   // Capability gating: body classes drive the caps-gate CSS (and addon CSS).
   useEffect(() => {

--- a/frontend/src/__tests__/newSession.test.ts
+++ b/frontend/src/__tests__/newSession.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import {
+  FOLDER_INIT,
+  focusRowIndex,
+  folderReducer,
+  mayTakeOpeningFocus,
+  type FolderAction,
+  type FolderState,
+} from "../components/dialogs/NewSessionDialog";
+
+/** Replays a sequence of gestures and answers the way the dialog dispatches
+ * them, so each trace below reads in the order the user lived it. */
+function run(state: FolderState, ...actions: FolderAction[]): FolderState {
+  return actions.reduce(folderReducer, state);
+}
+
+/** A freshly opened dialog whose suggestion has landed: the ordinary case, and
+ * the one with something worth losing in the Folder field. */
+const prefilled = run(
+  FOLDER_INIT,
+  { t: "reopen" },
+  { t: "suggested", path: "/home/me/code/myrepo" }
+);
+
+describe("folderReducer — browsing, and cancelling a browse", () => {
+  it("shows each selected row in the field, so the highlight and the git nudge follow it", () => {
+    const s = run(
+      prefilled,
+      { t: "browse-open" },
+      { t: "browse-select", path: "/home/me/Downloads" }
+    );
+    expect(s.path).toBe("/home/me/Downloads");
+    expect(s.browsing).toBe(true);
+  });
+
+  it("puts the folder back when the user escapes out of a tree they were only checking", () => {
+    // Browse to double-check something, walk into the wrong tree, Escape. The
+    // field kept whichever directory had been passed through last, and Create
+    // sent that as repo_path.
+    const s = run(
+      prefilled,
+      { t: "browse-open" },
+      { t: "browse-select", path: "/home/me/Downloads" },
+      { t: "browse-select", path: "/home/me/Downloads/tmp" },
+      { t: "browse-cancel" }
+    );
+    expect(s.path).toBe("/home/me/code/myrepo");
+    expect(s.browsing).toBe(false);
+    expect(s.undo).toBeNull();
+  });
+
+  it("hands a cancelled field back to a suggestion that was still walking", () => {
+    const onHome = run(FOLDER_INIT, { t: "reopen" }, { t: "fallback", path: "/home/me" });
+    const s = run(
+      onHome,
+      { t: "browse-open" },
+      { t: "browse-select", path: "/home/me/Downloads" },
+      { t: "browse-cancel" },
+      { t: "suggested", path: "/home/me/code/myrepo" }
+    );
+    expect(s.path).toBe("/home/me/code/myrepo");
+  });
+
+  it("never escapes back to the empty field a first-ever open started from", () => {
+    // Browse… is most tempting while the field is still blank, so the snapshot
+    // Escape restores was "". A suggestion landing mid-browse has to move that
+    // baseline, or cancelling empties the field and Create answers "a folder is
+    // required" — after submit() has already closed the dialog.
+    const s = run(
+      FOLDER_INIT,
+      { t: "reopen" },
+      { t: "browse-open" },
+      { t: "suggested", path: "/home/me/code/myrepo" },
+      { t: "browse-select", path: "/home/me/Downloads" },
+      { t: "browse-cancel" }
+    );
+    expect(s.path).toBe("/home/me/code/myrepo");
+    expect(s.touched).toBe(false);
+  });
+
+  it("still prefers a hand-typed folder over a pre-fill when a browse is cancelled", () => {
+    const s = run(
+      FOLDER_INIT,
+      { t: "reopen" },
+      { t: "user-set", path: "/srv/work/project" },
+      { t: "browse-open" },
+      { t: "suggested", path: "/home/me/code/myrepo" },
+      { t: "browse-select", path: "/home/me/Downloads" },
+      { t: "browse-cancel" }
+    );
+    expect(s.path).toBe("/srv/work/project");
+  });
+
+  it("keeps the folder when the browse is finished deliberately", () => {
+    // "use this folder", a folder just created, or the panel toggled shut.
+    const s = run(prefilled, { t: "browse-open" }, { t: "browse-commit", path: "/srv/work" });
+    expect(s).toEqual({ path: "/srv/work", browsing: false, undo: null, touched: true });
+  });
+
+  it("does not swallow a path typed while the browser was open", () => {
+    // Escape cancels the browsing; the typing is not part of the browse.
+    const s = run(
+      prefilled,
+      { t: "browse-open" },
+      { t: "browse-select", path: "/home/me/Downloads" },
+      { t: "user-set", path: "/srv/work/project" },
+      { t: "browse-cancel" }
+    );
+    expect(s.path).toBe("/srv/work/project");
+  });
+});
+
+describe("folderReducer — the pre-fill racing the user", () => {
+  it("never replaces a path typed while the filesystem walk was still running", () => {
+    // /api/repos/suggest does hundreds of listdir/stat probes under $HOME plus a
+    // git rev-parse per survivor, and the dialog is typeable throughout.
+    const s = run(
+      FOLDER_INIT,
+      { t: "reopen" },
+      { t: "user-set", path: "/srv/work/project" },
+      { t: "suggested", path: "/home/me/nearby" },
+      { t: "fallback", path: "/home/me" }
+    );
+    expect(s.path).toBe("/srv/work/project");
+  });
+
+  it("never replaces a folder chosen from a chip, a template or the browser", () => {
+    const chosen: FolderAction[] = [
+      { t: "user-set", path: "/srv/work/project" },
+      { t: "browse-select", path: "/srv/work/project" },
+      { t: "browse-commit", path: "/srv/work/project" },
+    ];
+    for (const a of chosen)
+      expect(
+        run(FOLDER_INIT, { t: "reopen" }, a, { t: "suggested", path: "/home/me/nearby" }).path
+      ).toBe("/srv/work/project");
+  });
+
+  it("still fills a field the user has emptied — there is nothing there to protect", () => {
+    const s = run(
+      FOLDER_INIT,
+      { t: "reopen" },
+      { t: "user-set", path: "" },
+      { t: "suggested", path: "/home/me/code/myrepo" }
+    );
+    expect(s.path).toBe("/home/me/code/myrepo");
+  });
+
+  it("prefers the suggestion to $HOME whichever order the two requests land in", () => {
+    const suggestFirst = run(
+      FOLDER_INIT,
+      { t: "reopen" },
+      { t: "suggested", path: "/home/me/code/myrepo" },
+      { t: "fallback", path: "/home/me" }
+    );
+    const homeFirst = run(
+      FOLDER_INIT,
+      { t: "reopen" },
+      { t: "fallback", path: "/home/me" },
+      { t: "suggested", path: "/home/me/code/myrepo" }
+    );
+    expect(suggestFirst.path).toBe("/home/me/code/myrepo");
+    expect(homeFirst.path).toBe("/home/me/code/myrepo");
+  });
+
+  it("clears nothing when an endpoint has no folder to offer", () => {
+    const s = run(
+      FOLDER_INIT,
+      { t: "reopen" },
+      { t: "fallback", path: "/home/me" },
+      { t: "suggested", path: "" }
+    );
+    expect(s.path).toBe("/home/me");
+  });
+
+  it("keeps the last opening's folder as a placeholder, but not its touches", () => {
+    const lastTime = run(
+      FOLDER_INIT,
+      { t: "user-set", path: "/srv/work/project" },
+      { t: "browse-open" }
+    );
+    const s = run(lastTime, { t: "reopen" });
+    expect(s).toEqual({ path: "/srv/work/project", browsing: false, undo: null, touched: false });
+    // Which is what leaves this opening's own suggestion free to improve on it.
+    expect(run(s, { t: "suggested", path: "/home/me/code/myrepo" }).path).toBe(
+      "/home/me/code/myrepo"
+    );
+  });
+});
+
+describe("mayTakeOpeningFocus", () => {
+  it("takes the caret from whatever opened the dialog", () => {
+    // The New button, the command palette's input as it unmounts, the terminal.
+    expect(mayTakeOpeningFocus({ activeIsTarget: false, activeInsideDialog: false })).toBe(true);
+  });
+
+  it("leaves a field inside the dialog that the user reached first", () => {
+    // The bug it exists for: the caret in Prompt, mid-sentence.
+    expect(mayTakeOpeningFocus({ activeIsTarget: false, activeInsideDialog: true })).toBe(false);
+  });
+
+  it("is a harmless no-op once the Name box already has the caret", () => {
+    expect(mayTakeOpeningFocus({ activeIsTarget: true, activeInsideDialog: true })).toBe(true);
+  });
+});
+
+describe("focusRowIndex — where a keyboard navigation lands", () => {
+  it("lands on the folder it stepped out of, so ← walks back out the way it came in", () => {
+    const home = ["/home/me/code", "/home/me/Downloads", "/home/me/notes"];
+    expect(focusRowIndex(home, "/home/me/Downloads")).toBe(1);
+  });
+
+  it("starts at the top when stepping in, where the folder left behind isn't listed", () => {
+    const code = ["/home/me/code/src", "/home/me/code/tests"];
+    expect(focusRowIndex(code, "/home/me/code")).toBe(0);
+  });
+
+  it("has no row to give in an empty folder, which sends focus to “use this folder”", () => {
+    expect(focusRowIndex([], "/home/me/code")).toBe(-1);
+  });
+});

--- a/frontend/src/__tests__/onboarding.test.ts
+++ b/frontend/src/__tests__/onboarding.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { tourDecision } from "../state/store";
+import { shouldAutoShowSetup } from "../components/dialogs/SetupDialog";
+
+describe("tourDecision (welcome tour auto-open)", () => {
+  it("opens for a user the server has never seen get anywhere", () => {
+    expect(tourDecision({ tourDone: false, hintsEnabled: true, onboarded: false })).toBe("open");
+  });
+
+  it("leaves a returning user alone even when this browser has forgotten them", () => {
+    // The whole bug: cleared storage / a second profile / a second machine.
+    expect(tourDecision({ tourDone: false, hintsEnabled: true, onboarded: true })).toBe("skip");
+  });
+
+  it("waits rather than guessing while /api/config is still in flight", () => {
+    expect(tourDecision({ tourDone: false, hintsEnabled: true, onboarded: undefined })).toBe("wait");
+  });
+
+  it("short-circuits locally, so a finished tour never waits on the network", () => {
+    expect(tourDecision({ tourDone: true, hintsEnabled: true, onboarded: undefined })).toBe("skip");
+    expect(tourDecision({ tourDone: false, hintsEnabled: false, onboarded: undefined })).toBe("skip");
+  });
+
+  it("honors hints-off for a brand new user too", () => {
+    expect(tourDecision({ tourDone: false, hintsEnabled: false, onboarded: false })).toBe("skip");
+  });
+});
+
+describe("shouldAutoShowSetup (first-run checklist auto-open)", () => {
+  it("opens for a first-run user with something failing", () => {
+    expect(shouldAutoShowSetup({ failing: true, onboarded: false })).toBe(true);
+  });
+
+  it("never ambushes a veteran with a first-run checklist", () => {
+    expect(shouldAutoShowSetup({ failing: true, onboarded: true })).toBe(false);
+  });
+
+  it("stays shut while the onboarded flag is unknown", () => {
+    expect(shouldAutoShowSetup({ failing: true, onboarded: undefined })).toBe(false);
+  });
+
+  it("keeps opening for the same first-run user until the tools are there", () => {
+    // No per-browser "already saw it" flag can suppress this: a missing tmux is
+    // still missing on the next load, and the checklist is the only thing that
+    // says so before the user tries to create a session.
+    expect(shouldAutoShowSetup({ failing: true, onboarded: false })).toBe(true);
+    expect(shouldAutoShowSetup({ failing: true, onboarded: false })).toBe(true);
+  });
+
+  it("stays shut when doctor is happy, whoever is asking", () => {
+    expect(shouldAutoShowSetup({ failing: false, onboarded: false })).toBe(false);
+    expect(shouldAutoShowSetup({ failing: false, onboarded: undefined })).toBe(false);
+  });
+});
+
+/** Source with its comments removed.
+ *
+ * The modules below deliberately name the retired endpoint and flags in prose so
+ * nobody reinvents them, so a raw substring search would flag the very
+ * documentation that keeps them retired. The `[^:"'`]` guard is what stops a
+ * `https://` inside a string from being read as the start of a comment. */
+function code(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:"'`\\])\/\/.*$/gm, "$1");
+}
+
+/** Every .ts/.tsx module the app itself ships, as source keyed by path. The glob
+ * is Vite's rather than a directory walk because this project installs no node
+ * types, and @types/node is not worth adding for one readdir. */
+const sources = Object.entries(
+  import.meta.glob<string>(["../**/*.{ts,tsx}", "!../__tests__/**"], {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  })
+).map(([path, text]) => ({ path: path.replace(/^\.\.\//, ""), text: code(text) }));
+
+describe("first-run state has exactly one authority", () => {
+  // These read source rather than behaviour because both regressions were side
+  // effects inside components, and this suite runs without a DOM — the tour's own
+  // close handler cannot be rendered here. What is checkable is that no module
+  // can reach the offending write at all.
+
+  it("finds sources to scan at all", () => {
+    // A glob that silently matched nothing would make both checks below pass
+    // without looking at anything.
+    expect(sources.length).toBeGreaterThan(20);
+    expect(sources.map((f) => f.path)).toContain("App.tsx");
+  });
+
+  it("never tells the server the welcome tour happened", () => {
+    // general.onboarded means "this user has a session". Writing it because a
+    // slideshow closed took away the grid's setup card and the auto-opening
+    // dependency checklist from a user who had installed nothing and created
+    // nothing — the two surfaces that were the way out.
+    const offenders = sources.filter((f) => f.text.includes("/api/onboarded"));
+    expect(offenders.map((f) => f.path)).toEqual([]);
+  });
+
+  it("keeps the writer-less per-browser setup flags out", () => {
+    // mf_setup_done and mf_ever_created were read but never written, so the
+    // dismissal they gated could not fire and the comments describing it were
+    // fiction. Either key coming back needs a writer and a reason.
+    const offenders = sources.filter(
+      (f) => f.text.includes("mf_setup_done") || f.text.includes("mf_ever_created")
+    );
+    expect(offenders.map((f) => f.path)).toEqual([]);
+  });
+});

--- a/frontend/src/components/dialogs/NewSessionDialog.css
+++ b/frontend/src/components/dialogs/NewSessionDialog.css
@@ -322,6 +322,76 @@
   border-color: var(--accent);
 }
 
+/* The folder-suggestion strip. It also carries .new-templates (see the JSX), so
+   the card, the head and the .nt-chip pills come from the Templates strip in
+   budgetNotifyTemplates.css and stay in step with it; only the per-source label
+   column and the git tint below are its own. The margin pulls it back against
+   the Folder field it belongs to, which .nf-body's 13px gap otherwise separates
+   it from. */
+.nf-suggest {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: -4px 0 0;
+}
+
+.nf-suggest .nt-head {
+  margin-bottom: 0;
+}
+
+.nf-suggest-legend {
+  font-size: 10.5px;
+}
+
+/* Label beside its own chips, in a fixed column so the three reasons line up
+   and the eye can skip whichever ones it doesn't care about. */
+.nf-suggest-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.nf-suggest-label {
+  flex: none;
+  width: 46px;
+  font-size: 11px;
+  color: var(--muted);
+  cursor: help;
+}
+
+.nf-suggest .nt-list {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Long project names would otherwise stretch one chip across the whole row. */
+.nf-suggest .nt-chip {
+  max-width: 190px;
+}
+
+.nf-suggest .nt-chip.is-git {
+  color: #c4b3ff;
+}
+
+/* Which chip filled the field matters more than what kind of folder it holds,
+   so this must stay after .is-git — they're equally specific. */
+.nf-suggest .nt-chip.active {
+  color: var(--accent);
+  background: rgba(var(--accent-rgb), 0.14);
+}
+
+/* The git-features aside. Deliberately not .error: pointing a session at a
+   plain folder is a legal thing to do, and the line is here to explain what
+   will be missing and offer the fix, not to stop anyone. The negative top
+   margin tucks it under the Folder input instead of floating a single line in
+   the middle of .nf-body's 13px gap. */
+.nf-git-nudge {
+  margin: -7px 0 -4px;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
 #repo-browser {
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -330,7 +400,9 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 240px;
+  /* 240px plus the .rb-hint line's height: the legend is chrome, and paying for
+     it out of the list would have cost a visible row. */
+  max-height: 262px;
 }
 
 .rb-head {
@@ -388,6 +460,12 @@
   gap: 2px;
 }
 
+/* Every row in the list is a <button> — a click on one is the selection, so it
+   had to become a real control. The UA chrome is stripped back so it still
+   reads as a list row, the row spans the full width (clicking the dead space
+   beside a short folder name used to do nothing), and the transparent border
+   reserves the same box .rb-use's dashed one occupies so the list doesn't shift
+   by a pixel between the two. */
 .rb-item {
   display: flex;
   align-items: center;
@@ -397,10 +475,24 @@
   font-size: 12px;
   color: var(--text);
   cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
 }
 
 .rb-item:hover {
   background: var(--panel-2);
+}
+
+.rb-item:focus-visible {
+  outline: 2px solid var(--accent);
+  /* Inset: the rows sit flush against #rb-list's scroll edge, and an outward
+     ring gets clipped by the overflow. */
+  outline-offset: -2px;
 }
 
 .rb-item.is-git {
@@ -426,19 +518,22 @@
   font-style: normal;
 }
 
-.rb-pick {
-  border-radius: 5px;
-  padding: 2px 9px;
-  font-size: 11px;
-  cursor: pointer;
-  flex: none;
-  border: 1px solid var(--border);
-  background: var(--panel-2);
-  color: var(--text);
+/* The folder the Folder field currently points at. Carried by a tinted fill and
+   an accent edge rather than a text colour, because .is-git already owns the
+   text colour and both states have to be readable at once. Declared after
+   :hover so pointing at the selected row doesn't undo the highlight. */
+.rb-item.rb-sel {
+  background: rgba(var(--accent-rgb), 0.16);
+  border-color: var(--accent);
 }
 
-.rb-pick:hover {
-  border-color: var(--accent);
+/* Click-selects / double-click-opens is Finder's model, not a web list's, so
+   the list says so once here — cheaper than every user discovering it by
+   accident, and it's the only place the ← / → keys are written down. */
+.rb-hint {
+  margin: 0;
+  font-size: 10.5px;
+  color: var(--muted);
 }
 
 .muted {

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -3,7 +3,7 @@
  * templates strip, prompt presets, provisioning fold, and per-session launch
  * flags live behind progressive disclosure. */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import type { Config, Instance } from "../../api/types";
 import { api } from "../../api/client";
 import { refreshInstances, refreshConfig, queryClient } from "../../state/queries";
@@ -41,6 +41,158 @@ interface Provider {
   command?: string;
 }
 
+/** One folder /api/repos/suggest thinks the user might mean. */
+interface RepoSuggestion {
+  path: string;
+  name: string;
+  is_git: boolean;
+  source: string;
+}
+
+/** The three reasons the endpoint can have for offering a folder, in the order
+ * it ranks them. Each one is labelled in the strip because an unexplained list
+ * of folder names reads as noise: without the label there is no way to tell the
+ * repo your last session ran in from some directory that merely happens to sit
+ * under $HOME, and the user can't judge a suggestion they can't account for. */
+const SUGGEST_SOURCES: Array<{ key: string; label: string; hint: string }> = [
+  { key: "recent", label: "Recent", hint: "folders your recent sessions ran in" },
+  { key: "cwd", label: "Here", hint: "the folder MindFlock itself was started in" },
+  { key: "nearby", label: "Nearby", hint: "repos and folders sitting under your home directory" },
+];
+
+/** How long the Folder field must sit still before we ask the server what it
+ * is. The endpoint answers 200-with-exists:false for half-typed paths, so a
+ * per-keystroke call would be harmless but pointless traffic. */
+const CHECK_DEBOUNCE_MS = 400;
+
+/** Last path segment, for naming the folder the confirm row would use. Keeps
+ * both separators so a Windows path doesn't come back as the whole string. */
+function leafName(path: string): string {
+  return path.replace(/[/\\]+$/, "").split(/[/\\]/).pop() || path;
+}
+
+/** The Folder field's whole state, gathered into one value because both ways it
+ * goes wrong are questions of ordering. Browsing writes every row the user
+ * clicks straight into the field, so walking away from the browser has to put
+ * back what the field held before — otherwise the last directory they merely
+ * passed through becomes the session's repo_path. And the pre-fill resolves
+ * after the dialog is already interactive, so it must never land on top of a
+ * path typed in the meantime. folderReducer decides both, and is pure so those
+ * sequences can be tested. */
+export interface FolderState {
+  /** What the Folder input shows, and what submit sends as repo_path. */
+  path: string;
+  /** Whether the folder browser sits open under the field. */
+  browsing: boolean;
+  /** The field as it stood when the browser opened — what Escape puts back.
+   * Null when there is no browse to undo. */
+  undo: { path: string; touched: boolean } | null;
+  /** Whether the user has said where they want to work, by typing, clicking a
+   * suggestion chip, choosing in the browser or applying a template. A pre-fill
+   * that arrives after that has been outvoted. */
+  touched: boolean;
+}
+
+export type FolderAction =
+  /** The dialog opened: forget the last opening's browse and its touches. */
+  | { t: "reopen" }
+  /** The best-ranked /api/repos/suggest folder arrived. */
+  | { t: "suggested"; path: string }
+  /** $HOME, for a field that nothing better has filled. */
+  | { t: "fallback"; path: string }
+  /** The user named a folder outside the browser: typed it, clicked a
+   * suggestion chip, or applied a template carrying one. */
+  | { t: "user-set"; path: string }
+  | { t: "browse-open" }
+  /** A row was clicked or arrowed into — the selection shows in the field. */
+  | { t: "browse-select"; path: string }
+  /** "use this folder", a folder just created, or the panel toggled shut: the
+   * deliberate finish, after which there is nothing left to undo. */
+  | { t: "browse-commit"; path: string }
+  /** Escape: put the field back the way the browser found it. */
+  | { t: "browse-cancel" };
+
+export const FOLDER_INIT: FolderState = {
+  path: "",
+  browsing: false,
+  undo: null,
+  touched: false,
+};
+
+/** The undo point after a pre-fill lands, which matters only mid-browse.
+ *
+ * Opening the browser snapshots the field as it stands, and on a first-ever open
+ * that snapshot is the empty string — the user reaches for Browse… precisely
+ * because the field is still blank. If the suggestion then arrives, Escape would
+ * hand the field back to that empty string, and Create answers an empty folder
+ * with "a folder is required" after it has already closed the dialog. So a
+ * pre-fill that arrives mid-browse becomes the new "nothing happened" baseline,
+ * unless the user already had a folder of their own to go back to. */
+function prefillUndo(s: FolderState, path: string): FolderState["undo"] {
+  if (!s.browsing) return s.undo;
+  if (s.undo && s.undo.path) return s.undo;
+  return { path, touched: false };
+}
+
+export function folderReducer(s: FolderState, a: FolderAction): FolderState {
+  switch (a.t) {
+    case "reopen":
+      // The path itself survives on purpose: it is the folder the last session
+      // was started in, which beats an empty field for the moment before this
+      // opening's own pre-fill lands.
+      return { ...s, browsing: false, undo: null, touched: false };
+    case "suggested":
+      // A filesystem walk that outran the user is welcome; one that comes back
+      // after they typed leaves what they typed alone. An empty field has
+      // nothing to lose either way, so it always gets filled.
+      if (!a.path || (s.touched && s.path)) return s;
+      return { ...s, path: a.path, undo: prefillUndo(s, a.path) };
+    case "fallback":
+      // $HOME is the weakest of the pre-fills — almost never where anyone
+      // works, just somewhere the browser can start — so it only ever fills a
+      // field that is otherwise empty.
+      if (!a.path || s.path) return s;
+      return { ...s, path: a.path, undo: prefillUndo(s, a.path) };
+    case "user-set":
+      // Typing while the browser is open moves the undo point with it: Escape
+      // is there to cancel the browsing, and has no business also swallowing a
+      // path the user wrote by hand.
+      return {
+        ...s,
+        path: a.path,
+        touched: true,
+        undo: s.browsing ? { path: a.path, touched: true } : null,
+      };
+    case "browse-open":
+      return { ...s, browsing: true, undo: { path: s.path, touched: s.touched } };
+    case "browse-select":
+      return { ...s, path: a.path, touched: true };
+    case "browse-commit":
+      return { path: a.path, browsing: false, undo: null, touched: true };
+    case "browse-cancel":
+      // Restores the touched flag too, so a browse that came to nothing also
+      // hands the field back to a suggestion still in flight.
+      return {
+        path: s.undo ? s.undo.path : s.path,
+        browsing: false,
+        undo: null,
+        touched: s.undo ? s.undo.touched : s.touched,
+      };
+  }
+}
+
+/** Whether the dialog's opening focus() may still claim the caret. It may not
+ * once focus sits on another control inside the dialog: the user got there
+ * first, and taking the caret back mid-word is how the tail of a sentence ends
+ * up in the Name box. Focus outside the dialog — the menu button that opened
+ * it, the terminal behind — is exactly what the dialog is there to take. */
+export function mayTakeOpeningFocus(where: {
+  activeIsTarget: boolean;
+  activeInsideDialog: boolean;
+}): boolean {
+  return where.activeIsTarget || !where.activeInsideDialog;
+}
+
 export function NewSessionDialog() {
   const open = useUi((s) => s.openDialog === "new-session");
   const closeDialog = useUi((s) => s.closeDialog);
@@ -48,7 +200,6 @@ export function NewSessionDialog() {
   const [title, setTitle] = useState("");
   const [program, setProgram] = useState("");
   const [providers, setProviders] = useState<Provider[]>([]);
-  const [repoPath, setRepoPath] = useState("");
   const [prompt, setPrompt] = useState("");
   const [launchArgs, setLaunchArgs] = useState("");
   const [provision, setProvision] = useState(false);
@@ -57,16 +208,29 @@ export function NewSessionDialog() {
   const [initRepo, setInitRepo] = useState(false);
   const [error, setError] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [browserOpen, setBrowserOpen] = useState(false);
   const [templates, setTemplates] = useState<Template[]>([]);
   const [activeTemplate, setActiveTemplate] = useState("");
   const [provisioningAvailable, setProvisioningAvailable] = useState(false);
   const [homePath, setHomePath] = useState("");
+  const [suggestions, setSuggestions] = useState<RepoSuggestion[]>([]);
+  // The server's verdict on the folder in the field, stamped with the path we
+  // asked about — see the debounce effect for why the stamp is load-bearing.
+  const [folderCheck, setFolderCheck] = useState<{ asked: string; plain: boolean } | null>(null);
   const [presetValue, setPresetValue] = useState("");
   const [savedPresets, setSavedPresets] = useState<Preset[]>([]);
   const launchDefaults = useRef<Record<string, string>>({});
   const titleRef = useRef<HTMLInputElement | null>(null);
   const launchRef = useRef<HTMLDetailsElement | null>(null);
+  // The modal's own element, so the opening focus can tell "nothing in here has
+  // the caret yet" from "the user is already typing in one of these fields".
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  // The Folder field and the browser's visibility travel together: see
+  // folderReducer for the two orderings that forced them into one value. These
+  // aliases keep the form's many readers reading a plain value, while every
+  // write goes through the reducer.
+  const [folder, folderDo] = useReducer(folderReducer, FOLDER_INIT);
+  const repoPath = folder.path;
+  const browserOpen = folder.browsing;
 
   // Reset + load fresh data on every open (matches openDialog()).
   useEffect(() => {
@@ -79,12 +243,36 @@ export function NewSessionDialog() {
     setInPlace(true);
     setInitRepo(false);
     setAdvancedOpen(false);
-    setBrowserOpen(false);
+    folderDo({ t: "reopen" });
     setActiveTemplate("");
     setPresetValue("");
     setSavedPresets(loadUserPresets());
+    let live = true;
+    // The folder suggestions get a request of their own rather than a place in
+    // the barrier below, because the endpoint walks the filesystem: hundreds of
+    // listdir/stat probes under $HOME plus a git rev-parse per surviving
+    // candidate, which is milliseconds warm and seconds on a cold or
+    // network-mounted home. Behind the barrier that walk would hold the agent
+    // list, the launch flags and the templates hostage to it as well.
     (async () => {
-      // Config + settings resolve in parallel; templates are optional sugar.
+      try {
+        const d = await api<{ suggestions?: RepoSuggestion[] }>("/api/repos/suggest");
+        if (!live) return;
+        const sug = d.suggestions || [];
+        setSuggestions(sug);
+        // Start on the best-ranked one — normally the folder the last session
+        // used — so the common case needs no Browse trip at all. Unless the user
+        // has already said where they want to work: see folderReducer.
+        folderDo({ t: "suggested", path: sug[0]?.path || "" });
+      } catch {
+        // Suggestions are sugar. The field, the browser and Create all work
+        // without them, so a failed walk must not cost the dialog anything.
+        if (live) setSuggestions([]);
+      }
+    })();
+    (async () => {
+      // Config, settings and templates all answer out of memory, so waiting for
+      // the slowest of the three costs the dialog nothing.
       const [cfgR, setR, tplR] = await Promise.allSettled([
         refreshConfig().then(() => queryClient.getQueryData<Config>(["config"])),
         api<{ settings?: { coding_cli?: { default_launch_args?: Record<string, string> } } }>(
@@ -92,9 +280,13 @@ export function NewSessionDialog() {
         ),
         api<{ templates?: Template[] }>("/api/templates"),
       ]);
+      if (!live) return;
       const cfg = cfgR.status === "fulfilled" ? cfgR.value : undefined;
       setHomePath(cfg?.home || "");
-      setRepoPath(cfg?.home || "");
+      // $HOME is the fallback it always was: almost never what the user wants,
+      // but a place the browser can start from when the suggestions had nothing
+      // to offer (or failed, or are still walking).
+      folderDo({ t: "fallback", path: cfg?.home || "" });
       setProvisioningAvailable(!!cfg?.provisioning_available);
       let provs: Provider[] = [];
       try {
@@ -103,6 +295,7 @@ export function NewSessionDialog() {
       } catch {
         /* providers are optional */
       }
+      if (!live) return;
       setProviders(provs);
       // Map the saved default (name / alias / raw command) to the provider NAME.
       const prev = cfg?.default_program || "";
@@ -126,9 +319,66 @@ export function NewSessionDialog() {
         launchDefaults.current[k.toLowerCase()] = String(raw[k] || "");
       setLaunchArgs((launchDefaults.current[agent.trim().toLowerCase()] || "").trim());
       setTemplates(tplR.status === "fulfilled" ? tplR.value?.templates || [] : []);
-      setTimeout(() => titleRef.current?.focus(), 0);
     })();
+    return () => {
+      // Answers for a dialog that has since been closed (or closed and reopened)
+      // have nothing to say about this opening, and the suggestion walk is slow
+      // enough to still be running when that happens.
+      live = false;
+    };
   }, [open]);
+
+  // The opening focus belongs to the opening itself, not to the back of the
+  // loads above: the dialog paints and is typeable the moment `open` flips, and
+  // a focus() that waits for a filesystem walk lands seconds later, yanking the
+  // caret out of the Prompt box mid-sentence so the rest of the sentence goes
+  // into Name. Even at this range something can get there first — a click that
+  // beats this effect's commit — and whatever did keeps the caret.
+  useEffect(() => {
+    if (!open) return;
+    const el = titleRef.current;
+    const active = document.activeElement;
+    if (
+      el &&
+      mayTakeOpeningFocus({
+        activeIsTarget: active === el,
+        activeInsideDialog: !!active && !!rootRef.current?.contains(active),
+      })
+    )
+      el.focus();
+  }, [open]);
+
+  // Whether the folder is a git repo is only knowable server-side, and the
+  // field is free text, so it has to be re-asked as the user types. Two things
+  // keep that honest: the timer, which waits for the typing to settle, and the
+  // `live` flag, which the cleanup clears so a slow answer for an abandoned
+  // path can never land on top of a newer one — the nudge appearing under a
+  // folder that already has a repo is exactly the wrong kind of wrong.
+  useEffect(() => {
+    const asked = repoPath.trim();
+    if (!open || !asked) {
+      setFolderCheck(null);
+      return;
+    }
+    let live = true;
+    const timer = window.setTimeout(async () => {
+      try {
+        const r = await api<{ exists?: boolean; is_dir?: boolean; is_git?: boolean }>(
+          "/api/repos/check?path=" + encodeURIComponent(asked)
+        );
+        if (live) setFolderCheck({ asked, plain: !!r.exists && !!r.is_dir && !r.is_git });
+      } catch {
+        // A folder we can't probe simply gets no aside. Guessing "no git here"
+        // from a failed request would nag people into initialising repos they
+        // already have.
+        if (live) setFolderCheck(null);
+      }
+    }, CHECK_DEBOUNCE_MS);
+    return () => {
+      live = false;
+      window.clearTimeout(timer);
+    };
+  }, [open, repoPath]);
 
   const setAgent = useCallback((value: string) => {
     const v = (value || "").trim();
@@ -139,7 +389,7 @@ export function NewSessionDialog() {
 
   const fillFromTemplate = (t: Template) => {
     if (t.program) setAgent(t.program);
-    if (t.repo_path) setRepoPath(t.repo_path);
+    if (t.repo_path) folderDo({ t: "user-set", path: t.repo_path });
     if (t.prompt) setPrompt(t.prompt);
     setProvision(!!t.provisioned);
     if (t.workspace_strategy) setStrategy(t.workspace_strategy);
@@ -151,9 +401,32 @@ export function NewSessionDialog() {
     titleRef.current?.focus();
   };
 
+  /** The git nudge's action drives the real "Create a git repo in this folder"
+   * checkbox instead of a flag of its own — two switches for one behaviour is
+   * how a submitted form ends up disagreeing with what the user was shown — and
+   * so it inherits that checkbox pair's mutual exclusion with "work directly in
+   * this folder". The fold is opened at the same time so the box it just ticked
+   * is visible and untickable, rather than changing state out of sight. */
+  const armInitRepo = () => {
+    setInitRepo(true);
+    setInPlace(false);
+    setAdvancedOpen(true);
+  };
+
   if (!open) return null;
 
-  const offerProvision = provisioningAvailable || !!repoPath.trim();
+  const folderPath = repoPath.trim();
+  const offerProvision = provisioningAvailable || !!folderPath;
+  // Only an answer about the path now in the field earns a line on screen; a
+  // reply for an older path is stale by definition, whether it arrived late or
+  // is simply what we last learned before the current keystrokes.
+  const plainFolder = folderCheck?.asked === folderPath && !!folderCheck?.plain;
+  // Empty groups drop out, so a machine with no recent sessions shows "Nearby"
+  // alone instead of two blank label columns.
+  const suggestRows = SUGGEST_SOURCES.map((g) => ({
+    ...g,
+    items: suggestions.filter((s) => s.source === g.key),
+  })).filter((g) => g.items.length > 0);
 
   const submit = async () => {
     setError("Creating…");
@@ -212,13 +485,17 @@ export function NewSessionDialog() {
     <div
       id="new-dialog"
       className="modal"
+      ref={rootRef}
       onClick={(e) => {
         if (e.target === e.currentTarget) closeDialog();
       }}
       onKeyDown={(e) => {
         if (e.key === "Escape") {
           e.preventDefault();
-          if (browserOpen) setBrowserOpen(false);
+          // Escape out of the browser is a cancel, not merely a close: browsing
+          // writes each selected row into the Folder field, so leaving it has to
+          // hand the field back the way the browser found it.
+          if (browserOpen) folderDo({ t: "browse-cancel" });
           else closeDialog();
         } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
           e.preventDefault();
@@ -306,13 +583,24 @@ export function NewSessionDialog() {
                   autoComplete="off"
                   placeholder="/home/me/projects/foo"
                   value={repoPath}
-                  onChange={(e) => setRepoPath(e.target.value)}
+                  onChange={(e) => folderDo({ t: "user-set", path: e.target.value })}
                 />
                 <button
                   type="button"
                   id="repo-browse-btn"
-                  title="Browse local folders"
-                  onClick={() => setBrowserOpen((v) => !v)}
+                  title={
+                    browserOpen
+                      ? "Close the browser and keep this folder (Esc puts the old one back)"
+                      : "Browse local folders"
+                  }
+                  onClick={() =>
+                    // Toggling the panel shut keeps whatever the field now holds:
+                    // it is on screen, the user has been looking at it, and only
+                    // Escape claims to undo anything.
+                    folderDo(
+                      browserOpen ? { t: "browse-commit", path: repoPath } : { t: "browse-open" }
+                    )
+                  }
                 >
                   Browse…
                 </button>
@@ -354,13 +642,71 @@ export function NewSessionDialog() {
           {/* The datalist mount slots.js populates from /api/providers. */}
           <datalist id="provider-list"></datalist>
 
+          {plainFolder && (
+            <p className="nf-git-nudge">
+              {initRepo ? (
+                <>A git repo will be created here — diff, commit and PR will work.</>
+              ) : (
+                <>
+                  No git repo in this folder, so diff, commit and PR stay off.{" "}
+                  <button
+                    type="button"
+                    className="linklike"
+                    title="Ticks “Create a git repo in this folder” under More options"
+                    onClick={armInitRepo}
+                  >
+                    Create one
+                  </button>
+                </>
+              )}
+            </p>
+          )}
+
+          {suggestRows.length > 0 && (
+            /* Wears .new-templates as well as its own class on purpose: this is
+               the same chip strip as Templates, filled from a different source,
+               and sharing the class is what stops the two from drifting apart. */
+            <div id="new-suggest" className="new-templates nf-suggest">
+              <div className="nt-head">
+                <span>Folders</span>
+                <span className="nf-suggest-legend">📦 git repo · 📁 plain folder</span>
+              </div>
+              {suggestRows.map((g) => (
+                <div key={g.key} className="nf-suggest-row">
+                  <span className="nf-suggest-label" title={g.hint}>
+                    {g.label}
+                  </span>
+                  <div className="nt-list">
+                    {g.items.map((s) => {
+                      const active = folderPath === s.path;
+                      return (
+                        <button
+                          key={s.path}
+                          type="button"
+                          className={
+                            "nt-chip" + (s.is_git ? " is-git" : "") + (active ? " active" : "")
+                          }
+                          data-path={s.path}
+                          aria-pressed={active}
+                          title={s.path + (s.is_git ? "" : "\nno git repo here yet")}
+                          onClick={() => folderDo({ t: "user-set", path: s.path })}
+                        >
+                          {(s.is_git ? "📦 " : "📁 ") + s.name}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
           {browserOpen && (
             <FolderBrowser
-              initialPath={repoPath.trim() || homePath || ""}
-              onPick={(p) => {
-                setRepoPath(p);
-                setBrowserOpen(false);
-              }}
+              initialPath={folderPath || homePath || ""}
+              selected={folderPath}
+              onSelect={(p) => folderDo({ t: "browse-select", path: p })}
+              onPick={(p) => folderDo({ t: "browse-commit", path: p })}
             />
           )}
 
@@ -555,12 +901,42 @@ export function NewSessionDialog() {
   );
 }
 
-/** Folder browser popover (port of loadBrowse, section 16). */
+/** Which row a keyboard navigation should land on once the new listing is up:
+ * the folder it just stepped out of, if that folder is in the listing — which is
+ * the case when stepping UP, so a wrong turn is one ← away from where it started
+ * — and otherwise the first row, since a folder is never among its own children.
+ * -1 means the listing has no rows to land on at all. */
+export function focusRowIndex(paths: string[], leaving: string): number {
+  if (!paths.length) return -1;
+  const i = paths.indexOf(leaving);
+  return i >= 0 ? i : 0;
+}
+
+/** Folder browser popover (port of loadBrowse, section 16), on Finder's rules:
+ * a single click SELECTS a row and a double click opens it. It used to be the
+ * other way round — the name navigated and a per-row "select" button was the
+ * only way to choose anything — which meant the one gesture everybody tries
+ * first did the one thing they didn't ask for. Selecting deliberately does NOT
+ * close the popover: the user is mid-browse, and a picker that vanishes on the
+ * first click is unusable for comparing two folders.
+ *
+ * Selecting writes into the Folder field itself rather than keeping a copy in
+ * here, so the highlight, the git nudge and the suggestion chips all follow the
+ * row that was clicked. That is what makes the dialog's snapshot load-bearing:
+ * see folderReducer for how Escape hands the field back. */
 function FolderBrowser({
   initialPath,
+  selected,
+  onSelect,
   onPick,
 }: {
   initialPath: string;
+  /** The path the Folder field holds, so the highlight always matches the form
+   * rather than a copy of the selection kept in here. */
+  selected: string;
+  /** Fill the field, stay open — undone if the browse is cancelled. */
+  onSelect(path: string): void;
+  /** Fill the field and close — the explicit "I'm done" gesture. */
   onPick(path: string): void;
 }) {
   interface BrowsePayload {
@@ -571,6 +947,10 @@ function FolderBrowser({
   }
   const [data, setData] = useState<BrowsePayload | null>(null);
   const [error, setError] = useState("");
+  const listRef = useRef<HTMLDivElement | null>(null);
+  // The folder a keyboard navigation is stepping out of, or null when the
+  // pointer drove it (or nothing is pending) — read by the effect below.
+  const leaving = useRef<string | null>(null);
 
   const load = useCallback(async (path: string) => {
     setError("");
@@ -578,6 +958,10 @@ function FolderBrowser({
       const q = path ? "?path=" + encodeURIComponent(path) : "";
       setData(await api<BrowsePayload>("/api/browse" + q));
     } catch (err) {
+      // A listing that never arrived leaves the old rows (and the row that has
+      // focus) on screen, so it must also drop any pending handoff rather than
+      // leave it to fire on somebody else's navigation.
+      leaving.current = null;
       setError((err as Error).message);
     }
   }, []);
@@ -586,6 +970,31 @@ function FolderBrowser({
     load(initialPath);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Navigating swaps every row in the list, which unmounts the button holding
+  // focus — and focus falls to document.body, so → and ← worked exactly once and
+  // getting back into the list meant Tabbing in from the top of the document,
+  // past the whole modal. So a keyboard move claims a row in the NEW listing
+  // (see focusRowIndex), and an empty folder hands focus to "use this folder",
+  // which down there is the only thing left to do anyway. Pointer navigation
+  // names nothing and so moves nothing: the mouse has not lost its place.
+  useEffect(() => {
+    const from = leaving.current;
+    if (from === null || !data) return;
+    leaving.current = null;
+    const idx = focusRowIndex((data.entries || []).map((e) => e.path), from);
+    const rows = listRef.current?.querySelectorAll<HTMLButtonElement>(".rb-item:not(.rb-use)");
+    const row =
+      idx >= 0 ? rows?.[idx] : listRef.current?.querySelector<HTMLButtonElement>(".rb-use");
+    row?.focus();
+  }, [data]);
+
+  /** Navigate the way the keyboard has to: name the folder being left before the
+   * rows are replaced, so the new listing knows where to put focus. */
+  const keyLoad = (to: string) => {
+    leaving.current = data?.path || "";
+    load(to);
+  };
 
   const mkdir = async () => {
     if (!data?.path) return;
@@ -596,8 +1005,10 @@ function FolderBrowser({
       const r = await api<{ path: string }>("/api/mkdir", {
         json: { path: data.path, name: name.trim() },
       });
+      // Naming a brand-new folder in a prompt IS the deliberate choice, so this
+      // stays a pick: field filled, browser closed. (Nothing re-lists afterwards
+      // for that reason — the popover is already gone.)
       onPick(r.path);
-      load(r.path);
     } catch (err) {
       setError((err as Error).message);
     }
@@ -622,33 +1033,68 @@ function FolderBrowser({
           + Folder
         </button>
       </div>
-      <div id="rb-list">
+      <div id="rb-list" ref={listRef}>
         {data && (
-          <div
-            className={"rb-item rb-use" + (data.is_git ? " is-git" : "")}
+          /* Names the folder it means. Child rows are selectable now, so "use
+             this folder" on its own would be ambiguous about which folder — the
+             one you're standing in, or the one you just highlighted. */
+          <button
+            type="button"
+            className={
+              "rb-item rb-use" +
+              (data.is_git ? " is-git" : "") +
+              (selected === data.path ? " rb-sel" : "")
+            }
+            title={"Use " + data.path + " and close the browser"}
             onClick={() => onPick(data.path)}
           >
-            {data.is_git ? "✓ use this repo" : "use this folder"}
-          </div>
+            {(data.is_git ? "✓ use this repo — " : "use this folder — ") + leafName(data.path)}
+          </button>
         )}
         {(data?.entries || []).map((e) => (
-          <div key={e.path} className={"rb-item" + (e.is_git ? " is-git" : "")}>
-            <span className="rb-name" onClick={() => load(e.path)}>
-              {(e.is_git ? "📦 " : "📁 ") + e.name}
-            </span>
-            <button
-              type="button"
-              className="rb-pick"
-              onClick={(ev) => {
-                ev.stopPropagation();
-                onPick(e.path);
-              }}
-            >
-              select
-            </button>
-          </div>
+          // Rows are real buttons: they're the primary control now, so keyboard
+          // reach, Enter/Space activation and a focus ring should come from the
+          // platform rather than a div wearing tabIndex and a key handler.
+          // Selecting is idempotent, which is what makes the double click safe —
+          // its first click writes the same path the second one would, so there
+          // is no second visible effect to notice.
+          <button
+            key={e.path}
+            type="button"
+            className={
+              "rb-item" + (e.is_git ? " is-git" : "") + (selected === e.path ? " rb-sel" : "")
+            }
+            aria-pressed={selected === e.path}
+            title={e.path}
+            onClick={() => onSelect(e.path)}
+            onDoubleClick={() => {
+              onSelect(e.path);
+              load(e.path);
+            }}
+            onKeyDown={(ev) => {
+              // → is the keyboard's double click and ← is its ↑ button: a
+              // pointer has both gestures, and Shift+Tabbing out of a long list
+              // to reach the parent button is not a substitute.
+              if (ev.key === "ArrowRight") {
+                ev.preventDefault();
+                onSelect(e.path);
+                keyLoad(e.path);
+              } else if (ev.key === "ArrowLeft" && data?.parent) {
+                ev.preventDefault();
+                keyLoad(data.parent);
+              }
+            }}
+          >
+            <span className="rb-name">{(e.is_git ? "📦 " : "📁 ") + e.name}</span>
+          </button>
         ))}
       </div>
+      {/* "cancels", not "closes": Esc puts the folder the field started with
+          back, and a legend that said otherwise is what made passing through the
+          wrong tree cost anything. The Browse button's tooltip spells the pair
+          out; this line has to stay one line, since #repo-browser pays for its
+          height out of the list. */}
+      <p className="rb-hint">Click selects · double-click or → opens · ← up · Esc cancels</p>
       <p id="rb-error" className="error">{error}</p>
     </div>
   );

--- a/frontend/src/components/dialogs/SetupDialog.tsx
+++ b/frontend/src/components/dialogs/SetupDialog.tsx
@@ -4,44 +4,15 @@
  *   SetupChecklist  — the ①②③ checklist (also used by the grid empty state)
  *   DoctorList      — the check list (also used by Settings → Doctor)
  *   useDoctorWarn   — F8 warn-chip state (sidebar chip reads it)
- *   useDoctorAutoShow — headless: load + 5-min doctor probe, auto-open rules */
+ *   useDoctorAutoShow — headless: load + 5-min doctor probe, auto-open rules
+ *   shouldAutoShowSetup — the auto-open rule itself (pure, so it is tested) */
 
 import { useCallback, useEffect, useState } from "react";
 import { create } from "zustand";
 import { api } from "../../api/client";
+import { useConfig } from "../../state/queries";
 import { useUi } from "../../state/store";
 import { toast } from "../../lib/toast";
-
-// --- localStorage flags (same keys as vanilla) -------------------------------
-
-export function setupDismissed(): boolean {
-  try {
-    return localStorage.getItem("mf_setup_done") === "1";
-  } catch {
-    return false;
-  }
-}
-function dismissSetup() {
-  try {
-    localStorage.setItem("mf_setup_done", "1");
-  } catch {
-    /* storage unavailable */
-  }
-}
-function everCreated(): boolean {
-  try {
-    return localStorage.getItem("mf_ever_created") === "1";
-  } catch {
-    return false;
-  }
-}
-export function markEverCreated() {
-  try {
-    localStorage.setItem("mf_ever_created", "1");
-  } catch {
-    /* storage unavailable */
-  }
-}
 
 // --- Doctor model -------------------------------------------------------------
 
@@ -84,9 +55,44 @@ export function useDoctorWarn() {
 
 let setupAutoShown = false; // auto-open the setup dialog at most once per load
 
+/** Should a failing doctor probe pop the first-run checklist at this user?
+ *
+ * Only at one nothing knows to be past first-run. The checklist is a first-run
+ * surface, and a veteran was getting ambushed by it on load because some
+ * optional check went to warn — an agent CLI that declares no credential
+ * locations, say. For her the sidebar's doctor chip is the right amount of noise,
+ * and it is untouched by this.
+ *
+ * The server's flag is the entire rule. `onboarded` is undefined until
+ * /api/config lands, and an unknown flag opens nothing: the honest reading is
+ * "ask again in a moment", which is why the caller re-evaluates instead of
+ * latching on the first probe. There is deliberately no per-browser "already saw
+ * it" override — the two localStorage keys that used to sit here (mf_setup_done,
+ * mf_ever_created) had no writer left in this app, and the only thing a working
+ * one could have bought is a user with a missing tmux never being shown the
+ * checklist again. It should keep opening every load until either the tools are
+ * installed or a session exists. */
+export function shouldAutoShowSetup(opts: {
+  failing: boolean;
+  onboarded: boolean | undefined;
+}): boolean {
+  return opts.failing && opts.onboarded === false;
+}
+
 /** Headless doctor probe: on load + every 5 minutes (never on the 4s poll).
- * Failing required tools auto-open the setup checklist once per load. */
+ * Failing required tools auto-open the setup checklist once per load, for a
+ * first-run user only — see shouldAutoShowSetup.
+ *
+ * The onboarded flag comes from the shared config query rather than an argument
+ * because this hook is called from the app shell's very first render, before
+ * /api/config has resolved: a value handed in there would be `undefined` for the
+ * life of the probe, and so would a getQueryData() read inside the mount-once
+ * effect below. Subscribing costs no extra request (same query key, 60s
+ * staleTime) and makes the decision reactive, which is what the race needs. */
 export function useDoctorAutoShow() {
+  const { data: config } = useConfig();
+  const failing = useDoctorWarnStore((s) => s.failing);
+
   useEffect(() => {
     const check = async () => {
       try {
@@ -96,10 +102,6 @@ export function useDoctorAutoShow() {
       } catch {
         /* unreachable backend is the conn-banner's job */
       }
-      if (useDoctorWarnStore.getState().failing && !setupAutoShown) {
-        setupAutoShown = true;
-        useUi.getState().openDialogFor("setup");
-      }
     };
     check();
     const t = setInterval(() => {
@@ -107,10 +109,22 @@ export function useDoctorAutoShow() {
     }, 300000);
     return () => clearInterval(t);
   }, []);
+
+  // Whichever of the probe and the config query lands second decides. Doing it
+  // here rather than inside check() is what stops a genuinely new user from
+  // waiting five minutes for the next probe just because doctor answered before
+  // the onboarded flag did.
+  useEffect(() => {
+    if (setupAutoShown) return;
+    const show = shouldAutoShowSetup({ failing, onboarded: config?.onboarded });
+    if (!show) return;
+    setupAutoShown = true;
+    useUi.getState().openDialogFor("setup");
+  }, [failing, config?.onboarded]);
 }
 
 /** The doctor check list (setup panel + Settings → Doctor). */
-export function DoctorList({ reprobeKey, autoCollapse }: { reprobeKey?: number; autoCollapse?: boolean }) {
+export function DoctorList({ reprobeKey }: { reprobeKey?: number }) {
   const [doctor, setDoctor] = useState<DoctorPayload | null>(lastDoctor);
   const [error, setError] = useState("");
 
@@ -124,7 +138,6 @@ export function DoctorList({ reprobeKey, autoCollapse }: { reprobeKey?: number; 
         lastDoctor = d;
         setDoctor(d);
         setError("");
-        if (autoCollapse && d.ok && everCreated()) dismissSetup();
       } catch (e) {
         if (live) setError((e as Error).message);
       }
@@ -132,7 +145,7 @@ export function DoctorList({ reprobeKey, autoCollapse }: { reprobeKey?: number; 
     return () => {
       live = false;
     };
-  }, [reprobeKey, autoCollapse]);
+  }, [reprobeKey]);
 
   if (error) return <p className="error">doctor failed: {error}</p>;
   if (!doctor) return <p className="muted">Checking dependencies…</p>;
@@ -202,8 +215,15 @@ export async function runGithubTest(): Promise<TestState> {
   }
 }
 
-/** The ①②③ checklist (empty-state card + the Setup dialog). */
-export function SetupChecklist({ standalone }: { standalone?: boolean }) {
+/** The ①②③ checklist (empty-state card + the Setup dialog).
+ *
+ * `standalone` is the grid's first-run card identifying itself, and nothing
+ * renders differently for it: it used to switch on a self-dismissal that could
+ * never fire, since the card exists only for a user the server calls not
+ * onboarded and the dismissal asked for the opposite. The prop is still accepted
+ * because TerminalGrid passes it, and an unknown prop there is a type error that
+ * would take the whole "Three steps to a running agent" card down. */
+export function SetupChecklist(_props: { standalone?: boolean }) {
   const [reprobeKey, setReprobeKey] = useState(0);
   const [gh, setGh] = useState<TestState>(idleTest);
   const [sc, setSc] = useState<TestState>(idleTest);
@@ -277,7 +297,7 @@ export function SetupChecklist({ standalone }: { standalone?: boolean }) {
           <span className="setup-num">①</span> Dependencies
         </h3>
         <div className="setup-doctor">
-          <DoctorList reprobeKey={reprobeKey} autoCollapse={!!standalone} />
+          <DoctorList reprobeKey={reprobeKey} />
         </div>
         <div className="setup-actions">
           <button type="button" className="setup-recheck" onClick={(e) => { e.stopPropagation(); setReprobeKey((k) => k + 1); }}>

--- a/frontend/src/components/dialogs/TodoDialog.tsx
+++ b/frontend/src/components/dialogs/TodoDialog.tsx
@@ -27,6 +27,14 @@ export function TodoDialog() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const editCancelled = useRef(false);
+  // Mirrored in a ref so `load` can stay identity-stable: if it changed on every
+  // edit, the polling effect below would re-run and re-focus the Add box, which
+  // blurs (and so commits) the inline edit the instant it opens.
+  const editingRef = useRef<string | null>(null);
+  const setEditing = useCallback((id: string | null) => {
+    editingRef.current = id;
+    setEditingId(id);
+  }, []);
 
   const save = useCallback(async (next: Todo[]) => {
     setTodos(next);
@@ -46,7 +54,7 @@ export function TodoDialog() {
   const load = useCallback(async () => {
     // Don't clobber a drag in flight, text being typed into the Add box, or an
     // inline edit in progress.
-    if (dragging.current || document.activeElement === addRef.current || editingId) return;
+    if (dragging.current || document.activeElement === addRef.current || editingRef.current) return;
     try {
       const r = await api<{ todos?: Todo[] }>("/api/assistant/todos");
       setTodos(r.todos || []);
@@ -54,7 +62,15 @@ export function TodoDialog() {
     } catch {
       setState("load failed");
     }
-  }, [editingId]);
+  }, []);
+
+  // Focus the Add box once per opening — never on an unrelated re-render, or it
+  // would yank focus out of an inline edit.
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => addRef.current?.focus(), 0);
+    return () => clearTimeout(t);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -62,7 +78,6 @@ export function TodoDialog() {
     const poll = setInterval(() => {
       if (!document.hidden) load();
     }, 4000);
-    setTimeout(() => addRef.current?.focus(), 0);
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") closeDialog();
     };
@@ -83,14 +98,14 @@ export function TodoDialog() {
   };
 
   const startEdit = (t: Todo) => {
-    setEditingId(t.id);
+    setEditing(t.id);
     setEditDraft(t.text);
     editCancelled.current = false;
   };
 
   const commitEdit = (id: string) => {
     if (editCancelled.current) return;
-    setEditingId(null);
+    setEditing(null);
     const text = editDraft.trim();
     const cur = todos.find((x) => x.id === id);
     if (!cur || !text || text === cur.text) return;
@@ -99,7 +114,7 @@ export function TodoDialog() {
 
   const cancelEdit = () => {
     editCancelled.current = true;
-    setEditingId(null);
+    setEditing(null);
   };
 
   return (

--- a/frontend/src/components/sidebar/Sidebar.css
+++ b/frontend/src/components/sidebar/Sidebar.css
@@ -112,6 +112,16 @@ body.sidebar-collapsed .sidebar-resizer {
   display: none;
 }
 
+/* Nothing to resize while a dialog owns the screen, either. The .modal backdrop
+   is fixed with NO z-index (see Pane.css), so this handle's z-index: 40 paints
+   its accent line straight over the dimmed page and still answers :hover — and
+   the drag still works through the backdrop. Keyed off the overlay element
+   rather than a body class so every dialog is covered, including ones that
+   never touch the store's openDialog (command palette, welcome tour). */
+body:has(.modal:not(.hidden)) .sidebar-resizer {
+  display: none;
+}
+
 /* Tools row: session count on the left, a subtle keyboard-shortcuts link on
    the right (status-bar-style help affordance). */
 #sidebar-footer .foot-row.foot-tools {

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -318,3 +318,35 @@ export const useUi = create<UiState>((set, get) => ({
 export function displayName(title: string): string {
   return useUi.getState().aliases[title] || title;
 }
+
+export type TourDecision = "open" | "skip" | "wait";
+
+/** Should the welcome walkthrough open itself on this load?
+ *
+ * `tourDone` alone used to answer this, which is how a returning user who
+ * cleared their browser storage — or opened the desktop app on a second machine
+ * — got the twelve slides replayed at them. The server already knows better
+ * (`general.onboarded`, from /api/config: true once a session has ever
+ * existed), so it gets the deciding vote.
+ *
+ * `onboarded` is undefined until that request resolves, and the answer then is
+ * "wait", never "open": popping the tour on a guess is the exact bug. The local
+ * flags are still consulted first, so someone who has finished the tour or
+ * turned hints off is left alone without waiting on the network.
+ *
+ * A returning user has by definition created a session, so the server's flag
+ * covers the case that matters. What it does not cover is someone who watched the
+ * slides, started nothing, and then opened a second device — they see the tour
+ * again. That is the accepted price of never reporting the tour itself: the
+ * frontend used to POST general.onboarded when the slideshow closed, and since
+ * that flag means "this user is running sessions", it silently retired the grid's
+ * setup card and the dependency checklist for a user who had neither. */
+export function tourDecision(opts: {
+  tourDone: boolean;
+  hintsEnabled: boolean;
+  onboarded: boolean | undefined;
+}): TourDecision {
+  if (opts.tourDone || !opts.hintsEnabled) return "skip";
+  if (opts.onboarded === undefined) return "wait";
+  return opts.onboarded ? "skip" : "open";
+}

--- a/frontend/src/styles/theme-light.css
+++ b/frontend/src/styles/theme-light.css
@@ -24,12 +24,17 @@
   background: rgba(0, 0, 0, 0.05);
 }
 
-/* Light-accent text is too faint on white — use the deeper accent variant. */
+/* Light-accent text is too faint on white — use the deeper accent variant. The
+   folder-suggestion chips take it for both states: a git chip and the chip that
+   filled the field read the same colour on light, and the picked one is told
+   apart by its accent border and tinted fill instead. */
 .light .stagechip.s-agent,
 .light .split-diff .sd-file,
 .light .diff-toolbar .diffstat.file,
 .light .rb-item.is-git,
 .light .rb-use.is-git,
+.light .nf-suggest .nt-chip.is-git,
+.light .nf-suggest .nt-chip.active,
 .light .ws-badge.active {
   color: var(--accent-deep);
 }

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -279,6 +279,17 @@ class TestLocalModeEnvExport:
         # The double-launch guard probes the real port — a dev machine with a
         # live server on 8765 would short-circuit main() before uvicorn.run.
         monkeypatch.setattr(run, "_port_squatter", lambda host, port: "")
+        # main() also starts a preflight *daemon thread* (the first-run report /
+        # the short check list). Left alone it walks this machine for real: the
+        # settings store is a fresh tmp file, so every test here looks like a
+        # first run, and the report shells out for the whole doctor and scans the
+        # developer's real home for repo suggestions — then prints the banner to
+        # a stdout capture that has already been torn down. Give the thread
+        # nothing real to do (same isolation as tests/unit/test_init_wizard.py).
+        monkeypatch.setattr(run, "_is_onboarded", lambda: True)
+        _ok = Check(id="stub", label="stub", status="ok")
+        for _name in ("check_git", "check_tmux", "check_agent_cli"):
+            monkeypatch.setattr(doctor, _name, lambda: _ok)
         return calls
 
     def test_default_mode_is_local_bound_loopback(self, uvicorn_spy, monkeypatch):

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -10,6 +10,8 @@ from fastapi.testclient import TestClient
 
 from backend import doctor
 from backend.doctor import Check
+from backend.providers import claude as claude_provider
+from backend.providers.base import BaseProvider
 
 
 @pytest.fixture(autouse=True)
@@ -283,10 +285,24 @@ class TestAgentCli:
 class TestAgentAuth:
     @pytest.fixture(autouse=True)
     def _isolated_home(self, monkeypatch, tmp_path):
-        # Point every credential candidate away from the real user's login.
+        # Point every credential candidate away from the real user's login. The
+        # non-Anthropic keys matter as much as ANTHROPIC_API_KEY now that the
+        # check asks each provider: aider counts any of these as a login, so a
+        # developer with OPENAI_API_KEY exported in their shell would see the
+        # "looks logged out" tests pass for the wrong reason.
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "DEEPSEEK_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        # A Mac running the suite has a real Claude login in its Keychain, which
+        # is genuine evidence — pin it off so the verdicts under test come only
+        # from the files/env this fixture controls.
+        monkeypatch.setattr(claude_provider, "_keychain_login_evidence", lambda: False)
         monkeypatch.setattr(doctor, "_default_provider_name", lambda: "claude")
         monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "claude")
 
@@ -311,10 +327,135 @@ class TestAgentAuth:
         assert c.status == "warn"
         assert "run `claude` once" in c.fix
 
-    def test_non_claude_provider_is_info(self, monkeypatch):
+    def test_provider_with_declared_credentials_gets_a_real_verdict(self, monkeypatch):
+        # aider names the API-key env vars it authenticates with, so it is
+        # probeable: no key set and the CLI on PATH is a genuine "looks logged
+        # out" warn, not the old "no auth probe for aider — skipped" shrug.
         monkeypatch.setattr(doctor, "_default_provider_name", lambda: "aider")
         monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "aider")
-        assert doctor.check_agent_auth().status == "info"
+        monkeypatch.setattr(doctor.shutil, "which", _which({"aider": "/usr/bin/aider"}))
+        c = doctor.check_agent_auth()
+        assert c.status == "warn"
+        assert "no sign of a login" in c.detail
+
+    def test_codex_credential_file_is_ok(self, monkeypatch, tmp_path):
+        # A provider that declares credential FILES (codex: ~/.codex/auth.json)
+        # is answered by the file existing — no env key needed.
+        (tmp_path / ".codex").mkdir()
+        (tmp_path / ".codex" / "auth.json").write_text("{}")
+        monkeypatch.setattr(doctor, "_default_provider_name", lambda: "codex")
+        monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "codex")
+        monkeypatch.setattr(doctor.shutil, "which", _which({"codex": "/usr/bin/codex"}))
+        c = doctor.check_agent_auth()
+        assert c.status == "ok"
+        assert "auth.json" in c.detail
+
+    def test_provider_declaring_no_credential_sources_never_nags(self, monkeypatch):
+        # goose keeps its credentials somewhere MindFlock does not read, so
+        # finding nothing proves nothing: info with no fix, even with the CLI off
+        # PATH, because a warn here could never be cleared.
+        monkeypatch.setattr(doctor, "_default_provider_name", lambda: "goose")
+        monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "goose")
+        monkeypatch.setattr(doctor.shutil, "which", _which({}))
+        c = doctor.check_agent_auth()
+        assert c.status == "info"
+        assert "no login probe" in c.detail
+        assert c.fix == "" and c.cmd == ""
+
+    def test_login_fix_uses_the_providers_own_login_command(self, monkeypatch):
+        # codex logs in with `codex login`, so the fix says exactly that —
+        # "run `codex login` once to log in" would be redundant — and cmd carries
+        # it so `doctor --fix` can offer to run it.
+        monkeypatch.setattr(doctor, "_default_provider_name", lambda: "codex")
+        monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "codex")
+        monkeypatch.setattr(doctor.shutil, "which", _which({"codex": "/usr/bin/codex"}))
+        c = doctor.check_agent_auth()
+        assert c.status == "warn"
+        assert c.fix == "run `codex login`"
+        assert c.cmd == "codex login"
+
+    def test_inherited_login_command_is_never_offered_to_run(self, monkeypatch):
+        # aider names the API keys it reads but has no login flow, so
+        # BaseProvider.login_command hands back the bare program name. Offering
+        # THAT is how `doctor --fix` and the init wizard came to print
+        # "run `aider`?" and hand their terminal to aider's own REPL, which
+        # authenticates nothing: cmd must stay empty while the fix line still
+        # says what would clear the warn.
+        monkeypatch.setattr(doctor, "_default_provider_name", lambda: "aider")
+        monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "aider")
+        monkeypatch.setattr(doctor.shutil, "which", _which({"aider": "/usr/bin/aider"}))
+        c = doctor.check_agent_auth()
+        assert c.status == "warn"
+        assert c.cmd == ""
+        assert "run `aider`" not in c.fix
+        assert "ANTHROPIC_API_KEY" in c.fix
+
+    def test_claude_still_offers_its_first_run_sign_in(self, monkeypatch):
+        # The other side of the same rule: ClaudeProvider overrides
+        # login_command deliberately because `claude` prompts to sign in on
+        # first run, so running it IS the login flow and stays runnable.
+        monkeypatch.setattr(
+            doctor.shutil, "which", _which({"claude": "/usr/bin/claude"})
+        )
+        c = doctor.check_agent_auth()
+        assert c.status == "warn"
+        assert c.cmd == "claude"
+        assert "run `claude` once" in c.fix
+
+    def test_config_declared_bare_command_is_still_offered(self, monkeypatch):
+        # A config that names its login command as data means it even when the
+        # command is just the program (antigravity signs in through Google on
+        # first run), so it is offered — the gate is "declared", not "has args".
+        provider = types.SimpleNamespace(
+            cfg=types.SimpleNamespace(
+                login_command="agy", auth_env=("AGY_KEY",), auth_files=()
+            ),
+            auth_evidence=lambda: "",
+        )
+        monkeypatch.setattr(doctor, "_default_provider_name", lambda: "antigravity")
+        monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "agy")
+        monkeypatch.setattr(doctor, "_agent_provider", lambda name: provider)
+        monkeypatch.setattr(doctor.shutil, "which", _which({"agy": "/usr/bin/agy"}))
+        c = doctor.check_agent_auth()
+        assert c.status == "warn"
+        assert c.fix == "run `agy` once to log in"
+        assert c.cmd == "agy"
+
+    def test_hand_written_provider_declares_by_overriding(self, monkeypatch):
+        # Classes carrying no cfg (claude's shape) declare a login flow by
+        # overriding the base method: the override is offered, and a sibling
+        # that only overrides the auth probe gets no runnable command at all.
+        class _Declares(BaseProvider):
+            name = "custom"
+            program_aliases = ("custom",)
+
+            def auth_evidence(self) -> str:
+                return ""
+
+            def login_command(self):
+                return "custom signin"
+
+        class _Inherits(BaseProvider):
+            name = "custom"
+            program_aliases = ("custom",)
+
+            def auth_evidence(self) -> str:
+                return ""
+
+        monkeypatch.setattr(doctor, "_default_provider_name", lambda: "custom")
+        monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "custom")
+        monkeypatch.setattr(
+            doctor.shutil, "which", _which({"custom": "/usr/bin/custom"})
+        )
+        monkeypatch.setattr(doctor, "_agent_provider", lambda name: _Declares())
+        declared = doctor.check_agent_auth()
+        monkeypatch.setattr(doctor, "_agent_provider", lambda name: _Inherits())
+        inherited = doctor.check_agent_auth()
+        assert declared.cmd == "custom signin"
+        assert declared.fix == "run `custom signin` once to log in"
+        assert inherited.status == "warn"
+        assert inherited.cmd == ""
+        assert inherited.fix == "log `custom` in from inside the CLI itself"
 
     def test_cli_not_installed_cannot_probe_auth(self, monkeypatch):
         # claude selected but not on PATH and no credential evidence: auth is
@@ -323,6 +464,15 @@ class TestAgentAuth:
         c = doctor.check_agent_auth()
         assert c.status == "warn"
         assert "cannot probe auth" in c.detail
+
+    def test_unregistered_provider_cannot_be_probed(self, monkeypatch):
+        # A provider name left in settings after its TOML was deleted: there is
+        # nobody to ask, so say so and stay out of the way.
+        monkeypatch.setattr(doctor, "_default_provider_name", lambda: "ghost-cli")
+        monkeypatch.setattr(doctor, "_resolve_agent_binary", lambda name: "ghost-cli")
+        c = doctor.check_agent_auth()
+        assert c.status == "info"
+        assert "not a registered provider" in c.detail
 
 
 class TestOptionalDeps:

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -255,9 +255,20 @@ def test_app_js_budget_lock_overlay_wired():
 
 
 def test_app_js_first_run_gate_uses_onboarded():
+    """The server's ``onboarded`` flag is the whole first-run gate.
+
+    It used to be one of three rival signals: this bundle also carried
+    ``mf_setup_done`` and ``mf_ever_created``, per-browser flags that let a
+    cleared profile or a second device replay first-run at a veteran — and whose
+    only writer had already been deleted, so the checklist's own dismissal could
+    never fire either. Both keys are gone; asserting they stay gone is what keeps
+    a browser-local flag from creeping back in beside the server's answer.
+    """
     js = client.get("/app.js").text
     assert "onboarded" in js
-    assert "mf_setup_done" in js
+    assert "shouldAutoShowSetup" in js  # the one gate, exported for its own test
+    for retired in ("mf_setup_done", "mf_ever_created"):
+        assert retired not in js, "a per-browser first-run flag is back: %s" % retired
 
 
 def test_style_has_budget_lock_rules():

--- a/tests/unit/test_frontend_sidebar_resize.py
+++ b/tests/unit/test_frontend_sidebar_resize.py
@@ -69,6 +69,16 @@ def test_collapsed_sidebar_hides_the_handle():
     assert "display: none" in _rule(css, "body.sidebar-collapsed .sidebar-resizer")
 
 
+def test_open_dialog_hides_the_handle():
+    """The .modal backdrop is fixed with no z-index, so the handle's z-index: 40
+    painted its accent line over every open dialog and kept answering :hover (the
+    drag worked through the backdrop too). Hidden while any modal is mounted."""
+    css = client.get("/style.css").text
+    assert "display: none" in _rule(
+        css, "body:has(.modal:not(.hidden)) .sidebar-resizer"
+    )
+
+
 def test_drag_locks_the_cursor_and_selection():
     css = client.get("/style.css").text
     dragging = _rule(css, "body.sidebar-resizing,\nbody.sidebar-resizing *")

--- a/tests/unit/test_init_wizard.py
+++ b/tests/unit/test_init_wizard.py
@@ -1,0 +1,814 @@
+"""Guided first run (`mindflock init`): the non-interactive report, the wizard's
+steps, the non-TTY degradation, the repo picker's three accepted answers, and
+the `serve --setup` wiring."""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+import backend.web.run as run
+from backend import cli, doctor, init_wizard
+from backend.config import settings as settings_mod
+from backend.doctor import Check
+
+_TMUX_MISSING = Check(
+    "tmux",
+    "tmux",
+    "fail",
+    "not found on PATH — sessions cannot start without it",
+    "sudo apt install tmux",
+    cmd="sudo apt install tmux",
+)
+_GIT_OK = Check("git", "git", "ok", "git version 2.43.0")
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings(tmp_path, monkeypatch):
+    """The wizard WRITES settings (general.last_repo_path), so every test in this
+    module must be pointed at a throwaway store — otherwise running the suite
+    edits the developer's own ~/.mindflock/settings.json."""
+    monkeypatch.setenv("MINDFLOCK_SETTINGS_FILE", str(tmp_path / "settings.json"))
+
+
+@pytest.fixture()
+def no_prompts(monkeypatch):
+    """Any call to input() fails the test: the paths that use this fixture claim
+    to be non-interactive, and a prompt there is a hang in production."""
+    monkeypatch.setattr(
+        "builtins.input", lambda prompt="": pytest.fail("must not prompt")
+    )
+
+
+def _candidates(monkeypatch, *entries):
+    """Pin the suggestion list so no test depends on what is on this machine."""
+    monkeypatch.setattr(init_wizard, "_candidate_repos", lambda limit=8: list(entries))
+
+
+def _entry(path, is_git=True, source="recent"):
+    return {
+        "path": str(path),
+        "name": os.path.basename(str(path)),
+        "is_git": is_git,
+        "source": source,
+    }
+
+
+def _answers(monkeypatch, *replies):
+    """Feed the picker a scripted stdin, one reply per prompt."""
+    it = iter(replies)
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(it))
+
+
+def _git_repo(path):
+    """A real repo, not a bare ``.git`` directory: the wizard asks git itself
+    whether a folder is a work tree, and an empty ``.git`` is not one."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    return path
+
+
+def _eventually(pred, timeout=5.0):
+    """Wait for something a background thread does. run.py runs its first-run
+    report and its dependency checks off the bind path on purpose, so a test that
+    asserts on either has to wait rather than assume main() already did it."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pred():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _drain(capsys, needle, *, err=False, timeout=5.0):
+    """Captured output, accumulated until ``needle`` shows up or time runs out.
+
+    A single ``capsys.readouterr()`` can run before the preflight thread has
+    written anything; reading in a loop and concatenating rebuilds the stream in
+    order. Returns the requested stream only — the other one is drained too, so
+    ask for the one you assert on."""
+    out = ""
+    errs = ""
+    deadline = time.time() + timeout
+    while True:
+        cap = capsys.readouterr()
+        out += cap.out
+        errs += cap.err
+        text = errs if err else out
+        if needle in text or time.time() > deadline:
+            return text
+        time.sleep(0.01)
+
+
+@pytest.fixture()
+def uvicorn_spy(monkeypatch):
+    """run.main() without a bind: records the uvicorn.run kwargs instead.
+
+    The double-launch guard probes the real port — a dev machine with a live
+    server on 8765 would short-circuit main() before uvicorn.run."""
+    import uvicorn
+
+    calls = []
+    monkeypatch.setattr(uvicorn, "run", lambda app, **kw: calls.append(kw))
+    monkeypatch.setattr(run, "_port_squatter", lambda host, port: "")
+    monkeypatch.setenv("CS_WEB_MODE", "")
+    monkeypatch.setenv("UVICORN_PORT", "")
+    return calls
+
+
+@pytest.fixture()
+def quiet_checks(monkeypatch):
+    """Keep run.py's preflight off this machine's real tmux/agent CLI: it runs on
+    a daemon thread that can outlive the test, and a failing check there writes to
+    a stderr capture that has already been torn down."""
+    for name in ("check_git", "check_tmux", "check_agent_cli"):
+        monkeypatch.setattr(doctor, name, lambda: _GIT_OK)
+
+
+class TestReport:
+    def test_missing_dependency_and_its_fix_are_named(
+        self, monkeypatch, capsys, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK, _TMUX_MISSING])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        init_wizard.report()
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "fix: sudo apt install tmux" in out
+        assert "/home/me/code/foo" in out
+        assert 'mindflock new /home/me/code/foo -p "' in out
+        assert "mindflock init" in out
+        # A healthy check is exactly what a first-run summary shouldn't spend a
+        # line on — the report is about what needs doing.
+        assert "git version 2.43.0" not in out
+
+    def test_healthy_machine_gets_one_line_not_a_table(
+        self, monkeypatch, capsys, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        init_wizard.report()
+        out = capsys.readouterr().out
+        assert "Dependencies look good" in out
+        assert "✗" not in out and "!" not in out
+
+    def test_doctor_that_raises_still_prints_the_next_commands(
+        self, monkeypatch, capsys, no_prompts
+    ):
+        def _boom():
+            raise RuntimeError("doctor blew up")
+
+        monkeypatch.setattr(doctor, "run_checks", _boom)
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        init_wizard.report()  # must not raise
+        out = capsys.readouterr().out
+        assert "Dependency check unavailable" in out
+        assert "mindflock new /home/me/code/foo" in out
+
+    def test_serving_drops_the_serve_line(self, monkeypatch, capsys, no_prompts):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        init_wizard.report()
+        assert "mindflock serve" in capsys.readouterr().out
+        init_wizard.report(serving=True)
+        assert "mindflock serve" not in capsys.readouterr().out
+
+    def test_non_git_folder_is_flagged_not_hidden(
+        self, monkeypatch, capsys, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry("/home/me/notes", is_git=False))
+        init_wizard.report()
+        assert "no git yet" in capsys.readouterr().out
+
+    def test_writes_to_the_given_stream(self, monkeypatch, no_prompts):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_TMUX_MISSING])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        buf = io.StringIO()
+        init_wizard.report(buf)
+        assert "sudo apt install tmux" in buf.getvalue()
+
+    def test_a_broken_stream_never_raises(self, monkeypatch, no_prompts):
+        # run.py prints this on the boot path: an unwritable stream must cost the
+        # hint, never the server.
+        class _Broken:
+            def write(self, _text):
+                raise OSError("stream is gone")
+
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_TMUX_MISSING])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        init_wizard.report(_Broken())
+
+    def test_report_is_the_one_layer_that_degrades(self, monkeypatch):
+        # Every caller (run.py's boot path, the non-TTY wizard) relies on this
+        # swallow and keeps no second copy of the wording, so a printer that blows
+        # up mid-way has to end here.
+        def _boom(out, *, serving):
+            raise RuntimeError("printer exploded")
+
+        monkeypatch.setattr(init_wizard, "_print_report", _boom)
+        init_wizard.report()
+
+
+class TestSharedDoctorPrinting:
+    """The glyph table has exactly one implementation (cli.print_checks), so the
+    doctor command and the wizard can never drift into two dialects of it."""
+
+    @pytest.fixture()
+    def printed(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            cli, "print_checks", lambda checks, stream=None: calls.append(list(checks))
+        )
+        return calls
+
+    def test_doctor_command_uses_it(self, monkeypatch, printed):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        assert cli.main(["doctor"]) == 0
+        assert printed == [[_GIT_OK]]
+
+    def test_report_uses_it(self, monkeypatch, printed, no_prompts):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_TMUX_MISSING])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        init_wizard.report()
+        assert printed == [[_TMUX_MISSING]]
+
+    def test_wizard_uses_it(self, monkeypatch, printed, tmp_path, no_prompts):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry(tmp_path))
+        assert init_wizard.run(assume_yes=True) == 0
+        assert printed == [[_GIT_OK]]
+
+    def test_empty_list_prints_nothing(self, capsys):
+        cli.print_checks([])
+        assert capsys.readouterr().out == ""
+
+
+class TestNonTtyDegradation:
+    def test_piped_stdin_reports_instead_of_prompting(
+        self, monkeypatch, capsys, no_prompts
+    ):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_TMUX_MISSING])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        assert init_wizard.run() == 0
+        out = capsys.readouterr().out
+        assert "First run" in out
+        assert "run `mindflock init` in a terminal" in out
+
+
+class TestServingFlag:
+    """`mindflock serve --setup` runs the wizard inside the process that binds the
+    port a moment later, so neither of the wizard's two exits may sign off by
+    telling the user to start a server."""
+
+    def test_a_non_tty_setup_run_omits_the_start_the_server_line(
+        self, monkeypatch, capsys, no_prompts
+    ):
+        # The desktop app's spawn, an installer script and CI all land here: stdin
+        # can't be prompted, so run() degrades to the report — which without the
+        # flag prints "mindflock serve  # start the server" one breath before this
+        # same process binds it.
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry("/home/me/code/foo"))
+        assert init_wizard.run(serving=True) == 0
+        out = capsys.readouterr().out
+        assert "mindflock serve" not in out
+        assert "mindflock new /home/me/code/foo" in out
+
+    def test_a_terminal_setup_run_ends_on_the_session_command(
+        self, monkeypatch, capsys, tmp_path, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry(_git_repo(tmp_path / "webapp")))
+        assert init_wizard.run(assume_yes=True, serving=True) == 0
+        out = capsys.readouterr().out
+        assert "You're set. One command:" in out
+        assert "mindflock serve" not in out
+        assert 'mindflock new %s -p "' % (tmp_path / "webapp") in out
+
+    def test_plain_init_still_names_the_server_command(
+        self, monkeypatch, capsys, tmp_path, no_prompts
+    ):
+        # `mindflock init` has no server behind it, so dropping the serve line
+        # there would leave the setup with no way to finish.
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry(_git_repo(tmp_path / "webapp")))
+        assert init_wizard.run(assume_yes=True) == 0
+        out = capsys.readouterr().out
+        assert "You're set. Two commands:" in out
+        assert "mindflock serve" in out
+
+
+class TestAssumeYes:
+    def test_takes_the_top_suggestion_and_remembers_it(
+        self, monkeypatch, capsys, tmp_path, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        repo = _git_repo(tmp_path / "webapp")
+        _candidates(monkeypatch, _entry(repo), _entry(tmp_path / "other"))
+        patches = []
+        monkeypatch.setattr(
+            settings_mod, "update_settings", lambda **kw: patches.append(kw)
+        )
+        assert init_wizard.run(assume_yes=True) == 0
+        assert patches == [{"general": {"last_repo_path": str(repo)}}]
+        out = capsys.readouterr().out
+        assert "Working folder: %s" % repo in out
+        assert 'mindflock new %s -p "' % repo in out
+
+    def test_the_choice_survives_into_the_settings_store(
+        self, monkeypatch, tmp_path, no_prompts
+    ):
+        # The round trip through the real store (isolated by
+        # MINDFLOCK_SETTINGS_FILE): general.last_repo_path is what the next New
+        # Session dialog and the /api/repos/suggest ranking read.
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        repo = _git_repo(tmp_path / "webapp")
+        _candidates(monkeypatch, _entry(repo))
+        assert init_wizard.run(assume_yes=True) == 0
+        assert settings_mod.load_settings().general.last_repo_path == str(repo)
+        assert init_wizard._remembered_repo() == str(repo)
+
+    def test_never_runs_an_installer_unwatched(
+        self, monkeypatch, capsys, tmp_path, no_prompts
+    ):
+        # --yes means "don't ask me", not "install things nobody is watching":
+        # the fix lines are printed and the exit code stays honest.
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_TMUX_MISSING])
+        monkeypatch.setattr(
+            cli, "_fix_checks", lambda checks: pytest.fail("--yes must not run fixes")
+        )
+        _candidates(monkeypatch, _entry(tmp_path))
+        assert init_wizard.run(assume_yes=True) == 1
+        out = capsys.readouterr().out
+        assert "sudo apt install tmux" in out
+        assert "never runs an installer unwatched" in out
+        assert "1 required dependency still missing" in out
+
+    def test_a_non_git_folder_is_said_out_loud(
+        self, monkeypatch, capsys, tmp_path, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        plain = tmp_path / "notes"
+        plain.mkdir()
+        _candidates(monkeypatch, _entry(plain, is_git=False, source="cwd"))
+        assert init_wizard.run(assume_yes=True) == 0
+        out = capsys.readouterr().out
+        assert "Not a git repo" in out
+        assert "Create a git repo in this folder" in out
+
+    def test_no_candidates_still_finishes_with_a_usable_command(
+        self, monkeypatch, capsys, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch)
+        assert init_wizard.run(assume_yes=True) == 0
+        out = capsys.readouterr().out
+        assert "No folder picked" in out
+        assert "mindflock new /path/to/repo" in out
+
+    def test_an_unwritable_settings_store_is_not_a_setup_failure(
+        self, monkeypatch, tmp_path, no_prompts
+    ):
+        def _boom(**kw):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        monkeypatch.setattr(settings_mod, "update_settings", _boom)
+        _candidates(monkeypatch, _entry(tmp_path))
+        assert init_wizard.run(assume_yes=True) == 0
+
+
+class TestFixLoopReuse:
+    """Installing tmux, installing the agent CLI and logging it in are all doctor
+    checks carrying runnable commands, so the wizard hands the whole set to the
+    doctor's own fix loop rather than re-implementing any of them."""
+
+    def test_interactive_run_delegates_to_the_doctor_fix_loop(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_TMUX_MISSING])
+        seen = []
+
+        def _fix(checks):
+            seen.append(list(checks))
+            return [Check("tmux", "tmux", "ok", "tmux 3.4")]
+
+        monkeypatch.setattr(cli, "_fix_checks", _fix)
+        _candidates(monkeypatch, _entry(tmp_path))
+        _answers(monkeypatch, "")  # Enter at the repo prompt = top suggestion
+        # The re-probed 'ok' from the fix loop is what decides the exit code.
+        assert init_wizard.run() == 0
+        assert seen == [[_TMUX_MISSING]]
+
+
+class TestRepoPicker:
+    def _list(self, tmp_path):
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        for p in (first, second):
+            (p / ".git").mkdir(parents=True)
+        return [_entry(first), _entry(second, source="nearby")]
+
+    def test_number_picks_from_the_list(self, monkeypatch, tmp_path):
+        cands = self._list(tmp_path)
+        _answers(monkeypatch, "2")
+        assert init_wizard._pick_repo(cands) == cands[1]["path"]
+
+    def test_empty_keeps_the_top_suggestion(self, monkeypatch, tmp_path):
+        cands = self._list(tmp_path)
+        _answers(monkeypatch, "")
+        assert init_wizard._pick_repo(cands) == cands[0]["path"]
+
+    def test_typed_path_wins_over_the_list(self, monkeypatch, tmp_path):
+        typed = tmp_path / "elsewhere"
+        typed.mkdir()
+        _answers(monkeypatch, str(typed))
+        assert init_wizard._pick_repo(self._list(tmp_path)) == os.path.realpath(typed)
+
+    def test_typed_path_expands_a_tilde(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "code").mkdir()
+        _answers(monkeypatch, "~/code")
+        assert init_wizard._pick_repo(self._list(tmp_path)) == os.path.realpath(
+            tmp_path / "code"
+        )
+
+    def test_out_of_range_number_asks_again(self, monkeypatch, capsys, tmp_path):
+        cands = self._list(tmp_path)
+        _answers(monkeypatch, "9", "1")
+        assert init_wizard._pick_repo(cands) == cands[0]["path"]
+        assert "there is no 9 in that list" in capsys.readouterr().out
+
+    def test_path_that_does_not_exist_asks_again(self, monkeypatch, capsys, tmp_path):
+        cands = self._list(tmp_path)
+        _answers(monkeypatch, str(tmp_path / "nope"), "2")
+        assert init_wizard._pick_repo(cands) == cands[1]["path"]
+        assert "is not a folder yet" in capsys.readouterr().out
+
+    def test_nonsense_forever_gives_up_on_the_top_suggestion(
+        self, monkeypatch, tmp_path
+    ):
+        # A scripted stdin that never answers usefully must not trap the wizard.
+        cands = self._list(tmp_path)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "/nope/nowhere")
+        assert init_wizard._pick_repo(cands) == cands[0]["path"]
+
+    def test_eof_keeps_the_top_suggestion(self, monkeypatch, tmp_path):
+        def _eof(prompt=""):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", _eof)
+        cands = self._list(tmp_path)
+        assert init_wizard._pick_repo(cands) == cands[0]["path"]
+
+    def test_assume_yes_takes_the_top_without_asking(
+        self, monkeypatch, tmp_path, no_prompts
+    ):
+        cands = self._list(tmp_path)
+        assert init_wizard._pick_repo(cands, assume_yes=True) == cands[0]["path"]
+
+    def test_numbered_list_marks_git_and_the_recent_folder(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        plain = tmp_path / "notes"
+        plain.mkdir()
+        _answers(monkeypatch, "")
+        init_wizard._pick_repo(
+            [_entry(tmp_path / "repo"), _entry(plain, is_git=False, source="nearby")]
+        )
+        out = capsys.readouterr().out
+        assert "1  " in out and "2  " in out
+        assert "git repo, used most recently" in out
+        assert "no git yet" in out
+
+
+class TestCandidateRepos:
+    def test_picker_suggestions_are_used_and_the_memory_is_passed_in(self, monkeypatch):
+        seen = {}
+
+        def _suggest(recent_paths=(), cwd=None, limit=12):
+            seen.update(recent=list(recent_paths), cwd=cwd, limit=limit)
+            return [_entry("/home/me/code/foo")]
+
+        mod = types.ModuleType("backend.web.core.repo_picker")
+        mod.suggest_repos = _suggest
+        monkeypatch.setitem(sys.modules, "backend.web.core.repo_picker", mod)
+        monkeypatch.setattr(
+            init_wizard, "_remembered_repo", lambda: "/home/me/code/foo"
+        )
+        assert init_wizard._candidate_repos(limit=3) == [_entry("/home/me/code/foo")]
+        assert seen["recent"] == ["/home/me/code/foo"]
+        assert seen["limit"] == 3
+
+    def test_a_picker_that_blows_up_falls_back_to_the_cwd(self, monkeypatch, tmp_path):
+        def _boom(**kwargs):
+            raise RuntimeError("bad mount")
+
+        mod = types.ModuleType("backend.web.core.repo_picker")
+        mod.suggest_repos = _boom
+        monkeypatch.setitem(sys.modules, "backend.web.core.repo_picker", mod)
+        monkeypatch.setattr(init_wizard, "_remembered_repo", lambda: "")
+        monkeypatch.chdir(tmp_path)
+        assert init_wizard._candidate_repos() == [
+            {
+                "path": os.path.realpath(tmp_path),
+                "name": os.path.basename(os.path.realpath(tmp_path)),
+                "is_git": False,
+                "source": "cwd",
+            }
+        ]
+
+    def test_fallback_puts_the_remembered_folder_first_and_dedupes(
+        self, monkeypatch, tmp_path
+    ):
+        repo = _git_repo(tmp_path / "webapp")
+        monkeypatch.chdir(repo)
+        cands = init_wizard._fallback_candidates([str(repo)])
+        assert [c["source"] for c in cands] == ["recent"]  # cwd is the same folder
+        assert cands[0]["is_git"] is True
+
+    def test_fallback_skips_a_folder_that_is_gone(self, tmp_path):
+        cands = init_wizard._fallback_candidates([str(tmp_path / "deleted")])
+        assert all(c["path"] != str(tmp_path / "deleted") for c in cands)
+
+
+class TestGitDetection:
+    """Whether a folder is git-backed is asked of git itself, because the answer
+    the wizard prints has to be the answer the session-create path will act on."""
+
+    def test_a_subdirectory_of_a_repo_counts_as_a_repo(self, tmp_path):
+        # ~/code/foo/src carries no .git of its own, yet a session started there
+        # gets the worktree, the diff, the commit and the PR.
+        sub = _git_repo(tmp_path / "foo") / "src"
+        sub.mkdir()
+        assert init_wizard._is_git_worktree(str(sub)) is True
+
+    def test_a_plain_folder_is_still_not_one(self, tmp_path):
+        assert init_wizard._is_git_worktree(str(tmp_path / "notes")) is False
+
+    def test_the_wizard_does_not_tell_you_to_git_init_your_own_repo(
+        self, monkeypatch, capsys, tmp_path, no_prompts
+    ):
+        sub = _git_repo(tmp_path / "foo") / "src"
+        sub.mkdir()
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry(sub))
+        assert init_wizard.run(assume_yes=True) == 0
+        out = capsys.readouterr().out
+        assert "Working folder: %s" % sub in out
+        assert "Not a git repo" not in out
+        assert "git init" not in out
+
+    def test_without_the_web_extras_the_dot_git_entry_answers(
+        self, monkeypatch, tmp_path
+    ):
+        # An install missing the web extras (the picker and the git helpers both
+        # live under them) must still get an answer, not a traceback.
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setitem(sys.modules, "backend.web.core.git_ops", None)
+        assert init_wizard._is_git_worktree(str(tmp_path)) is True
+        assert init_wizard._is_git_worktree(str(tmp_path / "nothing")) is False
+
+
+class TestSettingsMemory:
+    def test_unreadable_settings_mean_no_memory_not_a_crash(self, monkeypatch):
+        def _boom():
+            raise OSError("settings are gone")
+
+        monkeypatch.setattr(settings_mod, "load_settings", _boom)
+        assert init_wizard._remembered_repo() == ""
+
+    def test_remembering_a_repo_writes_the_general_group(self, monkeypatch):
+        patches = []
+        monkeypatch.setattr(
+            settings_mod, "update_settings", lambda **kw: patches.append(kw)
+        )
+        init_wizard._remember_repo("/home/me/code/foo")
+        assert patches == [{"general": {"last_repo_path": "/home/me/code/foo"}}]
+
+
+class TestInitCommand:
+    def test_reachable_through_main_and_exits_zero(
+        self, monkeypatch, tmp_path, no_prompts
+    ):
+        monkeypatch.setattr(doctor, "run_checks", lambda: [_GIT_OK])
+        _candidates(monkeypatch, _entry(tmp_path))
+        assert cli.main(["init", "--yes"]) == 0
+
+    def test_yes_flag_is_passed_through(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(
+            init_wizard, "run", lambda assume_yes=False: seen.append(assume_yes) or 0
+        )
+        assert cli.main(["init", "--yes"]) == 0
+        assert cli.main(["init"]) == 0
+        assert seen == [True, False]
+
+    def test_short_yes_flag_works(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(
+            init_wizard, "run", lambda assume_yes=False: seen.append(assume_yes) or 0
+        )
+        cli.main(["init", "-y"])
+        assert seen == [True]
+
+    def test_help_describes_the_guided_setup(self):
+        help_text = " ".join(cli._build_parser().format_help().split())
+        assert (
+            "guided first-run setup: check dependencies, log in your agent CLI, "
+            "pick your repo" in help_text
+        )
+
+    def test_wizard_exit_code_is_the_command_exit_code(self, monkeypatch):
+        monkeypatch.setattr(init_wizard, "run", lambda assume_yes=False: 1)
+        assert cli.main(["init"]) == 1
+
+
+class TestServeSetupFlag:
+    def test_cli_forwards_the_setup_token(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(run, "main", lambda argv=None: calls.append(argv))
+        assert cli.main(["serve", "--setup"]) == 0
+        assert cli.main(["serve", "tailscale", "--port", "9000", "--setup"]) == 0
+        assert calls == [["--setup"], ["tailscale", "9000", "--setup"]]
+
+    def test_setup_runs_the_wizard_before_the_bind(
+        self, monkeypatch, uvicorn_spy, quiet_checks
+    ):
+        order = []
+        monkeypatch.setattr(
+            init_wizard,
+            "run",
+            lambda assume_yes=False, serving=False: order.append(("wizard", serving))
+            or 0,
+        )
+        reported = []
+        monkeypatch.setattr(init_wizard, "report", lambda *a, **kw: reported.append(kw))
+        import uvicorn
+
+        monkeypatch.setattr(
+            uvicorn, "run", lambda app, **kw: order.append("bind") or uvicorn_spy
+        )
+        monkeypatch.setattr(run, "_is_onboarded", lambda: False)
+        run.main(["--setup"])
+        # serving=True: the wizard is running inside the process that binds the
+        # port next, so it must not sign off by telling the user to start one.
+        assert order == [("wizard", True), "bind"]
+        assert not _eventually(
+            lambda: reported, timeout=0.3
+        ), "--setup already covered the report"
+
+    def test_a_wizard_that_blows_up_still_serves(
+        self, monkeypatch, uvicorn_spy, quiet_checks
+    ):
+        def _boom(assume_yes=False, serving=False):
+            raise RuntimeError("wizard exploded")
+
+        monkeypatch.setattr(init_wizard, "run", _boom)
+        monkeypatch.setattr(run, "_is_onboarded", lambda: True)
+        run.main(["--setup"])
+        assert uvicorn_spy, "a broken setup must not stop the server"
+
+
+class TestFirstRunBanner:
+    def test_first_serve_reports_and_never_prompts(
+        self, monkeypatch, uvicorn_spy, quiet_checks, no_prompts
+    ):
+        seen = []
+        monkeypatch.setattr(run, "_is_onboarded", lambda: False)
+        monkeypatch.setattr(
+            init_wizard,
+            "report",
+            lambda stream=None, serving=False: seen.append(serving),
+        )
+        monkeypatch.setattr(
+            init_wizard,
+            "run",
+            lambda assume_yes=False, serving=False: pytest.fail(
+                "a first serve must not prompt"
+            ),
+        )
+        run.main([])
+        assert uvicorn_spy
+        assert _eventually(lambda: seen)
+        assert seen == [True]  # serving=True: don't tell them to start what started
+
+    def test_the_report_never_delays_the_bind(
+        self, monkeypatch, uvicorn_spy, quiet_checks
+    ):
+        # The report walks the full doctor and probes git per suggested folder. On
+        # the very launch it exists for — the desktop app's own first start, which
+        # spawns this server and polls the port — running it before uvicorn binds
+        # is time the app spends retrying onto offline.html.
+        order = []
+        release = threading.Event()
+
+        def _slow_report(stream=None, serving=False):
+            order.append("report-start")
+            release.wait(5.0)
+            order.append("report-done")
+
+        import uvicorn
+
+        monkeypatch.setattr(uvicorn, "run", lambda app, **kw: order.append("bind"))
+        monkeypatch.setattr(run, "_is_onboarded", lambda: False)
+        monkeypatch.setattr(init_wizard, "report", _slow_report)
+        run.main([])
+        assert "bind" in order, "the bind must not wait on the first-run report"
+        release.set()
+        assert _eventually(lambda: "report-done" in order)
+        assert order.index("bind") < order.index("report-done")
+
+    def test_the_report_lands_after_the_banner_in_one_piece(
+        self, monkeypatch, capsys, uvicorn_spy, quiet_checks
+    ):
+        # The banner's closing line is racing the preflight thread, so the report
+        # is rendered into a buffer and written once — printed line by line it
+        # would end up with "Press Ctrl-C to stop." in the middle of it.
+        def _report(stream=None, serving=False):
+            stream.write("First run — where this machine stands:\nsecond line\n")
+
+        monkeypatch.setattr(run, "_is_onboarded", lambda: False)
+        monkeypatch.setattr(init_wizard, "report", _report)
+        run.main([])
+        out = _drain(capsys, "second line")
+        assert "First run — where this machine stands:\nsecond line\n" in out
+        assert out.index("Press Ctrl-C") < out.index("First run")
+
+    def test_a_first_run_does_not_walk_the_doctor_twice(self, monkeypatch, uvicorn_spy):
+        # The report's own doctor pass already covers git, tmux and the agent CLI
+        # with their fix lines, so the short check list must not shell out for the
+        # same three a second time on the same boot.
+        probed = []
+        for name in ("check_git", "check_tmux", "check_agent_cli"):
+            monkeypatch.setattr(
+                doctor, name, lambda _n=name: probed.append(_n) or _GIT_OK
+            )
+        reported = []
+        monkeypatch.setattr(run, "_is_onboarded", lambda: False)
+        monkeypatch.setattr(
+            init_wizard, "report", lambda stream=None, serving=False: reported.append(1)
+        )
+        run.main([])
+        assert _eventually(lambda: reported)
+        assert not _eventually(lambda: probed, timeout=0.3)
+
+    def test_a_later_serve_still_gets_the_short_check_list(
+        self, monkeypatch, capsys, uvicorn_spy
+    ):
+        # Nothing about moving the report off the bind path may cost the boot its
+        # "tmux is missing, here is the command" line.
+        monkeypatch.setattr(doctor, "check_git", lambda: _GIT_OK)
+        monkeypatch.setattr(doctor, "check_tmux", lambda: _TMUX_MISSING)
+        monkeypatch.setattr(doctor, "check_agent_cli", lambda: _GIT_OK)
+        reported = []
+        monkeypatch.setattr(run, "_is_onboarded", lambda: True)
+        monkeypatch.setattr(init_wizard, "report", lambda *a, **kw: reported.append(kw))
+        run.main([])
+        err = _drain(capsys, "fix: sudo apt install tmux", err=True)
+        assert "! tmux:" in err
+        assert not reported, "only a first run gets the report"
+
+    def test_second_serve_says_nothing(self, monkeypatch, uvicorn_spy, quiet_checks):
+        reported = []
+        monkeypatch.setattr(run, "_is_onboarded", lambda: True)
+        monkeypatch.setattr(init_wizard, "report", lambda *a, **kw: reported.append(kw))
+        run.main([])
+        assert uvicorn_spy
+        assert not _eventually(
+            lambda: reported, timeout=0.3
+        ), "only a first run gets the report"
+
+    def test_run_py_degrades_to_silence_not_to_a_second_copy_of_the_text(
+        self, monkeypatch, capsys, uvicorn_spy, quiet_checks
+    ):
+        # report() swallows its own failure (see TestReport), so any fallback
+        # wording here could only ever be unreachable copy rotting out of sync
+        # with the wizard it duplicated. What the boot path still owes when the
+        # hint dies is booting anyway.
+        blew_up = []
+
+        def _boom(stream=None, serving=False):
+            blew_up.append(serving)
+            raise RuntimeError("report exploded")
+
+        monkeypatch.setattr(run, "_is_onboarded", lambda: False)
+        monkeypatch.setattr(init_wizard, "report", _boom)
+        run.main([])
+        assert uvicorn_spy, "a broken first-run hint must not stop the server"
+        assert _eventually(lambda: blew_up)
+        assert blew_up == [True]
+        out = capsys.readouterr().out
+        assert "Three steps" not in out
+        assert "click" not in out

--- a/tests/unit/test_provider_connect.py
+++ b/tests/unit/test_provider_connect.py
@@ -28,6 +28,7 @@ from fastapi.testclient import TestClient
 import backend.web.addons.settings as settings_addon
 from backend import providers
 from backend.config import settings as S
+from backend.providers import claude_usage_api
 from backend.providers.base import BaseProvider
 from backend.providers.config import detect_auth
 from backend.web.core import provider_login
@@ -48,6 +49,11 @@ def _isolate(tmp_path, monkeypatch):
         "CLAUDE_CONFIG_DIR",
     ):
         monkeypatch.delenv(var, raising=False)
+    # A Mac running the suite has a real Claude login in its Keychain, which is
+    # genuine evidence — pin that lookup off so the file/env assertions below
+    # can't be answered by the developer's own login (the keychain tests
+    # re-patch it with what they want it to find).
+    monkeypatch.setattr(claude_usage_api, "_keychain_doc", lambda: None)
     S.invalidate()
     providers.rebuild_registry()
     yield
@@ -321,6 +327,46 @@ def test_claude_auth_evidence_prefers_config_dir_over_home(tmp_path, monkeypatch
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(cfg))
     evidence = providers.get("claude").auth_evidence()
     assert str(cfg) in evidence and str(tmp_path / ".claude.json") not in evidence
+
+
+def test_claude_auth_evidence_finds_a_macos_keychain_login(tmp_path, monkeypatch):
+    # On macOS Claude Code keeps its OAuth credentials in the login Keychain and
+    # writes no .credentials.json, so a fully logged-in Mac was reported as
+    # "no sign of a login" until the keychain counted as evidence too.
+    monkeypatch.setenv("HOME", str(tmp_path))  # no credential files anywhere
+    monkeypatch.setattr(
+        claude_usage_api,
+        "_keychain_doc",
+        lambda: {"claudeAiOauth": {"accessToken": "x"}},
+    )
+    assert "Keychain" in providers.get("claude").auth_evidence()
+
+
+def test_claude_auth_evidence_skips_the_keychain_when_a_file_answered(
+    tmp_path, monkeypatch
+):
+    # The keychain lookup shells out to `security` and can raise a one-time
+    # keychain prompt, so a credential file must short-circuit it entirely.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude.json").write_text('{"oauthAccount": "x"}')
+
+    def _never():
+        raise AssertionError("the keychain was consulted despite a credential file")
+
+    monkeypatch.setattr(claude_usage_api, "_keychain_doc", _never)
+    assert ".claude.json" in providers.get("claude").auth_evidence()
+
+
+def test_claude_auth_evidence_survives_a_broken_keychain_lookup(tmp_path, monkeypatch):
+    # A denied keychain prompt / missing `security` binary is no evidence, never
+    # an exception into the doctor or the providers list.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def _boom():
+        raise OSError("security: user denied access")
+
+    monkeypatch.setattr(claude_usage_api, "_keychain_doc", _boom)
+    assert providers.get("claude").auth_evidence() == ""
 
 
 def test_claude_auth_evidence_never_raises_on_unreadable_path(tmp_path, monkeypatch):

--- a/tests/unit/test_repo_picker.py
+++ b/tests/unit/test_repo_picker.py
@@ -1,0 +1,527 @@
+"""Repo suggestions for the folder picker: the ranking, the bounds, the routes.
+
+Two flavors of coverage, for the reason ``test_git_ops`` splits the same way:
+
+* ranking/bounds tests that replace the authoritative git probe with a ``.git``
+  stat, so a test that builds seventy candidate folders stays hermetic and fast
+  (the ranking is the subject; whether git agrees is not);
+* a handful of tests against *real* throwaway repos in ``tmp_path`` — a plain
+  folder, a bare ``git init`` with no HEAD, and a repo with one commit — because
+  the ``is_git`` / ``has_commits`` distinction is exactly what the dialog uses to
+  say whether the session gets worktrees and diffs.
+
+``HOME`` is monkeypatched throughout: the scan roots hang off it, and a test that
+swept the developer's real home directory would be both slow and unrepeatable.
+The route tests point ``MINDFLOCK_SETTINGS_FILE`` at ``tmp_path`` as well, so the
+onboarded/last-repo writes never touch the user's own ``settings.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.config import settings as S
+from backend.web import server
+from backend.web.core import repo_picker
+
+
+# --------------------------------------------------------------------------- #
+# helpers                                                                      #
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    """A throwaway HOME the scan roots hang off."""
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setenv("HOME", str(h))
+    return h
+
+
+@pytest.fixture()
+def marker_git(monkeypatch):
+    """Count any folder carrying a ``.git`` marker as a repo — no subprocesses.
+
+    The real probe shells out to git once per surviving candidate, which is fine
+    for a dialog and far too slow for a test that lays out seventy of them.
+    """
+    monkeypatch.setattr(
+        repo_picker,
+        "_is_git_repo",
+        lambda p: os.path.exists(os.path.join(p, ".git")),
+    )
+
+
+def _marker_repo(parent, name: str) -> str:
+    """A directory that looks like a repo to ``marker_git``."""
+    d = parent / name
+    (d / ".git").mkdir(parents=True)
+    return str(d)
+
+
+def _git(cwd, *args) -> None:
+    """Run git in ``cwd`` (real, local, throwaway — never the user's repo)."""
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
+
+
+def _real_repo(parent, name: str, *, commit: bool = False) -> str:
+    d = parent / name
+    d.mkdir(parents=True)
+    _git(d, "init", "-q")
+    if commit:
+        _git(d, "commit", "-q", "--allow-empty", "-m", "first")
+    return str(d)
+
+
+def _paths(suggestions) -> list:
+    return [s["path"] for s in suggestions]
+
+
+def _names(suggestions) -> list:
+    return [s["name"] for s in suggestions]
+
+
+class TestSuggestRepos:
+    def test_recent_paths_keep_the_order_the_caller_gave_them(self, home, marker_git):
+        # Recency is the caller's call (settings, then live, then closed
+        # sessions) — this module must not re-sort it.
+        first = _marker_repo(home, "gamma")
+        second = _marker_repo(home, "alpha")
+        third = _marker_repo(home, "beta")
+
+        got = repo_picker.suggest_repos(recent_paths=[first, second, third])
+
+        assert _paths(got)[:3] == [first, second, third]
+        assert [s["source"] for s in got[:3]] == ["recent", "recent", "recent"]
+
+    def test_a_recent_folder_that_no_longer_exists_is_dropped(self, home, marker_git):
+        alive = _marker_repo(home, "alive")
+
+        got = repo_picker.suggest_repos(
+            recent_paths=[str(home / "moved-away"), "", alive]
+        )
+
+        assert _paths(got) == [alive]
+
+    def test_every_suggestion_carries_the_full_wire_shape(self, home, marker_git):
+        repo = _marker_repo(home, "shapely")
+
+        (got,) = repo_picker.suggest_repos(recent_paths=[repo])
+
+        assert got == {
+            "path": repo,
+            "name": "shapely",
+            "is_git": True,
+            "source": "recent",
+        }
+
+    def test_a_recent_folder_that_is_not_a_repo_is_still_offered(
+        self, home, marker_git
+    ):
+        # A plain folder runs a session in-place with git features off, so it is
+        # a legitimate answer — flagged, not hidden.
+        plain = home / "notes"
+        plain.mkdir()
+
+        (got,) = repo_picker.suggest_repos(recent_paths=[str(plain)])
+
+        assert got["is_git"] is False
+
+    def test_the_launch_directory_is_offered_when_it_is_a_repo(self, home, marker_git):
+        launched_from = _marker_repo(home, "launched")
+
+        got = repo_picker.suggest_repos(cwd=launched_from)
+
+        assert got[0]["path"] == launched_from
+        assert got[0]["source"] == "cwd"
+
+    def test_a_launch_directory_that_is_not_a_repo_is_left_out(self, home, marker_git):
+        plain = home / "somewhere"
+        plain.mkdir()
+
+        assert repo_picker.suggest_repos(cwd=str(plain)) == []
+
+    def test_the_same_repo_seen_twice_keeps_its_best_rank(self, home, marker_git):
+        repo = _marker_repo(home / "code", "shared")
+
+        got = repo_picker.suggest_repos(recent_paths=[repo], cwd=repo)
+
+        assert _paths(got) == [repo]
+        assert got[0]["source"] == "recent"  # not re-listed as cwd or nearby
+
+    def test_a_symlink_and_its_target_are_one_suggestion(self, home, marker_git):
+        target = _marker_repo(home / "code", "real")
+        link = home / "shortcut"
+        link.symlink_to(target)
+
+        got = repo_picker.suggest_repos(recent_paths=[str(link)])
+
+        # Resolved, so the nearby sweep can't offer the same repo a second time
+        # under its other name.
+        assert _paths(got) == [os.path.realpath(target)]
+
+    def test_only_direct_children_of_a_scan_root_are_swept(self, home, marker_git):
+        near = _marker_repo(home / "code", "near")
+        _marker_repo(home / "code" / "nested", "deep")
+
+        got = repo_picker.suggest_repos()
+
+        assert _paths(got) == [near]
+
+    def test_a_scan_root_that_is_itself_a_repo_is_offered(self, home, marker_git):
+        root_repo = _marker_repo(home, "projects")
+
+        got = repo_picker.suggest_repos()
+
+        assert root_repo in _paths(got)
+
+    def test_dotted_and_noise_folders_are_skipped(self, home, marker_git):
+        wanted = _marker_repo(home / "code", "wanted")
+        _marker_repo(home / "code", ".hidden")
+        _marker_repo(home / "code", "node_modules")
+        _marker_repo(home / "code", "__pycache__")
+        _marker_repo(home / "code", "venv")
+
+        got = repo_picker.suggest_repos()
+
+        assert _paths(got) == [wanted]
+
+    def test_nearby_is_alphabetical_across_every_root(self, home, marker_git):
+        _marker_repo(home / "work", "zeta")
+        _marker_repo(home / "code", "Alpha")
+        _marker_repo(home / "dev", "middle")
+
+        got = repo_picker.suggest_repos()
+
+        assert _names(got) == ["Alpha", "middle", "zeta"]
+        assert {s["source"] for s in got} == {"nearby"}
+
+    def test_the_limit_caps_the_list(self, home, marker_git):
+        for n in range(6):
+            _marker_repo(home / "code", "repo-%d" % n)
+
+        assert len(repo_picker.suggest_repos(limit=4)) == 4
+        assert repo_picker.suggest_repos(limit=0) == []
+
+    def test_the_per_root_cap_stops_a_huge_directory(self, home, marker_git):
+        # 70 repos in one root, examined in sorted order: the cap must cut the
+        # tail rather than stat every folder in someone's home directory. The
+        # dotted siblings are what makes the root realistic — they sort ahead of
+        # every letter, so the budget has to be spent on names that can actually
+        # be offered rather than on names the filter drops.
+        for n in range(70):
+            _marker_repo(home / "code", "repo-%02d" % n)
+        for n in range(70):
+            (home / "code" / (".junk-%02d" % n)).mkdir()
+
+        got = repo_picker.suggest_repos(limit=500)
+
+        assert len(got) == repo_picker._MAX_PER_ROOT
+        assert "repo-59" in _names(got)
+        assert "repo-60" not in _names(got)
+
+    def test_dot_entries_do_not_spend_the_per_root_budget(self, home, marker_git):
+        # A lived-in home directory is mostly dotted entries (~/.cache, ~/.ssh,
+        # ~/.zshrc), and "." sorts ahead of every letter and digit. Slicing the
+        # raw listing to the budget therefore handed the whole allowance to names
+        # the very next line discarded, and the nearby tier returned NOTHING on
+        # any home directory with sixty-odd dotfiles — that is every machine that
+        # has been used, and nearby is the only tier a first-run user has.
+        for n in range(repo_picker._MAX_PER_ROOT + 5):
+            (home / (".cache-%02d" % n)).mkdir()
+        alpha = _marker_repo(home, "alpha")
+        beta = _marker_repo(home, "beta")
+
+        got = repo_picker.suggest_repos()
+
+        assert _paths(got) == [alpha, beta]
+
+    def test_a_repeated_recent_path_costs_one_git_probe(self, home, monkeypatch):
+        # server.py's gather appends last_repo_path, then one path per live
+        # session, then one per recently-closed entry — for someone who keeps
+        # every session in one checkout that is the same folder forty times over.
+        # Probing git as an argument to _add ran the rev-parse subprocess before
+        # the dedup check saw it, so opening the New Session dialog spawned ~41
+        # processes to produce one suggestion.
+        first = _marker_repo(home, "one")
+        second = _marker_repo(home, "two")
+        probed: list = []
+
+        def counting_probe(path):
+            probed.append(path)
+            return os.path.exists(os.path.join(path, ".git"))
+
+        monkeypatch.setattr(repo_picker, "_is_git_repo", counting_probe)
+
+        got = repo_picker.suggest_repos(
+            recent_paths=[first] * 10 + [second] * 10, limit=2
+        )
+
+        assert _paths(got) == [first, second]
+        assert probed == [first, second]
+
+    def test_the_overall_cap_stops_the_whole_sweep(self, home, marker_git, monkeypatch):
+        monkeypatch.setattr(repo_picker, "_MAX_SCANNED", 3)
+        for n in range(3):
+            _marker_repo(home / "code", "code-%d" % n)
+        _marker_repo(home / "work", "later")
+
+        got = repo_picker.suggest_repos(limit=500)
+
+        # The budget was spent under ~/code, so ~/work is never reached.
+        assert "later" not in _names(got)
+
+    def test_an_unreadable_directory_degrades_instead_of_raising(
+        self, home, marker_git, monkeypatch
+    ):
+        (home / "code").mkdir()
+        reachable = _marker_repo(home / "work", "reachable")
+        real_listdir = os.listdir
+
+        def deny(path, *a, **kw):
+            if str(path) == str(home / "code"):
+                raise PermissionError(13, "Permission denied")
+            return real_listdir(path, *a, **kw)
+
+        monkeypatch.setattr(repo_picker.os, "listdir", deny)
+
+        got = repo_picker.suggest_repos()
+
+        assert _paths(got) == [reachable]
+
+    def test_a_real_repo_is_recognised_without_the_stubbed_probe(self, home):
+        """The wiring to the shared git probe, exercised against real git."""
+        repo = _real_repo(home / "code", "genuine", commit=True)
+        (home / "code" / "plain").mkdir()
+
+        got = repo_picker.suggest_repos(cwd=repo)
+
+        assert got[0] == {
+            "path": repo,
+            "name": "genuine",
+            "is_git": True,
+            "source": "cwd",
+        }
+        assert "plain" not in _names(got)
+
+
+class TestCheckRepo:
+    def test_a_path_that_does_not_exist_is_a_normal_answer(self, home):
+        got = repo_picker.check_repo(str(home / "not-yet"))
+
+        assert got == {
+            "path": str(home / "not-yet"),
+            "exists": False,
+            "is_dir": False,
+            "is_git": False,
+            "has_commits": False,
+        }
+
+    def test_a_blank_path_answers_about_nothing(self, home, monkeypatch):
+        # realpath("") is the process cwd, which nobody asked about.
+        monkeypatch.chdir(str(home))
+
+        assert repo_picker.check_repo("   ")["path"] == ""
+        assert repo_picker.check_repo("")["exists"] is False
+
+    def test_a_tilde_is_expanded_but_an_env_var_is_left_alone(
+        self, home, marker_git, monkeypatch
+    ):
+        # Expanduser only, because that is all the folder actually gets created
+        # with: /api/browse and _prepare_plain_repo never call expandvars. When
+        # this step expanded $VAR and they did not, the dialog reported "git repo,
+        # has commits" about one directory and Create then made a literal "$VAR"
+        # folder tree somewhere else entirely — a git-less session in a directory
+        # the user never named.
+        repo = _marker_repo(home, "typed")
+        monkeypatch.setenv("MY_CODE_DIR", str(home))
+        monkeypatch.chdir(str(home))
+
+        assert repo_picker.check_repo("~/typed")["path"] == repo
+
+        got = repo_picker.check_repo("$MY_CODE_DIR/typed")
+
+        assert got["path"].endswith("$MY_CODE_DIR/typed")
+        assert (got["exists"], got["is_git"]) == (False, False)
+
+    def test_a_plain_folder_exists_but_is_not_a_repo(self, home):
+        plain = home / "notes"
+        plain.mkdir()
+
+        got = repo_picker.check_repo(str(plain))
+
+        assert (got["exists"], got["is_dir"], got["is_git"]) == (True, True, False)
+        assert got["has_commits"] is False
+
+    def test_a_file_is_not_a_directory(self, home):
+        f = home / "README.md"
+        f.write_text("hi\n")
+
+        got = repo_picker.check_repo(str(f))
+
+        assert got["exists"] is True
+        assert got["is_dir"] is False
+
+    def test_a_fresh_git_init_has_no_commits_yet(self, home):
+        # This is the case that can't have a worktree forked off it — the dialog
+        # needs to say so before the session is created, not after it fails.
+        repo = _real_repo(home, "empty-repo")
+
+        got = repo_picker.check_repo(repo)
+
+        assert got["is_git"] is True
+        assert got["has_commits"] is False
+
+    def test_a_repo_with_a_commit_reports_commits(self, home):
+        repo = _real_repo(home, "used-repo", commit=True)
+
+        got = repo_picker.check_repo(repo)
+
+        assert (got["is_git"], got["has_commits"]) == (True, True)
+
+
+class TestLastRepoPathSetting:
+    def test_it_survives_a_save_and_a_fresh_load(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MINDFLOCK_SETTINGS_FILE", str(tmp_path / "settings.json"))
+        S.invalidate()
+
+        S.update_settings(general={"last_repo_path": "/home/me/code/foo"})
+        S.invalidate()  # force a re-read from disk, not the parse cache
+
+        assert S.load_settings().general.last_repo_path == "/home/me/code/foo"
+        stored = json.loads((tmp_path / "settings.json").read_text())
+        assert stored["general"]["last_repo_path"] == "/home/me/code/foo"
+        S.invalidate()
+
+    def test_an_unset_path_stays_out_of_the_document(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MINDFLOCK_SETTINGS_FILE", str(tmp_path / "settings.json"))
+        S.invalidate()
+
+        S.update_settings(general={"onboarded": True})
+
+        stored = json.loads((tmp_path / "settings.json").read_text())
+        assert "last_repo_path" not in stored["general"]
+        S.invalidate()
+
+    def test_creating_a_session_remembers_the_folder_it_chose(
+        self, tmp_path, home, monkeypatch
+    ):
+        """The writer side: without this the suggestion list never learns."""
+        monkeypatch.setenv("MINDFLOCK_SETTINGS_FILE", str(tmp_path / "settings.json"))
+        S.invalidate()
+        chosen = str(home / "chosen-repo")
+
+        # Same neutering as test_webui's create tests: no real worktree, no
+        # background Start, no tmux — only the route's own bookkeeping runs.
+        class _FakeInst:
+            def __init__(self, opts):
+                self.Title = opts.title
+                self.Branch = ""
+                self.Prompt = getattr(opts, "prompt", "") or ""
+                self.ExtraEnv = {}
+
+            def SetStatus(self, status):  # noqa: N802
+                return None
+
+            def Started(self):  # noqa: N802
+                return False
+
+            def Start(self, *a, **k):  # noqa: N802
+                return None
+
+            def GetWorktreePath(self):  # noqa: N802
+                return ""
+
+        monkeypatch.setattr(server.session, "NewInstance", _FakeInst)
+        monkeypatch.setattr(
+            server, "_prepare_plain_repo", lambda repo, init: (chosen, True)
+        )
+        monkeypatch.setattr(server, "_instance_json", lambda inst, **kw: {})
+        monkeypatch.setattr(server, "_register_task", lambda coro: coro.close())
+        monkeypatch.setattr(server._ports, "env_for", lambda title: {})
+        monkeypatch.setattr(server.ENGINE, "instances", {})
+
+        r = TestClient(server.app).post(
+            "/api/instances",
+            json={"title": "remembers", "program": "bash", "repo_path": chosen},
+        )
+
+        assert r.status_code == 202
+        assert S.load_settings().general.last_repo_path == chosen
+        S.invalidate()
+
+
+class TestRepoPickerApi:
+    @pytest.fixture()
+    def client(self, tmp_path, home, monkeypatch):
+        monkeypatch.setenv("MINDFLOCK_SETTINGS_FILE", str(tmp_path / "settings.json"))
+        S.invalidate()
+        # The registry is a process singleton that may already hold the
+        # developer's own sessions; empty it so the ranking under test is the
+        # only thing feeding the list.
+        monkeypatch.setattr(server.ENGINE, "instances", {})
+        monkeypatch.setattr(server, "_load_recently_closed", lambda: [])
+        yield TestClient(server.app)
+        S.invalidate()
+
+    def test_suggest_ranks_settings_then_closed_then_nearby(
+        self, client, home, marker_git, monkeypatch
+    ):
+        last_used = _marker_repo(home / "code", "last-used")
+        closed_repo = _marker_repo(home / "code", "closed-repo")
+        _marker_repo(home / "code", "just-lying-around")
+        S.update_settings(general={"last_repo_path": last_used})
+        monkeypatch.setattr(
+            server,
+            "_load_recently_closed",
+            lambda: [
+                {"title": "x", "folder": "/gone/wt", "data": {"path": closed_repo}}
+            ],
+        )
+
+        body = client.get("/api/repos/suggest").json()
+
+        assert body["home"] == str(home)
+        assert _paths(body["suggestions"])[:2] == [last_used, closed_repo]
+        assert [s["source"] for s in body["suggestions"][:2]] == ["recent", "recent"]
+        assert "just-lying-around" in _names(body["suggestions"])
+        assert set(body["suggestions"][0]) == {"path", "name", "is_git", "source"}
+
+    def test_suggest_offers_the_repo_a_live_session_uses(
+        self, client, home, marker_git, monkeypatch
+    ):
+        repo = _marker_repo(home / "code", "in-use")
+        inst = type("_Inst", (), {"Path": repo, "UpdatedAt": None})()
+        monkeypatch.setattr(server.ENGINE, "instances", {"live": inst})
+
+        body = client.get("/api/repos/suggest").json()
+
+        assert body["suggestions"][0]["path"] == repo
+        assert body["suggestions"][0]["source"] == "recent"
+
+    def test_check_reports_a_repo_the_user_typed(self, client, home):
+        repo = _real_repo(home, "typed-repo", commit=True)
+
+        body = client.get("/api/repos/check", params={"path": repo}).json()
+
+        assert body == {
+            "path": repo,
+            "exists": True,
+            "is_dir": True,
+            "is_git": True,
+            "has_commits": True,
+        }
+
+    def test_check_answers_200_while_the_user_is_still_typing(self, client, home):
+        r = client.get("/api/repos/check", params={"path": str(home / "co")})
+
+        assert r.status_code == 200
+        assert r.json()["exists"] is False
+
+    def test_check_rejects_only_a_blank_path(self, client):
+        assert client.get("/api/repos/check", params={"path": "  "}).status_code == 400
+        assert client.get("/api/repos/check").status_code == 400

--- a/tests/unit/test_serve_mode.py
+++ b/tests/unit/test_serve_mode.py
@@ -42,12 +42,22 @@ class TestServeModeSetting:
 class TestRunModeResolution:
     @pytest.fixture()
     def run_mod(self, monkeypatch):
+        from backend import doctor
+        from backend.doctor import Check
         from backend.web import run as run_mod
 
         # Neutralize everything main() does besides resolving mode/host.
         monkeypatch.setenv("CS_WEB_MODE", "")
         monkeypatch.setenv("UVICORN_PORT", "8765")
         monkeypatch.setattr(run_mod, "_port_squatter", lambda host, port: "")
+        # …including the preflight daemon thread: with a tmp settings store every
+        # call looks like a first run, and the report walks the real doctor and
+        # scans the developer's home for repo suggestions on a thread that
+        # outlives the test.
+        monkeypatch.setattr(run_mod, "_is_onboarded", lambda: True)
+        _ok = Check(id="stub", label="stub", status="ok")
+        for _name in ("check_git", "check_tmux", "check_agent_cli"):
+            monkeypatch.setattr(doctor, _name, lambda: _ok)
         return run_mod
 
     def _captured_host(self, monkeypatch, run_mod, argv):


### PR DESCRIPTION
The gap between installing MindFlock and having an agent working was mostly discovery. Nothing was broken — but the fast path existed only in the README: four commands to find and sequence, a folder tree to navigate, and a doctor that went quiet about the thing most likely to be wrong.

### `mindflock init`
Runs the doctor, offers to run each fix (tmux, the agent CLI, logging it in — through the existing `--fix` loop, which already knew how to confirm and re-probe), then lists the git repos it found and remembers the one you pick.

A first `serve` prints the same findings **without prompting**: a server that waits on stdin before binding its port looks like a hung app to the desktop shell that just spawned it. So the interactive wizard is opt-in (`mindflock init`, or `serve --setup`), and the report is built off the main thread — a first run is precisely the launch that's polling for the port.

### The New Session dialog stops opening in `$HOME`
`GET /api/repos/suggest` ranks the folder your last session used, the live sessions' repos, the server's cwd, and a depth-one scan under home; the dialog pre-selects the best one. It also now says something when the folder isn't a repo, where before it silently turned diff/commit/PR off — the checkbox that fixes that was already there, three clicks deep under **More options**.

On this machine that's 9 candidates offered where the pre-fix scan found 1.

### The folder browser selects like Finder
A click used to navigate, and committing a folder meant finding the per-row **select** button. Click selects, double click descends, Escape cancels the browse instead of leaving the field on whatever directory you last passed through.

### `agent-auth` covers every provider
It handled Claude and shrugged at the rest (`no auth probe for codex — skipped`), so a Codex or opencode user learned they were logged out when their first session failed. Every provider already declared where its credentials live, for Settings → Providers; the check reads that now. A provider declaring nothing stays silent rather than nagging about evidence it cannot find, and only a login command the provider *actually declares* becomes runnable — otherwise `doctor --fix` would offer to drop you into an agent REPL that can't resolve the check.

### One first-run signal instead of three
The tour and the setup checklist each kept a browser-local flag beside the server's `onboarded`, so a cleared profile or a second machine replayed the twelve-slide tour at someone plainly not new. The server's flag is the whole rule now; both local keys are retired (neither had a writer left, so the checklist's own dismissal could never fire either).

Deliberately **no** new flag for "watched the tour": that would have to mean `onboarded`, and marking it there deletes the grid's setup card for a user who has created nothing.

### Three strays riding along
- A todo clicked for editing closed within a frame — the poll callback's deps changed as the edit began, re-running the effect that focuses the Add box, and that blur committed the edit.
- On macOS the doctor told logged-in users they were logged out: Claude Code keeps credentials in the login Keychain there, which the probe never read.
- The sidebar's resize handle painted over every open dialog — the `.modal` backdrop is fixed with no `z-index` of its own, so the handle's `z-index: 40` drew its accent line across the dimmed page and kept answering `:hover`, with the drag working through the backdrop on a sidebar nobody could see.

### Verification
- `3878 passed` (python unit suite), `189 passed` (frontend vitest), `tsc --noEmit` clean.
- Bundle byte-reproducible from sources.
- Smoke-tested `mindflock doctor`, `mindflock init --yes` and the first-run report against isolated settings files — no writes to a real `~/.mindflock/settings.json`.
- Two adversarial review passes; 14 findings found and fixed, each with a regression test. Two were blocking: the tour marking `onboarded` (above), and the nearby-repo scan spending its whole work budget on dotfiles so it returned nothing on a real home directory — green in tests only because the fixture used a pristine tmp home.
