### PR TITLE
Release 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-08-05
+
 ### Added
 
 - **`mindflock init` — a guided first-run setup.** Getting to a first session
@@ -1018,7 +1020,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.11...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.12...HEAD
+[0.1.12]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.12
 [0.1.11]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.11
 [0.1.10]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.10
 [0.1.9]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.9

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.11"
+version = "0.1.12"
 description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump + CHANGELOG roll for 0.1.12, per `docs/development.md` → *Cutting a release*.

Ships the onboarding work from #47: `mindflock init`, repo suggestions in New Session, Finder-style folder selection, per-provider `agent-auth`, one first-run signal instead of three — plus three fixes (todo inline edit, macOS Keychain login detection, sidebar handle over dialogs).

Release notes come from the CHANGELOG section, which landed with the feature PR. Tag goes on the merge commit.