### PR TITLE
Fix fast-track: premature halts, dead settings, and pushing the trunk

### DIFF
--- a/backend/ticket_ingestion/session_runner.py
+++ b/backend/ticket_ingestion/session_runner.py
@@ -142,6 +142,7 @@ class SessionRunner:
         agent = self._agent_for(story)
         self._arm_autopilot(
             title,
+            "tix",
             getattr(story, "provider", "") or "",
             str(getattr(story, "id", "") or story.slug),
             str(getattr(story, "name", "") or ""),
@@ -198,6 +199,7 @@ class SessionRunner:
         title = f"pr-{pr_slug(pr)}"
         self._arm_autopilot(
             title,
+            "pr",
             str(getattr(pr, "repo", "") or ""),
             "%s#%s" % (getattr(pr, "repo", ""), pr.number),
             str(getattr(pr, "title", "") or ""),
@@ -258,7 +260,9 @@ class SessionRunner:
         provider = getattr(story, "provider", "")
         return fresh_agent(lambda c: c.agent_for(provider), self.config)
 
-    def _arm_autopilot(self, title: str, source: str, item: str, message: str) -> None:
+    def _arm_autopilot(
+        self, title: str, kind: str, lookup: str, item: str, message: str
+    ) -> None:
         """Record how far an AUTO-ingested item should carry itself.
 
         The auto path runs in a separate OS process from the web server, so this
@@ -281,14 +285,32 @@ class SessionRunner:
         try:
             from backend.web.core import autopilot as _autopilot
 
-            depth = _autopilot.normalize_depth(self._depth_for(source))
+            depth = _autopilot.normalize_depth(self._depth_for(lookup))
             if depth in ("", "off") or depth not in _autopilot.SOURCE_DEPTHS:
+                logger.info(
+                    "No autopilot depth configured for %s (%s) — %s will not "
+                    "fast-track itself",
+                    lookup,
+                    kind,
+                    title,
+                )
                 return
-            _autopilot.arm(
-                title, depth, source=source, item=item, message=message or ""
-            )
+            # `kind` is the record's own vocabulary (tix/pr/iss); `lookup` is the
+            # provider or repo slug the DEPTH is configured against. Passing the
+            # lookup as the source silently coerced it to "session", losing which
+            # surface the run came from.
+            _autopilot.arm(title, depth, source=kind, item=item, message=message or "")
+            logger.info("Autopilot armed for %s: will carry it to %s", title, depth)
         except Exception:  # noqa: BLE001
-            logger.debug("autopilot arm skipped for %s", title, exc_info=True)
+            # WARNING, not debug. This used to fail invisibly: a long-running
+            # pipeline predating the feature simply never armed anything, and the
+            # only symptom was the fast-track toggle sitting off with no
+            # explanation anywhere.
+            logger.warning(
+                "Could not arm autopilot for %s — it will not fast-track itself",
+                title,
+                exc_info=True,
+            )
 
     def _depth_for(self, source: str) -> str:
         """The configured autopilot depth for a ticketing source / repo slug.

--- a/backend/web/core/autopilot.py
+++ b/backend/web/core/autopilot.py
@@ -460,7 +460,15 @@ def next_action(rec: dict, snap: dict) -> Tuple[str, dict]:
         # no remote, API fault) is treated as pending and eventually times out —
         # never as permission to merge. "none" means this repo reports no checks at
         # all, which is a legitimate green light rather than something to wait for.
+        # A named blocker is authoritative and specific — conflicts, a missing
+        # review, a behind branch. Conflicts and reviews need a HUMAN, so they halt;
+        # a check that is merely still running is a wait.
+        blockers = list(snap.get("merge_blockers") or [])
         ci = str(snap.get("pr_checks") or "unknown")
+        if blockers:
+            if ci == "pending":
+                return "wait", {"reason": "waiting for required checks: " + blockers[0]}
+            return "stop", {"reason": "cannot merge — " + "; ".join(blockers)}
         if ci == "failed":
             return "stop", {"reason": "CI failed on the PR — not merging"}
         if ci in ("pending", "unknown"):

--- a/backend/web/core/autopilot.py
+++ b/backend/web/core/autopilot.py
@@ -75,6 +75,7 @@ __all__ = [
     "prune",
     "snapshot",
     "dto",
+    "claim",
 ]
 
 _FileName = "autopilot.json"
@@ -151,6 +152,11 @@ ARM_GRACE_S = 1800.0
 #: gives up. Generous — you may arm a ticket and let it sit — but bounded, so a
 #: session that never gets an agent does not stay armed forever. 2 hours.
 ARM_WAIT_DEADLINE_S = 7200.0
+#: How long an unrefreshed driver lease is honoured before another server may take
+#: over. The driver passes every 5s, so this is many missed passes — long enough
+#: that a slow pass never loses the lease, short enough that a crashed server does
+#: not strand a chain.
+LEASE_STALE_S = 45.0
 #: Branch names autopilot will never push or PR from, whatever the configured base
 #: resolves to. Defence in depth: the base-branch guard relies on
 #: `_session_base_branch`, and if that resolves to "" (a detached probe, a repo with
@@ -241,6 +247,14 @@ def _blank() -> dict:
         "step_since": 0.0,
         "acted_at": 0.0,
         "boot": "",
+        # WHICH SERVER IS DRIVING THIS CHAIN, and when it last said so. Two servers
+        # sharing one store (a dev instance on another port, say) both ran the
+        # driver: they saw each other's boot id, each treated it as a restart, and
+        # reset the idle dwell every pass — so the 30s settle could never elapse and
+        # a chain sat at "agent just went idle" forever. Both would also have ACTED,
+        # double-committing and double-pushing. One lease, one driver.
+        "owner": "",
+        "owner_at": 0.0,
         "started": 0.0,
         "updated": 0.0,
     }
@@ -310,12 +324,20 @@ def _normalize(entry) -> dict:
             e[key] = 0
     idle = entry.get("idle_since")
     e["idle_since"] = float(idle) if isinstance(idle, (int, float)) else None
-    for key in ("step_since", "acted_at", "started", "updated", "worked_at"):
+    for key in (
+        "step_since",
+        "acted_at",
+        "started",
+        "updated",
+        "worked_at",
+        "owner_at",
+    ):
         try:
             e[key] = float(entry.get(key, 0.0) or 0.0)
         except (TypeError, ValueError):
             e[key] = 0.0
     e["boot"] = str(entry.get("boot", "") or "")
+    e["owner"] = str(entry.get("owner", "") or "")
     return e
 
 
@@ -582,6 +604,42 @@ def get(title: str) -> Optional[dict]:
     with _LOCK:
         entry = _load().get(title)
     return _normalize(entry) if entry is not None else None
+
+
+def claim(title: str, owner: str, now: Optional[float] = None):
+    """Take or refresh the driver lease for ``title``.
+
+    Returns ``(rec, took_over)`` when this ``owner`` may drive the chain, or
+    ``(None, False)`` when a DIFFERENT server holds a live lease. ``took_over`` is
+    True when the lease changed hands (a restart, or a crashed owner), which is the
+    signal to re-earn the idle dwell rather than trusting a stale one.
+
+    Read-modify-write under the module lock, so the last writer wins within a
+    process; across processes the staleness window is what keeps exactly one
+    driver acting.
+    """
+    if not title or not owner:
+        return None, False
+    ts = float(now if now is not None else time.time())
+    with _LOCK:
+        data = _load()
+        if title not in data:
+            return None, False
+        rec = _normalize(data[title])
+        held = rec.get("owner") or ""
+        fresh = ts - float(rec.get("owner_at") or 0.0) <= LEASE_STALE_S
+        if held and held != owner and fresh:
+            return None, False  # another live server is driving this one
+        took = held != owner
+        rec["owner"] = owner
+        rec["owner_at"] = ts
+        if took:
+            # A new driver must not inherit a dwell it never observed.
+            rec["idle_since"] = None
+        rec["updated"] = ts
+        data[title] = rec
+        _save(data)
+    return dict(rec), took
 
 
 def dto(title: str):

--- a/backend/web/core/autopilot.py
+++ b/backend/web/core/autopilot.py
@@ -132,12 +132,31 @@ NEVER_SKIP = frozenset(
 # plain retry, then one with the hook skipped), and a run makes at most this many
 # commit attempts overall however the retries are distributed.
 MAX_COMMIT_ATTEMPTS = 4
+#: Cap on how many times the driver will issue the SAME verb. A push the remote
+#: keeps refusing must stop being re-typed; the stage never moves, so nothing else
+#: would ever end that loop.
+MAX_ACTIONS_PER_VERB = 3
 #: Consecutive-idle dwell before the FIRST commit of a chain. Longer than the
 #: prompt queue's 12s settle on purpose: feeding a prompt to an agent that turns
 #: out to be mid-thought is recoverable, committing and opening a PR for it is
 #: not. Costs ~18s more latency and removes the whole "committed mid-thought"
 #: class of failure.
 IDLE_SETTLE_S = 30.0
+#: How long a record survives with no matching session before :func:`prune`
+#: drops it. Must comfortably exceed a cold clone plus worktree provisioning,
+#: because intake arms BEFORE the session exists. 30 minutes.
+ARM_GRACE_S = 1800.0
+#: How long the "waiting for the agent to start" state may last before the run
+#: gives up. Generous — you may arm a ticket and let it sit — but bounded, so a
+#: session that never gets an agent does not stay armed forever. 2 hours.
+ARM_WAIT_DEADLINE_S = 7200.0
+#: Branch names autopilot will never push or PR from, whatever the configured base
+#: resolves to. Defence in depth: the base-branch guard relies on
+#: `_session_base_branch`, and if that resolves to "" (a detached probe, a repo with
+#: no upstream, an exception swallowed upstream) the comparison silently passes and
+#: the trunk gets pushed. A remote whose ruleset is bypass-silent then accepts it
+#: and merely NOTES that a PR was required — which is exactly what happened, twice.
+TRUNK_BRANCHES = frozenset({"main", "master", "trunk", "develop", "development"})
 
 
 def autopilot_path() -> str:
@@ -195,6 +214,10 @@ def _blank() -> dict:
         "state": "running",
         "step": "",
         "reason": "",
+        # The server's own sentence for what this pass is waiting on ("waiting for
+        # checks to finish", "prompt queue still has work"). next_action already
+        # produces one for every wait; without a home for it the UI had to guess.
+        "note": "",
         "source": "session",
         "item": "",
         "message": "",
@@ -204,7 +227,13 @@ def _blank() -> dict:
         "attempts": {},
         "skipped": [],
         "commits": 0,
+        # Per-verb action counter, e.g. {"push": 2} — the backstop for a step that
+        # keeps being attempted because the observed stage never changes.
+        "issues": {},
         "idle_since": None,
+        # When this run last SAW the agent working. Until it is set, a clean tree
+        # means "not started yet", not "finished with nothing to show".
+        "worked_at": 0.0,
         "step_since": 0.0,
         "acted_at": 0.0,
         "boot": "",
@@ -240,6 +269,7 @@ def _normalize(entry) -> dict:
     e["state"] = state if state in ("running", "halted", "done") else "running"
     e["step"] = str(entry.get("step", "") or "")
     e["reason"] = str(entry.get("reason", "") or "")
+    e["note"] = str(entry.get("note", "") or "")
     src = str(entry.get("source", "") or "session")
     e["source"] = src if src in ("session", "tix", "pr", "iss") else "session"
     e["item"] = str(entry.get("item", "") or "")
@@ -257,6 +287,15 @@ def _normalize(entry) -> dict:
             except (TypeError, ValueError):
                 continue
         e["attempts"] = out
+    iss = entry.get("issues")
+    if isinstance(iss, dict):
+        out2: Dict[str, int] = {}
+        for k, v in list(iss.items())[:32]:
+            try:
+                out2[str(k)] = max(0, int(v))
+            except (TypeError, ValueError):
+                continue
+        e["issues"] = out2
     sk = entry.get("skipped")
     e["skipped"] = [str(h) for h in sk][:16] if isinstance(sk, list) else []
     for key in ("commits",):
@@ -266,7 +305,7 @@ def _normalize(entry) -> dict:
             e[key] = 0
     idle = entry.get("idle_since")
     e["idle_since"] = float(idle) if isinstance(idle, (int, float)) else None
-    for key in ("step_since", "acted_at", "started", "updated"):
+    for key in ("step_since", "acted_at", "started", "updated", "worked_at"):
         try:
             e[key] = float(entry.get(key, 0.0) or 0.0)
         except (TypeError, ValueError):
@@ -333,6 +372,11 @@ def next_action(rec: dict, snap: dict) -> Tuple[str, dict]:
         return "done", {}
 
     # A blocked commit: retry, skip, or halt.
+    # A target of "agent only" must never run git commit — dispatch it before the
+    # interrupt branch, which would otherwise re-commit on an allowlisted hook.
+    if depth == "agent":
+        return _agent_action(rec, snap, depth)
+
     if stage == "interrupt":
         return _interrupt_action(rec, snap)
 
@@ -345,14 +389,38 @@ def next_action(rec: dict, snap: dict) -> Tuple[str, dict]:
     if stage == "committed":
         if depth == "commit":  # defensive: reaches() already covered this
             return "done", {}
+        # NEVER push the base branch. A session sitting on main/master has no
+        # feature branch, so "push" means pushing the trunk itself and "open a PR"
+        # is meaningless — there is nothing to open one against. This is not
+        # hypothetical: a run on `main` pushed 20 files straight to origin/main and
+        # the remote reported "Bypassed rule violations … Changes must be made
+        # through a pull request". Committing is fine and already happened; going
+        # further needs a branch, so stop and say exactly that.
+        live = str(snap.get("branch") or "")
+        if snap.get("on_base_branch") or live.lower() in TRUNK_BRANCHES:
+            return "stop", {
+                "reason": "committed, but this session is on %s — make a branch to push or PR"
+                % (live or "the base branch")
+            }
         if snap.get("has_origin") is False:
             return "stop", {"reason": "no origin remote — add one to push"}
-        check = snap.get("check") or {}
-        state = str(check.get("state") or "")
+        check = snap.get("check")
+        state = str((check or {}).get("state") or "")
         if state == "failed":
             return "stop", {"reason": "checks failed — fix them and re-run"}
         if state == "running":
             return "wait", {"reason": "waiting for checks to finish"}
+        # The push route SOFT-GATES on the verification check: in a repo that
+        # declares a `check_command` it answers 409 "checks haven't passed for this
+        # commit" whenever the result is missing, not-ok, or stale. Discovering
+        # that by pushing turned into a permanent halt, so ask for the check here
+        # instead. Never force past it — the gate is the owner's "if tests fail,
+        # stop", and it is the one thing that must keep working.
+        if snap.get("check_required"):
+            if check is None or check.get("stale"):
+                return "run_check", {"reason": "starting the verification check"}
+            if state != "ok":
+                return "wait", {"reason": "waiting for checks to finish"}
         return "push", {}
 
     if stage == "pushed":
@@ -361,6 +429,15 @@ def next_action(rec: dict, snap: dict) -> Tuple[str, dict]:
     if stage == "pr":
         if depth != "merge":
             return "done", {}
+        # Merge is the one irreversible rung, so CI gates it. "unknown" (no token,
+        # no remote, API fault) is treated as pending and eventually times out —
+        # never as permission to merge. "none" means this repo reports no checks at
+        # all, which is a legitimate green light rather than something to wait for.
+        ci = str(snap.get("pr_checks") or "unknown")
+        if ci == "failed":
+            return "stop", {"reason": "CI failed on the PR — not merging"}
+        if ci in ("pending", "unknown"):
+            return "wait", {"reason": "waiting for CI to pass before merging"}
         return "merge", {}
 
     return "wait", {"reason": "stage %s" % (stage or "unknown")}
@@ -386,6 +463,16 @@ def _interrupt_action(rec: dict, snap: dict) -> Tuple[str, dict]:
     step = str(snap.get("failed_step") or "")
     named = step or hook or "a hook"
     retryable = [h for h in (rec.get("retryable") or []) if h not in NEVER_SKIP]
+
+    # THIS RUN HAS NOT COMMITTED YET. The "interrupt" it is looking at therefore
+    # belongs to an EARLIER attempt — very often a manual commit whose
+    # .mindflock_commit_status is still on disk — so halting here would abort the
+    # press within seconds, blaming a failure the user pressed the button to get
+    # past. Spend our own first attempt instead: that is byte-for-byte what the
+    # manual "Re-commit" button does (re-stage the hooks' auto-fixes, same
+    # message), and the policy below then governs everything after it.
+    if int(rec.get("commits") or 0) == 0:
+        return "commit", {"skip": list(rec.get("skipped") or [])}
 
     if not hook:
         # No parseable hook id (a raw git hook, or the pane scrolled away).
@@ -424,10 +511,16 @@ def _agent_action(rec: dict, snap: dict, depth: str) -> Tuple[str, dict]:
       autopilot waits for the queue to drain before it commits;
     * the tree is actually dirty, so an agent that died before writing anything
       halts loudly instead of committing an empty tree.
+
+    CRUCIALLY, a clean tree is only a FAILURE once this run has actually seen the
+    agent do something (``worked_at``) or produce a commit. Arming is normally the
+    FIRST thing you do — before the agent has written a line, or between turns, or
+    while it is still starting up — and ``_agent_activity`` reports "idle" 8s after
+    a static pane and instantly when a Stop hook fires. Halting then said "the
+    agent finished without changing anything" about an agent that had not begun,
+    roughly 35 seconds after every press. That was the single worst bug in the
+    feature. Now it waits, bounded by the arm deadline.
     """
-    if depth == "agent":
-        # Target is "let the agent work": reaching idle IS completion.
-        pass
     activity = str(snap.get("activity") or "")
     if snap.get("limited"):
         return "wait", {"reason": "usage limit — waiting for the window to reopen"}
@@ -444,10 +537,34 @@ def _agent_action(rec: dict, snap: dict, depth: str) -> Tuple[str, dict]:
     if depth == "agent":
         return "done", {}
     if not snap.get("dirty"):
-        if int(snap.get("beyond_base") or 0) > 0:
-            # Committed already but the stage still reads "agent": nothing to
-            # commit, let the next pass see the real stage.
-            return "wait", {"reason": "nothing uncommitted"}
+        beyond = snap.get("beyond_base")
+        if beyond is None:
+            # Could not MEASURE how far ahead we are (no base branch resolved, or
+            # the count failed). That is not evidence of "nothing happened", so it
+            # must never be read as one — wait and re-measure.
+            return "wait", {"reason": "working out what has already been committed"}
+        if int(beyond) > 0:
+            # Work is already committed; the stage just still reads "agent".
+            return "done", {}
+        # HAS THIS RUN ALREADY DONE SOMETHING? If so, the sentence below is a lie
+        # and must never be reached. A session on its BASE branch lands here
+        # permanently — `_session_stage` collapses to "agent" whenever
+        # `origin/<base>..HEAD` is 0, which it always is once the base branch has
+        # been pushed — so a run that had committed AND pushed reported "the agent
+        # finished without changing anything", with commits=1 and step="push"
+        # recorded right next to it.
+        if int(rec.get("commits") or 0) > 0 or rec.get("step"):
+            live = str(snap.get("branch") or "")
+            if snap.get("on_base_branch") or live.lower() in TRUNK_BRANCHES:
+                return "stop", {
+                    "reason": "committed on %s — make a branch to push or PR"
+                    % (live or "the base branch")
+                }
+            return "done", {}
+        if not rec.get("worked_at"):
+            # Armed before the agent got going. Wait for it, bounded by the arm
+            # deadline — see the docstring.
+            return "wait", {"reason": "waiting for the agent to start"}
         return "stop", {"reason": "the agent finished without changing anything"}
     return "commit", {"skip": list(rec.get("skipped") or [])}
 
@@ -575,18 +692,44 @@ def disarm(title: str) -> bool:
     return True
 
 
-def prune(live_titles) -> int:
-    """Drop records for sessions that no longer exist.
+def prune(live_titles, now: Optional[float] = None) -> int:
+    """Drop records for sessions that no longer exist AND are past the arm grace.
 
     Mandatory, not housekeeping: titles are REUSED after a delete, so without
     this a recreated session would inherit the previous one's target and attempt
     counters. Finished/halted records are kept (the UI shows them) until their
     session goes away.
+
+    THE GRACE WINDOW IS LOAD-BEARING, not politeness. Every intake entry point
+    arms BEFORE its session exists — that is the whole point of keying the store
+    by title (a forced start arms, then clones; the ingestion pipeline arms from a
+    separate OS process and its session only reaches this engine after a save and
+    an adopt). A prune that required the title to be live right now deleted every
+    such record within one 5s pass, which silently disabled the entire intake half
+    of the feature: you picked "take this to a PR", and nothing ever happened,
+    with no halt reason because there was no record left to hold one.
+
+    So a record younger than :data:`ARM_GRACE_S` is never dropped for being
+    unknown — a cold clone plus provisioning can legitimately take that long. The
+    reuse hazard is covered where it actually arises: the session-delete path
+    disarms explicitly.
     """
     live = set(live_titles or [])
+    ts = float(now if now is not None else time.time())
     with _LOCK:
         data = _load()
-        dead = [t for t in data if t not in live]
+        dead = []
+        for t, raw in data.items():
+            if t in live:
+                continue
+            started = 0.0
+            if isinstance(raw, dict):
+                try:
+                    started = float(raw.get("started") or 0.0)
+                except (TypeError, ValueError):
+                    started = 0.0
+            if ts - started > ARM_GRACE_S:
+                dead.append(t)
         if not dead:
             return 0
         for t in dead:

--- a/backend/web/core/autopilot.py
+++ b/backend/web/core/autopilot.py
@@ -76,6 +76,7 @@ __all__ = [
     "snapshot",
     "dto",
     "claim",
+    "rearm",
 ]
 
 _FileName = "autopilot.json"
@@ -612,6 +613,55 @@ def get(title: str) -> Optional[dict]:
     with _LOCK:
         entry = _load().get(title)
     return _normalize(entry) if entry is not None else None
+
+
+def rearm(title: str, now: Optional[float] = None) -> Optional[dict]:
+    """Wake a FINISHED run for another cycle, keeping its target.
+
+    Fast-track is a standing instruction, not a one-shot. A branch that already has
+    an open PR reads as stage "pr", so arming it satisfied the target immediately
+    and the run went ``done`` — and a done record is inert, so when the agent then
+    did more work nothing carried it anywhere. You had to re-press the button after
+    every single cycle.
+
+    Everything per-CYCLE is cleared (step, counters, skipped hooks, the dwell, the
+    PR url) so the new pass starts clean and cannot inherit an old attempt budget.
+    Everything per-INSTRUCTION is kept: the depth, the message, where it came from,
+    the retryable hooks, the branch.
+
+    Deliberately does NOT wake a HALTED run — that one stopped because a human
+    needs to look at it, and quietly resuming would bury the reason. Pressing the
+    button is how you say you have dealt with it.
+    """
+    if not title:
+        return None
+    ts = float(now if now is not None else time.time())
+    with _LOCK:
+        data = _load()
+        if title not in data:
+            return None
+        rec = _normalize(data[title])
+        if rec.get("state") != "done":
+            return None
+        rec.update(
+            state="running",
+            step="",
+            reason="",
+            note="",
+            url="",
+            attempts={},
+            issues={},
+            skipped=[],
+            commits=0,
+            idle_since=None,
+            worked_at=0.0,
+            step_since=ts,
+            acted_at=0.0,
+            updated=ts,
+        )
+        data[title] = rec
+        _save(data)
+    return dict(rec)
 
 
 def claim(title: str, owner: str, now: Optional[float] = None):

--- a/backend/web/core/autopilot.py
+++ b/backend/web/core/autopilot.py
@@ -758,13 +758,18 @@ def halt(title: str, reason: str) -> Optional[dict]:
 
     A silently stopped chain is the one failure mode that destroys trust in the
     feature, so the reason is required and always surfaced.
+
+    Clears ``note`` — it holds what the run was WAITING on, which is history the
+    moment the run stops. Left behind, a finished record still read "pre-commit
+    hooks are running" next to its own completion.
     """
-    return update(title, state="halted", reason=str(reason or "stopped"))
+    return update(title, state="halted", reason=str(reason or "stopped"), note="")
 
 
 def finish(title: str) -> Optional[dict]:
-    """Mark a run complete (its target rung was reached)."""
-    return update(title, state="done", reason="")
+    """Mark a run complete (its target rung was reached). Clears the wait note —
+    see :func:`halt`."""
+    return update(title, state="done", reason="", note="")
 
 
 def disarm(title: str) -> bool:

--- a/backend/web/core/autopilot.py
+++ b/backend/web/core/autopilot.py
@@ -74,6 +74,7 @@ __all__ = [
     "all_titles",
     "prune",
     "snapshot",
+    "dto",
 ]
 
 _FileName = "autopilot.json"
@@ -221,6 +222,9 @@ def _blank() -> dict:
         "source": "session",
         "item": "",
         "message": "",
+        # The PR this run opened, so the UI can bring it up exactly once — the same
+        # courtesy the manual "Make PR" button does.
+        "url": "",
         "base": "",
         "branch": "",
         "retryable": [],
@@ -274,6 +278,7 @@ def _normalize(entry) -> dict:
     e["source"] = src if src in ("session", "tix", "pr", "iss") else "session"
     e["item"] = str(entry.get("item", "") or "")
     e["message"] = str(entry.get("message", "") or "")
+    e["url"] = str(entry.get("url", "") or "")
     e["base"] = str(entry.get("base", "") or "")
     e["branch"] = str(entry.get("branch", "") or "")
     raw = entry.get("retryable")
@@ -577,6 +582,31 @@ def get(title: str) -> Optional[dict]:
     with _LOCK:
         entry = _load().get(title)
     return _normalize(entry) if entry is not None else None
+
+
+def dto(title: str):
+    """The compact block a session's ``/api/instances`` row carries, or None.
+
+    Lives here rather than in ``server.py`` because TWO callers need it and one of
+    them (``core.pending``, which renders provisioning rows) cannot import the
+    server without a cycle. A provisioning row that omitted this showed the
+    fast-track toggle OFF for the whole clone window — exactly when you would want
+    to change your mind — because intake arms BEFORE the session exists.
+    """
+    rec = get(title)
+    if rec is None:
+        return None
+    return {
+        "depth": rec.get("depth") or "",
+        "state": rec.get("state") or "",
+        "step": rec.get("step") or "",
+        "reason": rec.get("reason") or "",
+        "note": rec.get("note") or "",
+        "url": rec.get("url") or "",
+        "source": rec.get("source") or "session",
+        "item": rec.get("item") or "",
+        "skipped": list(rec.get("skipped") or []),
+    }
 
 
 def snapshot() -> dict:

--- a/backend/web/core/github_pr.py
+++ b/backend/web/core/github_pr.py
@@ -396,6 +396,81 @@ async def find_pr(wt: str, branch: str) -> Optional[dict]:
     return {"url": item.get("html_url"), "state": state, "number": item.get("number")}
 
 
+async def pr_checks(wt: str, branch: str) -> str:
+    """Verdict on the CI checks for ``branch``'s head commit.
+
+    Returns one of:
+
+    ``"ok"``       every check that reported has succeeded (or was neutral/skipped)
+    ``"failed"``   at least one check failed, errored, timed out, or was cancelled
+    ``"pending"``  something is still queued or in progress
+    ``"none"``     nothing reports checks for this commit at all
+    ``"unknown"``  we could not find out (no token, no remote, API/network fault)
+
+    Both surfaces are consulted, because a repo can use either or both: the Checks
+    API (GitHub Actions and most Apps) and the older combined Status API (many
+    external CI providers still only post statuses). "unknown" is deliberately
+    distinct from "none" — an autopilot must not read "I could not ask" as "there
+    is nothing to wait for", which is exactly the class of mistake that merges
+    unverified work.
+    """
+    ref = repo_ref(wt)
+    if ref is None or not branch:
+        return "unknown"
+    token = await _token()
+    if not token:
+        return "unknown"
+
+    failed = pending = reported = False
+
+    status, data = await _request(
+        "GET",
+        "/repos/{}/commits/{}/check-runs".format(ref.slug, branch),
+        token=token,
+        params={"per_page": "100"},
+    )
+    if status == 200 and isinstance(data, dict):
+        for run in data.get("check_runs") or []:
+            if not isinstance(run, dict):
+                continue
+            reported = True
+            if str(run.get("status") or "") != "completed":
+                pending = True
+                continue
+            if str(run.get("conclusion") or "") in (
+                "failure",
+                "timed_out",
+                "cancelled",
+                "action_required",
+                "startup_failure",
+                "stale",
+            ):
+                failed = True
+    elif status not in (200, 404):
+        return "unknown"
+
+    status, data = await _request(
+        "GET", "/repos/{}/commits/{}/status".format(ref.slug, branch), token=token
+    )
+    if status == 200 and isinstance(data, dict):
+        total = int(data.get("total_count") or 0)
+        combined = str(data.get("state") or "")
+        if total:
+            reported = True
+            if combined == "failure":
+                failed = True
+            elif combined == "pending":
+                pending = True
+    elif status not in (200, 404):
+        return "unknown"
+
+    if failed:
+        return "failed"
+    if pending:
+        return "pending"
+    return "ok" if reported else "none"
+
+
 # --------------------------------------------------------------------------- #
 # Sync bridge
 # --------------------------------------------------------------------------- #
@@ -421,3 +496,15 @@ def find_pr_sync(wt: str, branch: str) -> Optional[dict]:
         return _run_sync(find_pr(wt, branch))
     except Exception:  # noqa: BLE001 — a stage probe never fails a poll
         return None
+
+
+def pr_checks_sync(wt: str, branch: str) -> str:
+    """:func:`pr_checks` for synchronous callers (the autopilot snapshot).
+
+    Any failure answers ``"unknown"``, never ``"ok"`` — the caller uses this to
+    decide whether to MERGE, so an error must never be mistaken for a green light.
+    """
+    try:
+        return _run_sync(pr_checks(wt, branch))
+    except Exception:  # noqa: BLE001
+        return "unknown"

--- a/backend/web/core/github_pr.py
+++ b/backend/web/core/github_pr.py
@@ -471,6 +471,97 @@ async def pr_checks(wt: str, branch: str) -> str:
     return "ok" if reported else "none"
 
 
+async def pr_merge_state(wt: str, branch: str) -> Optional[dict]:
+    """Whether ``branch``'s PR can actually be merged, and what is stopping it.
+
+    Returns ``None`` when we cannot ask at all (no token, no GitHub behind
+    ``origin``, no open PR) — the caller should then leave the merge affordance
+    alone rather than claim to know. Otherwise::
+
+        {"number": int, "url": str, "state": str, "mergeable": bool|None,
+         "checks": "ok"|"failed"|"pending"|"none"|"unknown",
+         "can_merge": bool, "blockers": [str]}
+
+    ``state`` is GitHub's ``mergeable_state``: ``clean`` (good), ``dirty``
+    (conflicts), ``blocked`` (a required review or required check is unsatisfied),
+    ``behind`` (base moved ahead and the repo requires up-to-date branches),
+    ``unstable`` (a NON-required check is failing — GitHub still allows the merge),
+    ``draft``, or ``unknown``.
+
+    ``mergeable`` is computed lazily by GitHub and comes back ``null`` on the first
+    ask for a PR it has not evaluated recently. That is reported honestly as "still
+    working it out" rather than collapsed into "no": telling someone their PR is
+    unmergeable because we asked too early is worse than saying we don't know yet.
+    """
+    ref = repo_ref(wt)
+    if ref is None or not branch:
+        return None
+    token = await _token()
+    if not token:
+        return None
+
+    status, data = await _request(
+        "GET",
+        "/repos/{}/pulls".format(ref.slug),
+        token=token,
+        params={
+            "head": "{}:{}".format(ref.owner, branch),
+            "state": "open",
+            "per_page": "1",
+        },
+    )
+    if status != 200 or not isinstance(data, list) or not data:
+        return None
+    number = (data[0] or {}).get("number")
+    if not number:
+        return None
+
+    # The LIST payload omits mergeable/mergeable_state — only the single-PR read
+    # carries them, and only that read makes GitHub compute them.
+    status, pr = await _request(
+        "GET", "/repos/{}/pulls/{}".format(ref.slug, number), token=token
+    )
+    if status != 200 or not isinstance(pr, dict):
+        return None
+
+    mergeable = pr.get("mergeable")
+    state = str(pr.get("mergeable_state") or "unknown").lower()
+    if pr.get("draft"):
+        state = "draft"
+    checks = await pr_checks(wt, branch)
+
+    blockers: list = []
+    if state == "draft":
+        blockers.append("the pull request is still a draft")
+    elif state == "dirty":
+        blockers.append("the branch has merge conflicts with its base")
+    elif state == "behind":
+        blockers.append("the branch is behind its base and must be updated first")
+    elif state == "blocked":
+        # "blocked" means a REQUIRED gate is unsatisfied. Name which one, using the
+        # check verdict to tell a failing/pending check from a missing review.
+        if checks == "failed":
+            blockers.append("a required check is failing")
+        elif checks == "pending":
+            blockers.append("required checks are still running")
+        else:
+            blockers.append("a required review has not been given")
+    elif mergeable is None:
+        blockers.append("GitHub is still working out whether this can merge")
+    elif mergeable is False:
+        blockers.append("GitHub reports this cannot be merged")
+
+    return {
+        "number": number,
+        "url": pr.get("html_url") or "",
+        "state": state,
+        "mergeable": mergeable,
+        "checks": checks,
+        "can_merge": not blockers,
+        "blockers": blockers,
+    }
+
+
 # --------------------------------------------------------------------------- #
 # Sync bridge
 # --------------------------------------------------------------------------- #
@@ -495,6 +586,17 @@ def find_pr_sync(wt: str, branch: str) -> Optional[dict]:
     try:
         return _run_sync(find_pr(wt, branch))
     except Exception:  # noqa: BLE001 — a stage probe never fails a poll
+        return None
+
+
+def pr_merge_state_sync(wt: str, branch: str) -> Optional[dict]:
+    """:func:`pr_merge_state` for synchronous callers (the snapshot probe).
+
+    Any failure answers None — "we could not find out", never a claim either way.
+    """
+    try:
+        return _run_sync(pr_merge_state(wt, branch))
+    except Exception:  # noqa: BLE001
         return None
 
 

--- a/backend/web/core/live_stage.py
+++ b/backend/web/core/live_stage.py
@@ -64,6 +64,22 @@ _MAX_WATCHERS = 4
 _DEFAULT_SECONDS = 180.0
 
 _WATCH: Dict[str, dict] = {}
+#: The server's event loop, so a worker thread can hand work back to it. Set once
+#: by the lifespan via :func:`set_loop`.
+_MAIN_LOOP = None
+
+
+def set_loop(loop) -> None:
+    """Record the running event loop (called once from the server lifespan)."""
+    global _MAIN_LOOP
+    _MAIN_LOOP = loop
+
+
+def _alive(rec: dict) -> bool:
+    """Whether a watcher record has a live task. Tolerates a missing/None task so
+    a malformed entry can never wedge the module."""
+    task = (rec or {}).get("task")
+    return task is not None and not task.done()
 
 
 def watch(title: str, wt: str, reason: str, seconds: float = _DEFAULT_SECONDS) -> None:
@@ -77,14 +93,30 @@ def watch(title: str, wt: str, reason: str, seconds: float = _DEFAULT_SECONDS) -
     if not title or not wt:
         return
     try:
-        live = _WATCH.get(title)
+        # WHERE ARE WE? A route calls this ON the event loop; the autopilot driver
+        # calls it from a worker thread, where `asyncio.create_task` raises
+        # RuntimeError. Hop to the loop in that case rather than failing: the
+        # earlier version stored the record BEFORE creating the task, so a
+        # thread-side call left a task=None entry behind and every subsequent
+        # watch() in the whole process then died on `live["task"].done()` — which
+        # silently returned the entire app to 4s stage latency after the first
+        # autopilot commit.
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            loop = _MAIN_LOOP
+            if loop is None or loop.is_closed():
+                return
+            loop.call_soon_threadsafe(watch, title, wt, reason, seconds)
+            return
         now = time.monotonic()
-        if live is not None and not live["task"].done():
+        live = _WATCH.get(title)
+        if live is not None and _alive(live):
             live["until"] = max(live["until"], now + seconds)
             live["reason"] = reason
             live["settle_since"] = None
             return
-        if len([w for w in _WATCH.values() if not w["task"].done()]) >= _MAX_WATCHERS:
+        if len([w for w in _WATCH.values() if _alive(w)]) >= _MAX_WATCHERS:
             return
         rec: dict = {
             "wt": wt,
@@ -97,8 +129,11 @@ def watch(title: str, wt: str, reason: str, seconds: float = _DEFAULT_SECONDS) -
             "origin_sha": None,
             "task": None,
         }
+        # Create the task FIRST: a record without one is a landmine for every
+        # later call, so it must never be reachable.
+        task = asyncio.create_task(_loop(title, rec))
+        rec["task"] = task
         _WATCH[title] = rec
-        rec["task"] = asyncio.create_task(_loop(title, rec))
     except Exception:  # noqa: BLE001
         pass
 
@@ -117,7 +152,7 @@ def stop(title: str) -> bool:
 
 def active_titles() -> list:
     """Titles with a live watcher (diagnostics/tests)."""
-    return [t for t, w in _WATCH.items() if w.get("task") and not w["task"].done()]
+    return [t for t, w in _WATCH.items() if _alive(w)]
 
 
 def _signature(title: str, rec: dict) -> tuple:

--- a/backend/web/core/pending.py
+++ b/backend/web/core/pending.py
@@ -29,6 +29,7 @@ from typing import Dict, Optional, Set
 
 from backend import providers
 from backend.session.storage import Loading
+from backend.web.core import autopilot as _autopilot
 from backend.web.core.engine import get_engine
 
 # title -> {"kind": "pr"|"iss"|"tix", "since": epoch, **display meta}
@@ -158,6 +159,11 @@ def rows(engine=None) -> list:
                 "pr_url": None,
                 "failed_step": None,
                 "failed_hook": None,
+                # A provisioning row must carry it too: intake arms BEFORE the
+                # session exists, so without this the fast-track toggle showed OFF
+                # for the whole clone+provision window — exactly when you would
+                # want to change your mind and turn it off.
+                "autopilot": _autopilot.dto(title),
                 "queue": None,
                 "tokens": 0,
                 "tokens_in": 0,

--- a/backend/web/core/pending.py
+++ b/backend/web/core/pending.py
@@ -157,6 +157,7 @@ def rows(engine=None) -> list:
                 "has_origin": False,
                 "stage": "provisioning",
                 "pr_url": None,
+                "merge_state": None,
                 "failed_step": None,
                 "failed_hook": None,
                 # A provisioning row must carry it too: intake arms BEFORE the

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1869,6 +1869,16 @@ def _autopilot_default_message(inst, wt: str) -> str:
         branch = _current_branch(wt) or ""
     except Exception:  # noqa: BLE001
         branch = ""
+    # Prefer the human name of the work the session came from (a ticket title, a
+    # PR title) over the slug: "Add customer-submitted phone numbers to intake"
+    # says what landed; "Work on shortcut-21039" says nothing.
+    try:
+        rec = _autopilot.get(title) or {}
+        named = str(rec.get("message") or "").strip()
+        if named:
+            return named
+    except Exception:  # noqa: BLE001
+        pass
     subject = title or branch
     return ("Work on %s" % subject) if subject else "Work in progress"
 
@@ -5142,6 +5152,13 @@ async def instance_fast_track(
             status_code=400,
         )
     msg = str(body.get("message") or "").strip()
+    if not msg:
+        # An intake-armed run already carries the ticket / PR / issue NAME as its
+        # message. Re-arming with ⏩ used to overwrite that with a generated
+        # "Work on <slug>", throwing away the one genuinely descriptive subject
+        # available. Prefer it.
+        prev = _autopilot.get(title) or {}
+        msg = str(prev.get("message") or "").strip()
     if not msg:
         # Only adopt the on-disk message when a FAILED attempt is pending — the
         # same rule GET /commit-message applies. Reusing it unconditionally meant a

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1590,10 +1590,20 @@ def _autopilot_observe(title: str):
         _autopilot_halt(title, "workspace setup failed — fix it and re-arm")
         return
 
-    # A restart re-earns the idle dwell: the boot id changes, so a chain cannot
-    # shortcut the "is the agent really done" wait by being resumed mid-turn.
-    if rec.get("boot") != _SERVER_BOOT_ID:
-        rec = _autopilot.update(title, boot=_SERVER_BOOT_ID, idle_since=None) or rec
+    # ONE DRIVER PER CHAIN. Take (or refresh) the lease before deciding anything.
+    # Two servers sharing this store — a dev instance on another port, say — both
+    # ran the driver: each saw the other's boot id, treated it as a restart, and
+    # reset the idle dwell every pass, so the 30s settle could never elapse and a
+    # chain sat at "agent just went idle" indefinitely. Both would also have ACTED,
+    # double-committing and double-pushing the same worktree. Taking the lease also
+    # re-earns the dwell on a genuine handover (a restart, or a crashed owner), so
+    # a chain cannot shortcut the "is the agent really done" wait.
+    claimed, took_over = _autopilot.claim(title, _SERVER_BOOT_ID, now=time.time())
+    if claimed is None:
+        return  # another live server owns this chain
+    rec = claimed
+    if took_over and rec.get("boot") != _SERVER_BOOT_ID:
+        rec = _autopilot.update(title, boot=_SERVER_BOOT_ID) or rec
 
     # Branch drift: the push/PR/merge routes all resolve the LIVE branch, so a
     # switch mid-run would retarget the chain at different work.

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1409,26 +1409,12 @@ _AUTOPILOT_DEADLINES = {
 
 
 def _autopilot_dto(title: str):
-    """The compact autopilot block on a session's /api/instances row, or None.
+    """The session row's autopilot block — see :func:`autopilot.dto`.
 
-    Only what the UI renders: enough to say "auto → Open PR, waiting on the
-    agent" and, when a run has halted, exactly why.
+    Kept as a thin alias because it is referenced from both snapshot paths and by
+    tests; the shaping itself is shared with ``core.pending``.
     """
-    rec = _autopilot.get(title)
-    if rec is None:
-        return None
-    return {
-        "depth": rec.get("depth") or "",
-        "state": rec.get("state") or "",
-        "step": rec.get("step") or "",
-        "reason": rec.get("reason") or "",
-        # What this pass is waiting on, in the driver's own words. Without it the
-        # UI had to guess, and every deliberate wait read as "waiting on the agent".
-        "note": rec.get("note") or "",
-        "source": rec.get("source") or "session",
-        "item": rec.get("item") or "",
-        "skipped": list(rec.get("skipped") or []),
-    }
+    return _autopilot.dto(title)
 
 
 def _fasttrack_depth() -> str:
@@ -1802,6 +1788,10 @@ async def _autopilot_act(title, wt, rec, snap, action, detail) -> None:
                 )
                 return
             fields["step"] = "pr"
+            # Remember the PR so the client can open it exactly once, the same
+            # courtesy the manual "Make PR" button does.
+            if body.get("url"):
+                fields["url"] = str(body["url"])
         elif action == "merge":
             resp = await instance_merge_pr(title)
             if resp.status_code >= 400:
@@ -1990,6 +1980,7 @@ def _emit_autopilot_event(title: str) -> None:
                 "state": rec.get("state") or "",
                 "reason": rec.get("reason") or "",
                 "note": rec.get("note") or "",
+                "url": rec.get("url") or "",
                 "item": rec.get("item") or "",
                 "skipped": list(rec.get("skipped") or []),
             },

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1514,12 +1514,22 @@ def _autopilot_snapshot(inst, title: str, wt: str, stage: dict) -> dict:
         check_required = False
     # CI verdict on the PR, only when a merge is actually the target — it is a
     # network round trip and every other rung is indifferent to it.
+    # CI verdict + blockers on the PR, only when a merge is actually the target.
+    # Reuses the same probe the UI's merge button reads, so the driver and the
+    # button can never disagree about whether a merge would go through.
     pr_checks = ""
+    merge_blockers: list = []
     try:
         rec = _autopilot.get(title) or {}
         if rec.get("depth") == "merge" and (stage.get("stage") or "") == "pr":
             branch = _current_branch(wt) or ""
-            pr_checks = _github_pr.pr_checks_sync(wt, branch) if branch else "unknown"
+            ms = _pr_merge_state(wt, branch) if branch else None
+            if ms is None:
+                pr_checks = "unknown"
+            else:
+                pr_checks = str(ms.get("checks") or "unknown")
+                if not ms.get("can_merge"):
+                    merge_blockers = list(ms.get("blockers") or ["cannot merge yet"])
     except Exception:  # noqa: BLE001
         pr_checks = "unknown"
     return {
@@ -1534,6 +1544,7 @@ def _autopilot_snapshot(inst, title: str, wt: str, stage: dict) -> dict:
         "check": check,
         "check_required": check_required,
         "pr_checks": pr_checks,
+        "merge_blockers": merge_blockers,
         "on_base_branch": on_base,
         "branch": live_branch,
         "has_origin": _has_origin(wt),
@@ -2250,6 +2261,18 @@ def _session_snapshot(i, queues: dict) -> dict:
     # The publisher COMPUTES the stage and donates it to the memo; it must not
     # serve one the other 4s ticker filled up to 2.5s ago (see _probe_seed).
     d.update(_session_stage_fresh(i))
+    # Mergeability, ONLY at the PR rung: it is two network round trips, and every
+    # other stage is indifferent to it. None = "could not find out", which the UI
+    # must treat as "leave the button alone", never as "cannot merge".
+    d["merge_state"] = None
+    if d.get("stage") == "pr":
+        try:
+            _wt_ms = i.GetWorktreePath()
+            _br_ms = _current_branch(_wt_ms) if _wt_ms else ""
+            if _br_ms:
+                d["merge_state"] = _pr_merge_state(_wt_ms, _br_ms)
+        except Exception:  # noqa: BLE001 — a probe never fails a poll
+            d["merge_state"] = None
     d["queue"] = _queue_summary(i.Title, queues)
     # A dict read off an already-loaded store, so it is computed fresh on BOTH
     # snapshot paths and therefore never needs a _SNAPSHOT_PROBE_KEYS carry-over.
@@ -2297,6 +2320,7 @@ _SNAPSHOT_PROBE_KEYS = (
     "pr_url",
     "failed_step",
     "failed_hook",
+    "merge_state",
     "tokens",
     "tokens_in",
     "tokens_cache_read",
@@ -2331,6 +2355,7 @@ def _session_snapshot_cheap(i, queues: dict, prev: Optional[dict] = None) -> dic
         "provisioning" if (not i.Started() and i.Status == Loading) else "agent"
     )
     d["pr_url"] = None
+    d["merge_state"] = None
     d["queue"] = _queue_summary(i.Title, queues)
     d["autopilot"] = _autopilot_dto(i.Title)
     d["tokens"] = d["tokens_in"] = 0
@@ -4165,7 +4190,35 @@ def _configured_pr_base() -> str:
 # core.git_ops (imported above).
 
 
-_PR_CACHE: Dict[str, tuple] = {}  # branch -> (expires_epoch, info_or_None)
+_PR_CACHE: Dict[str, tuple] = {}  # branch -> (expires_epoch, info_or_None, last_good)
+#: How long a previously-seen PR survives lookups that come back empty. Long
+#: enough to ride out a rate limit or a network blip, short enough that a PR which
+#: really was deleted stops being reported within a few minutes.
+_PR_STICKY_S = 600.0
+# Mergeability is a SECOND network round trip (a single-PR read, which is also what
+# makes GitHub compute `mergeable` at all) plus the check rollup, so it gets its own
+# shorter-lived memo: blockers change while you watch — a review lands, a check goes
+# green — and a stale "cannot merge" is worse than a slightly late one.
+_MERGE_STATE_CACHE: Dict[str, tuple] = {}  # branch -> (expires_epoch, state_or_None)
+_MERGE_STATE_TTL = 20.0
+
+
+def _pr_merge_state(wt: str, branch: str, force: bool = False):
+    """Whether ``branch``'s PR can be merged and what is blocking it, memoized.
+
+    None means "could not find out" (no token, no GitHub origin, no open PR, or a
+    network fault) — never "no". The UI must leave the merge affordance alone in
+    that case rather than claim knowledge it does not have.
+    """
+    if not branch:
+        return None
+    now = time.time()
+    cached = _MERGE_STATE_CACHE.get(branch)
+    if not force and cached and cached[0] > now:
+        return cached[1]
+    state = _github_pr.pr_merge_state_sync(wt, branch)
+    _MERGE_STATE_CACHE[branch] = (now + _MERGE_STATE_TTL, state)
+    return state
 
 
 def _pr_info(wt: str, branch: str, force: bool = False):
@@ -4196,7 +4249,19 @@ def _pr_info(wt: str, branch: str, force: bool = False):
         if gh_available()
         else _github_pr.find_pr_sync(wt, branch)
     )
-    _PR_CACHE[branch] = (now + 60, info)
+    # STICKY ON FAILURE, bounded. None means BOTH "there is no PR" and "we could not
+    # ask" (a rate limit, a network blip, a slow `gh`), and caching it flapped the
+    # stage off "pr" and back every minute — which fired the "PR merged or closed"
+    # toast over and over for a PR that was open the whole time. So a previously
+    # known PR survives a failed lookup for _PR_STICKY_S, and is retried sooner than
+    # the normal TTL; only a persistent absence is finally believed. Same reasoning
+    # as _origin_branch_sha's "keep the previous answer rather than flapping".
+    if info is None and cached is not None and cached[1] is not None:
+        last_good = cached[2] if len(cached) > 2 else now
+        if now - last_good < _PR_STICKY_S:
+            _PR_CACHE[branch] = (now + 15, cached[1], last_good)
+            return cached[1]
+    _PR_CACHE[branch] = (now + 60, info, now if info is not None else 0.0)
     return info
 
 
@@ -5011,6 +5076,7 @@ async def instance_make_pr(title: str, payload: Optional[dict] = None) -> JSONRe
             rc, out, url = (0 if res.ok else 1), res.error, res.url
 
     _PR_CACHE.pop(branch, None)  # force a fresh stage read next poll
+    _MERGE_STATE_CACHE.pop(branch, None)
     _forget_probes(title)
     if handoff is not None:
         return handoff

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1864,6 +1864,12 @@ def _autopilot_default_message(inst, wt: str) -> str:
         title = str(getattr(inst, "Title", "") or "").strip()
     except Exception:  # noqa: BLE001
         title = ""
+    if not title:
+        # Called from the commit step, where the instance may not be in hand.
+        try:
+            title = str(_current_branch(wt) or "").split("/")[-1]
+        except Exception:  # noqa: BLE001
+            title = ""
     branch = ""
     try:
         branch = _current_branch(wt) or ""
@@ -1910,6 +1916,14 @@ def _autopilot_commit(title, wt, rec, detail, fields) -> bool:
                 msg = fh.read().strip()
         except OSError:
             msg = ""
+    if not msg:
+        # GENERATE one rather than halting. Arming on a CLEAN tree is the natural
+        # way to use this — arm the session, let the agent work — and the route
+        # records no message then, because there is nothing to describe yet. By the
+        # time work exists the record still had none, so the run halted with "no
+        # commit message to reuse" at the moment it was finally ready to commit.
+        # An honest default subject beats refusing to commit the work.
+        msg = _autopilot_default_message(ENGINE.instances.get(title), wt)
     if not msg:
         _autopilot_halt(title, "no commit message to reuse")
         return False

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1561,8 +1561,28 @@ def _autopilot_observe(title: str):
     session on this pass.
     """
     rec = _autopilot.get(title)
-    if rec is None or rec.get("state") != "running":
+    if rec is None:
         return
+    if rec.get("state") == "done":
+        # STANDING INSTRUCTION, not a one-shot. A branch that already has an open PR
+        # reads as stage "pr", so arming satisfied the target at once and the run
+        # went done — then the agent did more work and nothing carried it anywhere,
+        # because a done record is inert. Wake it when there is new uncommitted work:
+        # after a finished cycle the tree is clean (the commit consumed it), so dirt
+        # means the agent has been busy again.
+        try:
+            _wt_rearm = ENGINE.instances[title].GetWorktreePath()
+        except Exception:  # noqa: BLE001
+            return
+        if not _wt_rearm or not _is_dirty(_wt_rearm):
+            return
+        woken = _autopilot.rearm(title)
+        if woken is None:
+            return
+        rec = woken
+        _emit_autopilot_event(title)
+    elif rec.get("state") != "running":
+        return  # halted: a human has to look at it before it moves again
     if not _autopilot.normalize_depth(rec.get("depth")) in _autopilot.DEPTHS:
         return
     inst = ENGINE.instances.get(title)

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -417,6 +417,9 @@ async def lifespan(app: FastAPI):
     # unattended and resumes them the moment usage returns after an outage).
     _register_task(_prompt_queue_drain_loop())
     _register_task(_autopilot_loop())
+    # So the autopilot driver, which runs its blocking half in worker threads, can
+    # still start an edge watcher (asyncio.create_task needs the loop).
+    _live_stage.set_loop(asyncio.get_running_loop())
     _register_task(_window_refresh_loop())
     # Tailnet device discovery + remote session snapshots (multi-device mode).
     _register_task(_remote.discovery_loop(_server_port()))
@@ -1395,9 +1398,13 @@ _AUTOPILOT_ACTION_COOLDOWN = 15.0
 _AUTOPILOT_DEADLINES = {
     "agent": 5400.0,  # 90min: an agent working a whole ticket
     "commit": 1800.0,  # 30min: hook stacks can include tests and doc passes
-    "push": 300.0,
-    "pr": 180.0,
-    "merge": 900.0,  # includes waiting for required checks to report
+    "check": 1800.0,  # 30min: a verification command may run the whole suite
+    # These three were far too tight. A slow remote, a rate-limited API or a
+    # required-check queue must read as "still going", not as a failure — the
+    # deadline exists to stop a WEDGED chain, not to race the network.
+    "push": 900.0,
+    "pr": 600.0,
+    "merge": 5400.0,  # 90min: the merge rung genuinely waits for CI now
 }
 
 
@@ -1415,6 +1422,9 @@ def _autopilot_dto(title: str):
         "state": rec.get("state") or "",
         "step": rec.get("step") or "",
         "reason": rec.get("reason") or "",
+        # What this pass is waiting on, in the driver's own words. Without it the
+        # UI had to guess, and every deliberate wait read as "waiting on the agent".
+        "note": rec.get("note") or "",
         "source": rec.get("source") or "session",
         "item": rec.get("item") or "",
         "skipped": list(rec.get("skipped") or []),
@@ -1484,15 +1494,48 @@ def _autopilot_snapshot(inst, title: str, wt: str, stage: dict) -> dict:
     # countdown; probing for it here would only add a tmux round-trip (and
     # `_ensure_agent_session`'s reboot side effect) to get a boolean we have.
     limited = activity == "limit"
+    # None means "could not measure", which must never be read as "nothing has
+    # been committed" — that mistake produced a false "the agent finished without
+    # changing anything" on sessions whose work was already committed and pushed.
+    beyond = None
+    base = ""
+    live_branch = ""
     try:
         base = _session_base_branch(inst) or ""
-        beyond = _commits_beyond_base(wt, base) if base else 0
+        if base:
+            beyond = _commits_beyond_base(wt, base)
     except Exception:  # noqa: BLE001
-        beyond = 0
+        beyond = None
+    try:
+        live_branch = _current_branch(wt) or ""
+    except Exception:  # noqa: BLE001
+        live_branch = ""
+    # Sitting ON the base branch means there is no feature branch: pushing would
+    # push the trunk and a PR has nothing to target. Compared case-sensitively
+    # against the resolved base, and only when BOTH are known — an unknown base
+    # must not be guessed into a refusal.
+    on_base = bool(base and live_branch and base == live_branch)
     try:
         check = _wt_setup.check_summary(wt)
     except Exception:  # noqa: BLE001
         check = None
+    # Whether this repo GATES the push on a verification run. The push route 409s
+    # when a declared check has not passed, so the ladder has to know about the
+    # gate up front rather than discovering it as a fatal error.
+    try:
+        check_required = bool(_wt_setup.load_config(wt).check_command)
+    except Exception:  # noqa: BLE001
+        check_required = False
+    # CI verdict on the PR, only when a merge is actually the target — it is a
+    # network round trip and every other rung is indifferent to it.
+    pr_checks = ""
+    try:
+        rec = _autopilot.get(title) or {}
+        if rec.get("depth") == "merge" and (stage.get("stage") or "") == "pr":
+            branch = _current_branch(wt) or ""
+            pr_checks = _github_pr.pr_checks_sync(wt, branch) if branch else "unknown"
+    except Exception:  # noqa: BLE001
+        pr_checks = "unknown"
     return {
         "stage": stage.get("stage") or "",
         "failed_step": stage.get("failed_step") or "",
@@ -1503,6 +1546,10 @@ def _autopilot_snapshot(inst, title: str, wt: str, stage: dict) -> dict:
         "limited": limited,
         "queue_pending": queue_pending,
         "check": check,
+        "check_required": check_required,
+        "pr_checks": pr_checks,
+        "on_base_branch": on_base,
+        "branch": live_branch,
         "has_origin": _has_origin(wt),
         "now": now,
     }
@@ -1523,22 +1570,38 @@ def _autopilot_observe(title: str):
         return
     inst = ENGINE.instances.get(title)
     if inst is None:
-        return  # not adopted yet (intake) — a later pass picks it up
+        # Not adopted yet — the normal intake case, since arming happens before the
+        # session exists. Say so rather than looking wedged.
+        _autopilot_note(title, rec, "waiting for the workspace to be created")
+        return
+    # Every hold below is a WAIT, not a halt — but it must be VISIBLE. These used
+    # to be bare `return`s, so a chain held by a paused session, a budget lock or a
+    # failed worktree setup looked identical to one that had silently died.
     try:
-        if not inst.Started() or inst.Status == session.Paused:
+        if not inst.Started():
+            _autopilot_note(title, rec, "waiting for the session to start")
+            return
+        if inst.Status == session.Paused:
+            _autopilot_note(title, rec, "session is paused — resume it to continue")
             return
     except Exception:  # noqa: BLE001
         return
     if _budget_locked(title):
-        return  # over budget — hold, don't halt; the user may raise it
+        _autopilot_note(title, rec, "over the cost budget — raise it to continue")
+        return
     try:
         wt = inst.GetWorktreePath()
     except Exception:  # noqa: BLE001
         wt = ""
     if not wt:
+        _autopilot_note(title, rec, "waiting for the workspace")
         return
     setup_st = _wt_setup.setup_status(wt)
-    if setup_st and setup_st.get("state") in ("running", "failed"):
+    if setup_st and setup_st.get("state") == "running":
+        _autopilot_note(title, rec, "workspace setup is running")
+        return
+    if setup_st and setup_st.get("state") == "failed":
+        _autopilot_halt(title, "workspace setup failed — fix it and re-arm")
         return
 
     # A restart re-earns the idle dwell: the boot id changes, so a chain cannot
@@ -1550,16 +1613,46 @@ def _autopilot_observe(title: str):
     # switch mid-run would retarget the chain at different work.
     live_branch = _current_branch(wt) or ""
     armed_branch = rec.get("branch") or ""
-    if armed_branch and live_branch and live_branch != armed_branch:
-        _autopilot.halt(
-            title,
-            "the workspace switched from %s to %s mid-run"
-            % (armed_branch, live_branch),
+    acted = int(rec.get("commits") or 0) > 0 or rec.get("step") in (
+        "commit",
+        "push",
+        "pr",
+    )
+    if armed_branch and not live_branch:
+        # Detached HEAD (a rebase, a bisect, `checkout <sha>`). Pushing from here
+        # would target something nobody asked for.
+        _autopilot_note(
+            title, rec, "workspace is on a detached HEAD — check out a branch"
         )
-        _emit_autopilot(title)
         return
-    if not armed_branch and live_branch:
+    if armed_branch and live_branch and live_branch != armed_branch:
+        if acted:
+            _autopilot_halt(
+                title,
+                "the workspace switched from %s to %s mid-run"
+                % (armed_branch, live_branch),
+            )
+            return
+        # Nothing has been done on the armed branch yet, so this is not "drift" —
+        # it is the agent creating its working branch, which is the NORMAL intake
+        # sequence. Follow it instead of refusing to work.
+        rec = (
+            _autopilot.update(
+                title,
+                branch=live_branch,
+                note="following the agent onto " + live_branch,
+            )
+            or rec
+        )
+    elif not armed_branch and live_branch:
         rec = _autopilot.update(title, branch=live_branch) or rec
+
+    # The retry allowlist is re-read EVERY pass, never frozen at arm time: intake
+    # arms hours before the commit step runs, and a hook id added in Settings must
+    # take effect on the next pass rather than needing a disarm/re-arm.
+    fresh_hooks = _precommit_retry_hooks()
+    if list(rec.get("retryable") or []) != fresh_hooks:
+        rec = _autopilot.update(title, retryable=fresh_hooks) or rec
 
     stage = _session_stage(inst)  # uncached on purpose
     return rec, inst, wt, _autopilot_snapshot(inst, title, wt, stage)
@@ -1594,19 +1687,44 @@ async def _autopilot_step(title: str) -> None:
     await _autopilot_act(title, wt, rec, snap, action, detail)
 
 
+def _autopilot_note(title: str, rec: dict, note: str) -> None:
+    """Record WHY a pass did nothing, write-on-change.
+
+    The store's whole design is to avoid a write per 5s pass, so this only writes
+    when the sentence actually changes — one write per phase transition. Without
+    it every hold looked the same to the UI (and to the user) as a dead chain.
+    """
+    try:
+        if (rec or {}).get("note") != note:
+            _autopilot.update(title, note=note)
+            _emit_autopilot_event(title)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _autopilot_wait(title, rec, snap, detail, now) -> None:
     """Book-keeping for a pass that decided to do nothing: keep the idle dwell
-    honest, and halt if this step has outlived its deadline."""
+    honest, publish the reason, and halt if this step outlived its deadline."""
     if detail.get("mark_idle") and rec.get("idle_since") is None:
         _autopilot.update(title, idle_since=now)
     elif snap["activity"] != "idle" and rec.get("idle_since") is not None:
         _autopilot.update(title, idle_since=None)
+    # Remember that the agent was seen doing something: a clean tree only means
+    # "finished with nothing to show" AFTER that, and means "not started yet"
+    # before it. Throttled so a working agent costs at most one write per 30s.
+    if str(snap.get("activity") or "") in ("working", "clarify"):
+        worked = float(rec.get("worked_at") or 0.0)
+        if now - worked > 30.0:
+            _autopilot.update(title, worked_at=now)
+    _autopilot_note(title, rec, detail.get("reason") or "")
     step = rec.get("step") or "agent"
     deadline = _AUTOPILOT_DEADLINES.get(step, _AUTOPILOT_DEADLINES["agent"])
     since = float(rec.get("step_since") or 0.0)
     if since and now - since > deadline:
         _autopilot_halt(
-            title, "gave up waiting at %s after %dmin" % (step, deadline // 60)
+            title,
+            "gave up waiting at %s after %d min — %s"
+            % (step, deadline // 60, detail.get("reason") or "no progress"),
         )
 
 
@@ -1633,8 +1751,29 @@ async def _autopilot_act(title, wt, rec, snap, action, detail) -> None:
     """
     now = snap["now"]
     fields = {"acted_at": now, "step_since": now}
+    # Per-verb attempt cap. Without it a push the remote keeps refusing (protected
+    # branch, non-fast-forward, an auth prompt) was re-typed every 15s forever: the
+    # stage never moves, so next_action keeps saying "push", and acting re-stamps
+    # step_since so the deadline can never fire either.
+    issues = dict(rec.get("issues") or {})
+    tries = int(issues.get(action) or 0)
+    if tries >= _autopilot.MAX_ACTIONS_PER_VERB:
+        await asyncio.to_thread(
+            _autopilot_halt,
+            title,
+            "%s did not take after %d attempts — do it by hand"
+            % (action.replace("_", " "), tries),
+        )
+        return
+    issues[action] = tries + 1
+    fields["issues"] = issues
     try:
-        if action == "commit":
+        if action == "run_check":
+            started = await asyncio.to_thread(_autopilot_run_check, title, wt)
+            if not started:
+                return
+            fields["step"] = "check"
+        elif action == "commit":
             done = await asyncio.to_thread(
                 _autopilot_commit, title, wt, rec, detail, fields
             )
@@ -1666,7 +1805,26 @@ async def _autopilot_act(title, wt, rec, snap, action, detail) -> None:
         elif action == "merge":
             resp = await instance_merge_pr(title)
             if resp.status_code >= 400:
-                await asyncio.to_thread(_autopilot_halt, title, _resp_error(resp))
+                msg = _resp_error(resp)
+                low = msg.lower()
+                # GitHub says "not mergeable" while required checks are still
+                # queued. That is a WAIT — halting there raced the CI we are
+                # deliberately waiting for.
+                if any(
+                    k in low
+                    for k in (
+                        "not mergeable",
+                        "required status check",
+                        "pending",
+                        "waiting",
+                        "in progress",
+                    )
+                ):
+                    await asyncio.to_thread(
+                        _autopilot_note, title, rec, "GitHub is not ready: " + msg
+                    )
+                    return
+                await asyncio.to_thread(_autopilot_halt, title, msg)
                 return
             body = _resp_json(resp)
             if body.get("ok") is False:
@@ -1684,6 +1842,63 @@ async def _autopilot_act(title, wt, rec, snap, action, detail) -> None:
         return
     _autopilot.update(title, **fields)
     await asyncio.to_thread(_emit_autopilot, title)
+
+
+def _pending_commit_message(wt: str) -> str:
+    """The on-disk commit message, but ONLY when the last attempt failed.
+
+    After a success there is nothing to retry, so a lingering message is stale and
+    must not be adopted by the next thing that commits without one.
+    """
+    try:
+        with open(os.path.join(wt, _COMMIT_STATUS_FILE)) as fh:
+            if fh.read().strip() in ("", "0"):
+                return ""
+    except OSError:
+        return ""  # no attempt recorded — nothing is pending
+    try:
+        with open(os.path.join(wt, _COMMIT_MSG_FILE)) as fh:
+            return fh.read().strip()
+    except OSError:
+        return ""
+
+
+def _autopilot_default_message(inst, wt: str) -> str:
+    """A commit subject for a fast-track press that carried none.
+
+    Prefers the session's own identity, which for an intake session IS the item
+    ("sc-1421-fix-login" / "issue-owner-repo-42"), so the commit reads as the work
+    it is rather than as boilerplate.
+    """
+    try:
+        title = str(getattr(inst, "Title", "") or "").strip()
+    except Exception:  # noqa: BLE001
+        title = ""
+    branch = ""
+    try:
+        branch = _current_branch(wt) or ""
+    except Exception:  # noqa: BLE001
+        branch = ""
+    subject = title or branch
+    return ("Work on %s" % subject) if subject else "Work in progress"
+
+
+def _autopilot_run_check(title: str, wt: str) -> bool:
+    """Start the worktree's verification check. Returns whether one is now running.
+
+    The push route soft-gates on this check, so the driver has to RUN it rather
+    than discover the gate as a 409 and halt. Idempotent: an already-running check
+    counts as started.
+    """
+    try:
+        if _wt_setup.is_running(wt, "check"):
+            return True
+        cfg = _wt_setup.load_config(wt)
+        if not cfg.check_command:
+            return False
+        return bool(_wt_setup.start_check(title, wt, cfg.check_command))
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _autopilot_commit(title, wt, rec, detail, fields) -> bool:
@@ -1774,6 +1989,7 @@ def _emit_autopilot_event(title: str) -> None:
                 "step": rec.get("step") or "",
                 "state": rec.get("state") or "",
                 "reason": rec.get("reason") or "",
+                "note": rec.get("note") or "",
                 "item": rec.get("item") or "",
                 "skipped": list(rec.get("skipped") or []),
             },
@@ -2695,6 +2911,11 @@ def get_config() -> JSONResponse:
             # Auth gate state so Settings can show the current effective mode.
             "auth_mode": _auth.effective_mode(),
             "auth_enabled": _auth.auth_enabled(),
+            # The resolved fast-track rung, so the ⏩ button can NAME where it will
+            # stop. Display only — the server still decides the actual depth when a
+            # request omits one, which is what keeps this setting authoritative
+            # instead of shadowed by a sticky client value.
+            "fasttrack_depth": _fasttrack_depth(),
         }
     )
 
@@ -4391,6 +4612,15 @@ def _commit_shell_command(skip: str = "") -> str:
         "git add -A; n=$((n+1)); "
         "done; "
         'echo $rc > {status}; rm -f "$L"'
+        # Drop the message file once the commit LANDED. It exists only so a
+        # blocked commit can be retried (and re-offered in the dialog) with the
+        # same message — but it used to survive success and unrelated work, so the
+        # next commit that arrived without a message silently adopted a stale
+        # subject. That is not theoretical: a run was caught about to record 19
+        # files of one feature under a message describing a database migration.
+        # Now a leftover message can only exist while a failure is genuinely
+        # pending, which is exactly the case reuse is for.
+        "; [ $rc -eq 0 ] && rm -f {msgf} || true"
     ).format(
         msgf=shlex.quote(_COMMIT_MSG_FILE),
         status=_COMMIT_STATUS_FILE,
@@ -4922,13 +5152,19 @@ async def instance_fast_track(
         )
     msg = str(body.get("message") or "").strip()
     if not msg:
-        try:
-            with open(os.path.join(wt, _COMMIT_MSG_FILE)) as fh:
-                msg = fh.read().strip()
-        except OSError:
-            msg = ""
+        # Only adopt the on-disk message when a FAILED attempt is pending — the
+        # same rule GET /commit-message applies. Reusing it unconditionally meant a
+        # message left by unrelated work became the subject of whatever was armed
+        # next.
+        msg = await asyncio.to_thread(_pending_commit_message, wt)
     if not msg and await asyncio.to_thread(_is_dirty, wt):
-        return JSONResponse({"error": "commit message required"}, status_code=400)
+        # The ⏩ button presses with no message, and `.mindflock_commit_msg` only
+        # exists once something has committed THROUGH MindFlock — so the single most
+        # common press ("I have work, carry it to a PR") used to be rejected
+        # outright. Generate a subject instead of refusing: a chain that halts
+        # because nobody typed a sentence is worse than an honest default one, and
+        # the user can always amend it afterwards.
+        msg = await asyncio.to_thread(_autopilot_default_message, inst, wt)
     rec = await asyncio.to_thread(
         lambda: _autopilot.arm(
             title,

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22749,18 +22749,18 @@ function dropSideFor(rect, clientX, clientY) {
   if (Math.abs(dx) >= Math.abs(dy)) return dx < 0 ? "left" : "right";
   return dy < 0 ? "top" : "bottom";
 }
-const inflight = /* @__PURE__ */ new Map();
+const inflight$1 = /* @__PURE__ */ new Map();
 function freshStage(title) {
   if (!title) return Promise.resolve(null);
-  const live = inflight.get(title);
+  const live = inflight$1.get(title);
   if (live) return live;
   const p = instApi(title, "/stage").then((row) => {
     if (row && row.title) patchInstance(title, row);
     return row ?? null;
   }).catch(() => null).finally(() => {
-    inflight.delete(title);
+    inflight$1.delete(title);
   });
-  inflight.set(title, p);
+  inflight$1.set(title, p);
   return p;
 }
 const DEPTHS = ["agent", "commit", "push", "pr", "merge"];
@@ -22778,9 +22778,16 @@ const DEPTH_STEP_LABELS = {
   off: "Off",
   agent: "Agent only",
   commit: "Commit only",
-  push: "…then push",
-  pr: "…then open PR",
-  merge: "…then merge"
+  push: "Then push",
+  pr: "Then open PR",
+  merge: "Then merge"
+};
+const DEPTH_SHORT = {
+  agent: "→ agent",
+  commit: "→ commit",
+  push: "→ push",
+  pr: "→ PR",
+  merge: "→ merge"
 };
 function depthLabel(depth) {
   return DEPTH_LABELS[depth] || depth || "Off";
@@ -22796,7 +22803,7 @@ function autopilotChipTitle(run) {
   if (run.state === "halted")
     return "Fast-track stopped: " + (run.reason || "unknown reason");
   if (run.state === "done") return "Fast-track finished at " + target;
-  const where = run.step ? " (last step: " + run.step + ")" : " (waiting on the agent)";
+  const where = run.note ? " — " + run.note : run.step ? " (last step: " + run.step + ")" : " (waiting to start)";
   const skipped = ((_a2 = run.skipped) == null ? void 0 : _a2.length) ? "\nSkipped hooks: " + run.skipped.join(", ") : "";
   return "Fast-tracking to " + target + where + "\nClick to stop." + skipped;
 }
@@ -22997,42 +23004,30 @@ function commitSession(title) {
 async function pushSession(title, force = false) {
   if (!title || !requireGit()) return;
   selectSession(title, { noKeyboard: true });
+  markStep(title, "push");
   try {
     await instApi(title, "/push-branch", { json: force ? { force: true } : {} });
   } catch (err) {
     if (err.message === "checks haven't passed for this commit") {
       if (confirm("Checks haven't passed for this commit (see the ✗ checks chip).\nPush anyway?"))
         return pushSession(title, true);
+      clearStep(title);
       return;
     }
+    clearStep(title);
     toast("Push failed: " + errMsg(err), { duration: 6e3 });
   }
   void freshStage(title);
 }
-const DEPTH_KEY = "mf_fasttrack_depth";
 function resolveDepth() {
-  var _a2;
-  try {
-    const local = normalizeDepth(localStorage.getItem(DEPTH_KEY));
-    if (local && local !== "off") return local;
-  } catch {
-  }
   const cfg = queryClient.getQueryData(["config"]);
-  const fromSettings = normalizeDepth(
-    (_a2 = cfg == null ? void 0 : cfg.repository) == null ? void 0 : _a2.fasttrack_depth
-  );
-  return fromSettings && fromSettings !== "off" ? fromSettings : "pr";
-}
-function rememberDepth(depth) {
-  try {
-    localStorage.setItem(DEPTH_KEY, normalizeDepth(depth) || "");
-  } catch {
-  }
+  return normalizeDepth(cfg == null ? void 0 : cfg.fasttrack_depth) || "pr";
 }
 async function startFastTrack(title, depth, message, base) {
   var _a2;
   if (!title || !requireGit()) return;
-  const d = normalizeDepth(depth) || "pr";
+  const chosen = normalizeDepth(depth || "");
+  const d = chosen || resolveDepth();
   if (d === "merge") {
     const where = "";
     if (!confirm("Fast-track will commit, push, open a PR and MERGE it" + where + ".\nContinue?"))
@@ -23052,7 +23047,7 @@ async function startFastTrack(title, depth, message, base) {
   try {
     const r = await instApi(title, "/fast-track", {
       json: {
-        depth: d,
+        ...chosen ? { depth: chosen } : {},
         ...message ? { message } : {},
         ...base ? { base } : {}
       }
@@ -23092,6 +23087,7 @@ function makePrSession(title) {
 }
 async function submitMakePr(title, base) {
   if (!title || !requireGit()) return;
+  markStep(title, "pr");
   try {
     const r = await instApi(title, "/make-pr", {
       json: base ? { base } : {}
@@ -23105,6 +23101,7 @@ async function submitMakePr(title, base) {
       markLoopReset(title);
     }
   } catch (err) {
+    clearStep(title);
     toast("Make PR failed: " + errMsg(err), { duration: 6e3 });
   }
   await freshStage(title);
@@ -23112,6 +23109,7 @@ async function submitMakePr(title, base) {
 async function mergeSession(title) {
   if (!title || !requireGit()) return;
   if (!confirm("Merge this branch's PR into staging?")) return;
+  markStep(title, "merge");
   try {
     const r = await instApi(title, "/merge-pr", { method: "POST" });
     if (r && r.ok === false) {
@@ -23120,6 +23118,7 @@ async function mergeSession(title) {
       else toast(msg, { duration: 9e3 });
     }
   } catch (err) {
+    clearStep(title);
     toast("Merge failed: " + errMsg(err), { duration: 6e3 });
   }
   await freshStage(title);
@@ -23297,6 +23296,87 @@ function checkChip(inst) {
 }
 const NO_ORIGIN_CMD = "git remote add origin git@github.com:owner/repo.git";
 const NO_ORIGIN_ALT = "git remote add origin https://github.com/owner/repo.git";
+const inflight = /* @__PURE__ */ new Map();
+const INFLIGHT_TTL_MS = 12e4;
+function markStep(title, verb) {
+  if (title) inflight.set(title, { verb, at: Date.now() });
+}
+function clearStep(title) {
+  inflight.delete(title);
+}
+function inflightVerb(inst) {
+  const title = inst.title;
+  if (!title) return null;
+  const rec = inflight.get(title);
+  if (!rec) return null;
+  if (Date.now() - rec.at > INFLIGHT_TTL_MS) {
+    inflight.delete(title);
+    return null;
+  }
+  const stage = inst.stage || "";
+  if (rec.verb === "push" && (stage === "pushed" || stage === "pr") || rec.verb === "pr" && stage === "pr" || rec.verb === "merge" && stage !== "pr") {
+    inflight.delete(title);
+    return null;
+  }
+  return rec.verb;
+}
+function liveStep(inst) {
+  const stage = guidedStage(inst);
+  if (inst.workspace_missing)
+    return { label: "workspace gone", tone: "blocked", title: "The workspace directory no longer exists." };
+  if (inst.status === "paused")
+    return { label: "paused", tone: "quiet", title: "Session paused — resume it to continue." };
+  const setup = inst.setup;
+  if ((setup == null ? void 0 : setup.state) === "running")
+    return { label: "setting up", tone: "work", title: "Running the workspace setup commands." };
+  if ((setup == null ? void 0 : setup.state) === "failed")
+    return {
+      label: "setup failed",
+      tone: "blocked",
+      title: "Workspace setup failed" + (setup.failed_step ? " at " + setup.failed_step : "") + ". Queued prompts are held until it succeeds."
+    };
+  if (stage === "provisioning")
+    return { label: "provisioning", tone: "work", title: "Creating the workspace." };
+  if (stage === "precommit")
+    return { label: "pre-commit", tone: "work", title: "Running the pre-commit hooks." };
+  if (stage === "interrupt")
+    return {
+      label: "pre-commit ✗",
+      tone: "blocked",
+      title: "A pre-commit hook blocked the commit" + (inst.failed_step ? " at " + inst.failed_step : "") + "."
+    };
+  const verb = inflightVerb(inst);
+  if (verb === "push") return { label: "pushing", tone: "work", title: "Pushing the branch to origin." };
+  if (verb === "pr") return { label: "opening PR", tone: "work", title: "Opening the pull request." };
+  if (verb === "merge") return { label: "merging", tone: "work", title: "Merging the pull request." };
+  const check = inst.check;
+  if ((check == null ? void 0 : check.state) === "running")
+    return { label: "checks", tone: "work", title: "Running the verification check." };
+  if ((check == null ? void 0 : check.state) === "failed")
+    return {
+      label: "checks ✗",
+      tone: "blocked",
+      title: "The verification check failed" + (check.failed_step ? " at " + check.failed_step : "") + "."
+    };
+  const run = inst.autopilot;
+  if (run && run.depth && run.state === "running")
+    return {
+      label: run.note || "fast-tracking",
+      tone: "work",
+      title: autopilotChipTitle(run),
+      target: DEPTH_SHORT[run.depth] || ""
+    };
+  if (run && run.depth && run.state === "halted")
+    return { label: "fast-track ✗", tone: "blocked", title: autopilotChipTitle(run) };
+  if (stage === "pr")
+    return {
+      label: "PR open",
+      tone: "ok",
+      title: inst.pr_url ? "Open the pull request" : "A pull request is open for this branch.",
+      href: inst.pr_url || void 0
+    };
+  return null;
+}
 function fastTrackStep(inst) {
   var _a2;
   const title = inst.title;
@@ -24163,6 +24243,32 @@ function EventToasts() {
         notifyOnce(env.session, "checkfail", "checks failed on " + env.session, {
           onClick: () => selectSession(env.session)
         });
+      })
+    );
+    unsubs.push(
+      // Autopilot steps reached the UI only on the next 4s poll, so "pushing" could
+      // be over before it appeared. Patch the cache from the socket instead — same
+      // shape and same before-the-replay-guard reasoning as stage_changed below.
+      ev.subscribe("session.autopilot_changed", (env) => {
+        const d = env.data || {};
+        const depth = String(d.depth || "");
+        patchInstance(env.session, {
+          autopilot: depth ? {
+            depth,
+            state: String(env.new || d.state || "running"),
+            step: String(d.step || ""),
+            reason: String(d.reason || ""),
+            note: String(d.note || ""),
+            source: String(d.source || "session"),
+            item: String(d.item || ""),
+            skipped: Array.isArray(d.skipped) ? d.skipped : []
+          } : null
+        });
+        if (isReplay(env)) return;
+        if (String(env.new || "") === "halted")
+          notifyOnce(env.session, "ftstop", "fast-track stopped on " + env.session, {
+            onClick: () => selectSession(env.session)
+          });
       })
     );
     unsubs.push(
@@ -27648,6 +27754,7 @@ function Pane({
   const chip = chipState(inst);
   const ns = nextStep(inst);
   const ft = fastTrackStep(inst);
+  const step = liveStep(inst);
   const q = inst.queue;
   const pending = (q == null ? void 0 : q.pending) || 0;
   const limitedMs = (q == null ? void 0 : q.limited_until) ? q.limited_until * 1e3 - Date.now() : 0;
@@ -27711,7 +27818,23 @@ function Pane({
                 },
                 children: ns.label
               }
-            ) : /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "nextstep nextstep-status", type: "button", disabled: true, title: chip.title, children: chip.label }),
+            ) : null,
+            step && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+              "span",
+              {
+                className: "stepnow is-" + step.tone + (step.href ? " is-link" : ""),
+                title: step.title,
+                onClick: step.href ? (ev) => {
+                  ev.stopPropagation();
+                  window.open(step.href, "_blank");
+                } : void 0,
+                children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "stepnow-dot", "aria-hidden": "true" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "stepnow-text", children: step.label }),
+                  step.target && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "stepnow-target", children: step.target })
+                ]
+              }
+            ),
             ft && /* @__PURE__ */ jsxRuntimeExports.jsx(
               "button",
               {
@@ -29584,6 +29707,7 @@ function useSettingsModel(open) {
           json: { [group]: { [field]: value } }
         });
         setSettings((r == null ? void 0 : r.settings) || {});
+        void refreshConfig();
         toast("Saved " + field.replace(/_/g, " "));
       } catch (err) {
         toast("Save failed: " + (err.message || field));
@@ -29597,6 +29721,7 @@ function useSettingsModel(open) {
       try {
         const r = await api("/api/settings", { json: { [group]: patch } });
         setSettings((r == null ? void 0 : r.settings) || {});
+        void refreshConfig();
         if (okMsg) toast(okMsg);
       } catch (err) {
         toast("Save failed: " + (err.message || group));
@@ -33768,13 +33893,9 @@ function CommitDialog() {
     closeDialog();
     useUi.getState().setLastTab(title, "shell");
     selectSession(title);
-    if (chosen !== "commit") {
-      await startFastTrack(title, chosen, m);
-      void freshStage(title);
-      return;
-    }
     try {
       await instApi(title, "/commit", { json: { message: m } });
+      if (chosen !== "commit") await startFastTrack(title, chosen, m);
     } catch (err) {
       alert("Commit failed: " + errMsg(err));
     }
@@ -33831,10 +33952,7 @@ function CommitDialog() {
                 {
                   id: "commit-depth",
                   value: depth,
-                  onChange: (e) => {
-                    setDepth(e.target.value);
-                    rememberDepth(e.target.value);
-                  },
+                  onChange: (e) => setDepth(e.target.value),
                   children: SESSION_DEPTHS.map((d) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: d, children: DEPTH_STEP_LABELS[d] }, d))
                 }
               )

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -23377,6 +23377,41 @@ function liveStep(inst) {
     };
   return null;
 }
+const followed = /* @__PURE__ */ new Map();
+function followAutopilot(inst, opts) {
+  const title = inst.title;
+  const run = inst.autopilot;
+  if (!title) return null;
+  if (!run || !run.depth || run.state !== "running") {
+    followed.delete(title);
+    return null;
+  }
+  const step = String(run.step || "");
+  const seen = followed.get(title);
+  if (seen === step) return null;
+  const first = seen === void 0;
+  followed.set(title, step);
+  if (first && !(opts == null ? void 0 : opts.live)) return null;
+  if (step === "commit") {
+    try {
+      useUi.getState().setLastTab(title, "shell");
+      selectSession(title);
+    } catch {
+    }
+    return "commit";
+  }
+  if (step === "pr") {
+    const url = String(run.url || "") || inst.pr_url || "";
+    if (url) {
+      try {
+        offerUrl(url, "PR opened for " + title);
+      } catch {
+      }
+    }
+    return "pr";
+  }
+  return null;
+}
 function fastTrackStep(inst) {
   var _a2;
   const title = inst.title;
@@ -24096,7 +24131,6 @@ function NotifToggle({ state, onChange }) {
 }
 const BASE_TITLE = document.title || "MindFlock";
 const clarifyUnseen = /* @__PURE__ */ new Set();
-const lastStep = /* @__PURE__ */ new Map();
 function instances() {
   return queryClient.getQueryData(["instances"]) || [];
 }
@@ -24270,16 +24304,22 @@ function EventToasts() {
           } : null
         });
         if (isReplay(env)) return;
-        const step = String(d.step || "");
-        if (step === "commit" && lastStep.get(env.session) !== "commit") {
-          useUi.getState().setLastTab(env.session, "shell");
-          selectSession(env.session);
-        }
-        if (step === "pr" && lastStep.get(env.session) !== "pr") {
-          const url = String(d.url || "");
-          if (url) offerUrl(url, "PR opened for " + env.session);
-        }
-        lastStep.set(env.session, step);
+        followAutopilot(
+          {
+            title: env.session,
+            autopilot: {
+              depth: String(d.depth || ""),
+              state: String(env.new || d.state || "running"),
+              step: String(d.step || ""),
+              reason: String(d.reason || ""),
+              note: String(d.note || ""),
+              url: String(d.url || ""),
+              source: String(d.source || "session"),
+              item: String(d.item || "")
+            }
+          },
+          { live: true }
+        );
         if (String(env.new || "") === "halted")
           notifyOnce(env.session, "ftstop", "fast-track stopped on " + env.session, {
             onClick: () => selectSession(env.session)
@@ -35389,6 +35429,7 @@ function App() {
     for (const inst of instances2 || []) {
       noteActivity(inst);
       reconcileLoopReset(inst);
+      followAutopilot(inst);
     }
   }, [instances2]);
   const [openSpecial, setOpenSpecial] = reactExports.useState(/* @__PURE__ */ new Set());

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -23382,11 +23382,15 @@ function fastTrackStep(inst) {
   const title = inst.title;
   const caps2 = (_a2 = queryClient.getQueryData(["config"])) == null ? void 0 : _a2.caps;
   if (caps2 && !caps2.git) return null;
-  if (!title || inst.status === "loading" || inst.status === "paused") return null;
-  if (inst.workspace_missing) return null;
-  const stage = guidedStage(inst);
-  if (stage === "provisioning" || stage === "precommit") return null;
+  if (!title) return null;
   const run = inst.autopilot;
+  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted"));
+  if (!armed) {
+    if (inst.status === "loading" || inst.status === "paused") return null;
+    if (inst.workspace_missing) return null;
+    const stage = guidedStage(inst);
+    if (stage === "provisioning" || stage === "precommit") return null;
+  }
   if (run && run.depth && run.state === "running")
     return {
       label: "⏩",

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -34567,11 +34567,25 @@ function RecentDialog() {
           const gone = !e.exists;
           return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "recent-row", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "recent-info", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "recent-name", title: e.folder || "", children: e.title || "(untitled)" }),
-              e.in_place && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ws-badge kind", children: "in-place" }),
-              e.provisioned && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ws-badge kind", children: "provisioned" }),
-              gone && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ws-badge gone", children: "worktree gone" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "recent-when muted", children: fmtClosedAt(e.closed_at) })
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "span",
+                {
+                  className: "recent-name",
+                  title: [
+                    e.branch ? "Branch: " + e.branch : "",
+                    e.title ? "Session: " + e.title : "",
+                    e.folder || ""
+                  ].filter(Boolean).join("\n"),
+                  children: e.branch || e.title || "(untitled)"
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "recent-sub", children: [
+                e.branch && e.title && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "recent-slug muted", children: e.title }),
+                e.in_place && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ws-badge kind", children: "in-place" }),
+                e.provisioned && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ws-badge kind", children: "provisioned" }),
+                gone && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ws-badge gone", children: "worktree gone" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "recent-when muted", children: fmtClosedAt(e.closed_at) })
+              ] })
             ] }),
             /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "recent-actions", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx(

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22802,7 +22802,8 @@ function autopilotChipTitle(run) {
   const target = depthLabel(run.depth);
   if (run.state === "halted")
     return "Fast-track stopped: " + (run.reason || "unknown reason");
-  if (run.state === "done") return "Fast-track finished at " + target;
+  if (run.state === "done")
+    return "Fast-track finished at " + target + " — still on, and will pick up new work automatically.";
   const where = run.note ? " — " + run.note : run.step ? " (last step: " + run.step + ")" : " (waiting to start)";
   const skipped = ((_a2 = run.skipped) == null ? void 0 : _a2.length) ? "\nSkipped hooks: " + run.skipped.join(", ") : "";
   return "Fast-tracking to " + target + where + "\nClick to stop." + skipped;
@@ -23444,7 +23445,7 @@ function fastTrackStep(inst) {
   if (caps2 && !caps2.git) return null;
   if (!title) return null;
   const run = inst.autopilot;
-  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted"));
+  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted" || run.state === "done"));
   if (!armed) {
     if (inst.status === "loading" || inst.status === "paused") return null;
     if (inst.workspace_missing) return null;
@@ -23464,6 +23465,13 @@ function fastTrackStep(inst) {
       hint: true,
       title: autopilotChipTitle(run) + "\n\nClick ⏩✗ to start fast-track again.",
       run: () => startFastTrack(title, run.depth)
+    };
+  if (run && run.depth && run.state === "done")
+    return {
+      label: "⏩",
+      active: true,
+      title: "Fast-track finished at " + depthLabel(run.depth) + " and is still on: it picks up again as soon as the agent changes\nanything more.\n\nClick ⏩ to turn fast-track off.",
+      run: () => stopFastTrack(title)
     };
   const depth = resolveDepth();
   return {

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -26003,7 +26003,12 @@ function AutomationBar() {
               // `active` outranks the switch: a ticket forced from Intake is
               // genuinely being brought in even with auto ingestion switched off,
               // and "off" would be a lie about the work in flight.
-              "dc-dot " + (netIssue ? "error" : active ? "on" : !desired ? "off" : "idle")
+              // "dc-error", NOT a bare "error": `.error` is a GLOBAL class for error
+              // TEXT (`.error { min-height: 16px }`), and this element is a 9px circle.
+              // `.dc-dot` sets height but never min-height, so the global won
+              // uncontested and rendered the red state as a 9x16 OVAL — the one state
+              // that looked malformed, because it was the only one borrowing that name.
+              "dc-dot " + (netIssue ? "dc-error" : active ? "on" : !desired ? "off" : "idle")
             ),
             title: active ? "A ticket is being brought in right now (auto ingestion or a forced start)" : netIssue ? online ? "Connection issues in the ingestion log — see Settings → System logs" : "No network connection" : starting ? "Set to on but not running yet — starting, or the pipeline exited (flip the switch off and on to restart it)" : desired ? "Waiting for an assigned ticket — turns green while one is being brought in" : void 0
           }

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22807,6 +22807,22 @@ function autopilotChipTitle(run) {
   const skipped = ((_a2 = run.skipped) == null ? void 0 : _a2.length) ? "\nSkipped hooks: " + run.skipped.join(", ") : "";
   return "Fast-tracking to " + target + where + "\nClick to stop." + skipped;
 }
+function mergeBlockerLabel(ms) {
+  switch (ms.state) {
+    case "dirty":
+      return "conflicts";
+    case "behind":
+      return "behind base";
+    case "draft":
+      return "draft PR";
+    case "blocked":
+      if (ms.checks === "failed") return "checks ✗";
+      if (ms.checks === "pending") return "checks…";
+      return "review needed";
+    default:
+      return ms.mergeable === null ? "checking…" : "can't merge";
+  }
+}
 function caps() {
   var _a2;
   return ((_a2 = queryClient.getQueryData(["config"])) == null ? void 0 : _a2.caps) ?? {
@@ -23368,13 +23384,22 @@ function liveStep(inst) {
     };
   if (run && run.depth && run.state === "halted")
     return { label: "fast-track ✗", tone: "blocked", title: autopilotChipTitle(run) };
-  if (stage === "pr")
+  if (stage === "pr") {
+    const ms = inst.merge_state;
+    if (ms && !ms.can_merge)
+      return {
+        label: mergeBlockerLabel(ms),
+        tone: "blocked",
+        title: "This PR cannot be merged yet:\n" + (ms.blockers || []).map((b) => "• " + b).join("\n"),
+        href: inst.pr_url || ms.url || void 0
+      };
     return {
       label: "PR open",
       tone: "ok",
       title: inst.pr_url ? "Open the pull request" : "A pull request is open for this branch.",
       href: inst.pr_url || void 0
     };
+  }
   return null;
 }
 const followed = /* @__PURE__ */ new Map();
@@ -23486,6 +23511,17 @@ function nextStep(inst) {
           title: PR_FALLBACK_HINT,
           run: () => window.open(inst.pr_url, "_blank")
         } : { label: "Merge ↗", hint: true, title: PR_FALLBACK_HINT, run: () => mergeSession(title) };
+      {
+        const ms = inst.merge_state;
+        if (ms && !ms.can_merge)
+          return {
+            label: "Merge blocked",
+            disabled: true,
+            title: "This PR cannot be merged yet:\n" + (ms.blockers || []).map((b) => "• " + b).join("\n") + (inst.pr_url ? "\n\nOpen the PR to resolve it." : ""),
+            run: () => {
+            }
+          };
+      }
       return { label: "Merge", run: () => mergeSession(title) };
     case "merged":
       return inst.pr_url ? { label: "Open PR ↗", run: () => window.open(inst.pr_url, "_blank") } : null;
@@ -27864,12 +27900,13 @@ function Pane({
             ns ? /* @__PURE__ */ jsxRuntimeExports.jsx(
               "button",
               {
-                className: "nextstep" + (ns.hint ? " nextstep-hint" : ""),
+                className: "nextstep" + (ns.hint ? " nextstep-hint" : "") + (ns.disabled ? " nextstep-blocked" : ""),
                 type: "button",
+                disabled: !!ns.disabled,
                 title: ns.title || "Do the next step",
                 onClick: (ev) => {
                   ev.stopPropagation();
-                  ns.run();
+                  if (!ns.disabled) ns.run();
                 },
                 children: ns.label
               }

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -24092,6 +24092,7 @@ function NotifToggle({ state, onChange }) {
 }
 const BASE_TITLE = document.title || "MindFlock";
 const clarifyUnseen = /* @__PURE__ */ new Set();
+const lastStep = /* @__PURE__ */ new Map();
 function instances() {
   return queryClient.getQueryData(["instances"]) || [];
 }
@@ -24265,6 +24266,16 @@ function EventToasts() {
           } : null
         });
         if (isReplay(env)) return;
+        const step = String(d.step || "");
+        if (step === "commit" && lastStep.get(env.session) !== "commit") {
+          useUi.getState().setLastTab(env.session, "shell");
+          selectSession(env.session);
+        }
+        if (step === "pr" && lastStep.get(env.session) !== "pr") {
+          const url = String(d.url || "");
+          if (url) offerUrl(url, "PR opened for " + env.session);
+        }
+        lastStep.set(env.session, step);
         if (String(env.new || "") === "halted")
           notifyOnce(env.session, "ftstop", "fast-track stopped on " + env.session, {
             onClick: () => selectSession(env.session)

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -23417,16 +23417,15 @@ function followAutopilot(inst, opts) {
   if (seen === step) return null;
   const first = seen === void 0;
   followed.set(title, step);
-  if (first && !(opts == null ? void 0 : opts.live)) return null;
   if (step === "commit") {
     try {
       useUi.getState().setLastTab(title, "shell");
-      selectSession(title);
     } catch {
     }
     return "commit";
   }
   if (step === "pr") {
+    if (first && !(opts == null ? void 0 : opts.live)) return null;
     const url = String(run.url || "") || inst.pr_url || "";
     if (url) {
       try {

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -2266,6 +2266,14 @@ p.set-hint {
 #git-issue-bar .dc-dot {
   width: 9px;
   height: 9px;
+  /* Pin the box so no inherited or globally-scoped rule can deform the circle.
+     The red state used to carry a bare `error` class, and the app-wide
+     `.error { min-height: 16px }` (meant for error TEXT) beat an unset min-height
+     — producing a 9x16 oval in exactly one state. The state class is scoped now,
+     but stating these makes the shape robust rather than merely currently-correct. */
+  min-width: 0;
+  min-height: 0;
+  box-sizing: border-box;
   border-radius: 50%;
   flex: none;
 }
@@ -2290,10 +2298,12 @@ p.set-hint {
   background: var(--gold);
 }
 
-/* Browser offline, or the ingestion log shows recent connection failures. */
-#mindflock-bar .dc-dot.error,
-#pr-review-bar .dc-dot.error,
-#git-issue-bar .dc-dot.error {
+/* Browser offline, or the ingestion log shows recent connection failures.
+   Named `dc-error` rather than `error` so it cannot pick up the app-wide
+   error-TEXT rule (see the shape comment above). */
+#mindflock-bar .dc-dot.dc-error,
+#pr-review-bar .dc-dot.dc-error,
+#git-issue-bar .dc-dot.dc-error {
   background: var(--red);
   box-shadow: 0 0 6px var(--red);
 }

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -4699,6 +4699,10 @@ p.set-hint {
 
 .pane-head {
   flex-wrap: nowrap;
+  /* Backstop only. With the title able to shrink to 2.5rem and the container
+     queries below shedding the optional bits, this should never engage — but a
+     header that spills past the pane's rounded corner looks broken, so clip. */
+  overflow: hidden;
 }
 
 /* Normal right padding. (The old 54px gutter reserved room for the floating
@@ -4707,10 +4711,16 @@ p.set-hint {
   padding-right: 12px;
 }
 
+/* The title is the ONE thing in this header that yields.
+   `flex-shrink: 3` against the context line's 1 makes it absorb most of any
+   reduction, and the small floor lets it truncate hard — a 60-character session
+   name should cost its own characters, never the Commit button, the fast-track
+   toggle or the live-step indicator. Those are controls; the title is a label
+   whose full text is one hover away (title= carries it). */
 .pane-head .title {
   font-weight: 600;
-  flex: 0 1 auto;
-  min-width: 40px;
+  flex: 0 3 auto;
+  min-width: 2.5rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4887,12 +4897,12 @@ p.set-hint {
   align-items: center;
   gap: 6px;
   margin-left: 10px;
-  /* Was `flex: none` via `.tabs, .actions`. Now that this group can hold a text
-     label it has to be able to YIELD, or a verbose step pushes the usage chip and
-     the copy-history button out of the pane. */
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
+  /* NEVER shrinks. Making this yield (so a verbose step label could not push the
+     usage chip out) meant a long session title clipped the controls instead —
+     the Commit button, the ⏩ toggle and the step indicator were sliced off the
+     right edge. The label is bounded by its own max-width and the container
+     queries below, so the group's width stays predictable without shrinking. */
+  flex: none;
 }
 
 .pane-head .actions .nextstep {
@@ -4937,7 +4947,10 @@ p.set-hint {
 .pane-head .actions .stepnow-text {
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 22ch;
+  /* Bounded because `.actions` no longer shrinks: the group's width has to be
+     predictable. The server's wait sentences run long ("waiting for CI to pass
+     before merging"), and the full text is in the tooltip. */
+  max-width: 15ch;
 }
 
 .pane-head .actions .stepnow-target {

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -4779,6 +4779,23 @@ p.set-hint {
   .pane-head .tok {
     display: none;
   }
+
+  .pane-head .actions .stepnow-target {
+    display: none;
+  }
+
+  .pane-head .actions .stepnow-text {
+    max-width: 12ch;
+  }
+}
+
+/* Tightest layout: the dot alone still says "running / blocked", and the tooltip
+   still carries the detail. Deliberately NOT hidden with .nextstep at 420px —
+   once the action button is gone this is the only signal left. */
+@container (max-width: 360px) {
+  .pane-head .actions .stepnow-text {
+    display: none;
+  }
 }
 
 /* Between the fixed breakpoints a header can still overflow (long titles,
@@ -4870,6 +4887,12 @@ p.set-hint {
   align-items: center;
   gap: 6px;
   margin-left: 10px;
+  /* Was `flex: none` via `.tabs, .actions`. Now that this group can hold a text
+     label it has to be able to YIELD, or a verbose step pushes the usage chip and
+     the copy-history button out of the pane. */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .pane-head .actions .nextstep {
@@ -4889,20 +4912,105 @@ p.set-hint {
   filter: brightness(1.12);
 }
 
-/* Status-pill variant: shown in the same slot when there's no actionable next
-   step (provisioning / pre-commit running / paused / workspace gone), so the
-   action area is never an empty gap. Non-clickable, muted — clearly not the
-   primary accent button. */
-.pane-head .actions .nextstep.nextstep-status {
-  background: var(--panel-2);
-  color: var(--muted);
+/* Live step indicator — what is happening RIGHT NOW.
+   Replaces the old `.nextstep-status` pill, which filled the primary button's
+   slot with DISABLED GREY TEXT whenever there was no actionable next step. That
+   meant the busiest moment in the workflow (pre-commit hooks running) rendered as
+   a dead greyed-out button reading "pre-commit". This is deliberately NOT
+   button-shaped: it is a status line, so it never competes with the real action.
+   Colour and fill carry the meaning; motion is only ever a bonus. */
+.pane-head .actions .stepnow {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  /* Same yield-then-clip contract the context line uses, so a long label can
+     never push the cost chip or the copy button out of the header. */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
   font-weight: 500;
-  cursor: default;
-  filter: none;
+  color: var(--muted);
+  white-space: nowrap;
 }
 
-.pane-head .actions .nextstep.nextstep-status:hover {
-  filter: none;
+.pane-head .actions .stepnow-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 22ch;
+}
+
+.pane-head .actions .stepnow-target {
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+
+.pane-head .actions .stepnow-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* work: something is running. Accent + the house pulse cadence. */
+.pane-head .actions .stepnow.is-work {
+  color: var(--accent);
+}
+
+.pane-head .actions .stepnow.is-work .stepnow-dot {
+  animation: step-ping 1.4s ease-in-out infinite;
+}
+
+/* blocked: it needs a human. */
+.pane-head .actions .stepnow.is-blocked {
+  color: var(--red);
+}
+
+/* ok: a finished, good state (a PR is open). */
+.pane-head .actions .stepnow.is-ok {
+  color: var(--green, #3fb950);
+}
+
+/* quiet: true but inert (paused). Hollow dot, so "not running" is legible
+   without relying on colour or motion. */
+.pane-head .actions .stepnow.is-quiet .stepnow-dot {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px currentColor;
+}
+
+.pane-head .actions .stepnow.is-link {
+  cursor: pointer;
+}
+
+.pane-head .actions .stepnow.is-link:hover {
+  text-decoration: underline;
+}
+
+/* Matches the shape of the existing mic-pulse ring, accent-tokenised, at the
+   house 1.4s ease-in-out cadence (see cs-pulse). */
+@keyframes step-ping {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0.55);
+  }
+
+  50% {
+    box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0);
+  }
+}
+
+/* Motion is decoration here — the dot's colour and fill already carry the state,
+   so removing it loses nothing. Honour both the OS setting and the app's own
+   reduce-motion preference. */
+@media (prefers-reduced-motion: reduce) {
+  .pane-head .actions .stepnow.is-work .stepnow-dot {
+    animation: none;
+  }
+}
+
+.no-motion .pane-head .actions .stepnow.is-work .stepnow-dot {
+  animation: none;
 }
 
 /* Fast-track (⏩): a SECONDARY control that sits beside the guided button and
@@ -6231,6 +6339,51 @@ p.set-hint {
 #commit-form textarea:focus {
   outline: none;
   border-color: var(--accent);
+}
+
+/* Fast-track rung picker.
+   A <select> does NOT inherit the card's typography: the UA stylesheet sets the
+   `font` shorthand on form controls, so without this rule it rendered as a raw
+   Arial platform widget (square corners, ButtonFace grey) inside a rounded dark
+   card whose every other control is --bg + 1px --border + 7px radius.
+   `align-self: start` matters too: `#commit-form label` is a column flexbox with
+   the default `align-items: stretch`, which spread a four-option picker across
+   the whole 480px card with ~300px of dead space. */
+#commit-form #commit-depth {
+  align-self: start;
+  min-width: 210px;
+  max-width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 7px;
+  padding: 7px 10px;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+#commit-form #commit-depth:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+#commit-form #commit-depth:hover {
+  border-color: var(--accent);
+}
+
+/* Caption and hint on ONE line: the label is a column flexbox, so a bare text
+   node plus the hint span would otherwise stack into two rows and make this row
+   taller than the message row's caption. */
+#commit-form #commit-depth-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  gap: 4px 6px;
+}
+
+#commit-form #commit-depth-row > select {
+  grid-column: 1 / -1;
 }
 
 /* Rename dialog (single-line display name; same card style as #commit-form) */

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -5026,6 +5026,22 @@ p.set-hint {
   animation: none;
 }
 
+/* Blocked: the action is known to be refusable, so the button says why and does
+   nothing. Muted like the old status pill, but it keeps a border so it still reads
+   as a control that exists rather than as absent — and the tooltip carries the
+   specific blockers. */
+.pane-head .actions .nextstep.nextstep-blocked {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  cursor: not-allowed;
+  font-weight: 500;
+}
+
+.pane-head .actions .nextstep.nextstep-blocked:hover {
+  filter: none;
+}
+
 /* Fast-track (⏩): a SECONDARY control that sits beside the guided button and
    arms the rest of the stack in one press. Deliberately an accent OUTLINE, not a
    filled accent — the guided next step must stay the one obvious default action,

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -6789,20 +6789,44 @@ p.set-hint {
   background: var(--bg);
 }
 
+/* Two lines: the branch on its own, then the identity/badges/timestamp beneath.
+   Stacking is what lets a 60-character branch name actually be READ — on one line
+   next to badges and a timestamp it just ellipsised away, which is the whole thing
+   the row exists to tell you. */
 .recent-info {
   flex: 1;
   min-width: 0;
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
 }
 
 .recent-name {
   font-size: 13px;
   font-weight: 600;
+  /* min-width:0 alongside overflow:hidden — a nowrap flex item's default
+     min-width:auto refuses to shrink below its content, so the ellipsis never
+     engages without it. */
+  min-width: 0;
+  max-width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+}
+
+.recent-sub {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.recent-slug {
+  font-size: 11px;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
 }
 
 .recent-when {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConfig, useInstances } from "./state/queries";
 import { tourDecision, useUi } from "./state/store";
-import { noteActivity, reconcileLoopReset } from "./lib/stage";
+import { followAutopilot, noteActivity, reconcileLoopReset } from "./lib/stage";
 import { installKeymap, type KeymapHost } from "./lib/keymap";
 import { selectSession, instances as instancesSnapshot } from "./lib/sessionActions";
 import { TopBar } from "./components/TopBar";
@@ -97,6 +97,10 @@ export default function App() {
     for (const inst of instances || []) {
       noteActivity(inst);
       reconcileLoopReset(inst);
+      // Guaranteed path for following an autopilot run: the event gives
+      // sub-second response, this makes sure a dropped or missed event cannot
+      // leave the run unfollowed.
+      followAutopilot(inst);
     }
   }, [instances]);
 

--- a/frontend/src/__tests__/autopilot.test.ts
+++ b/frontend/src/__tests__/autopilot.test.ts
@@ -210,6 +210,17 @@ describe("the ⏩ control is a toggle", () => {
     }
   });
 
+  it("reads a FINISHED run as still armed", () => {
+    // Fast-track is a standing instruction: a done run wakes itself when the agent
+    // produces more work. Showing it OFF is why keeping it on felt impossible —
+    // a branch with an existing PR finishes instantly, every time.
+    const s = fastTrackStep({
+      title: "t", status: "running", stage: "pr", autopilot: run({ state: "done" }),
+    });
+    expect(s?.active).toBe(true);
+    expect(s?.title).toContain("picks up again");
+  });
+
   it("still surfaces a halted run while provisioning", () => {
     const s = fastTrackStep({
       title: "t",

--- a/frontend/src/__tests__/autopilot.test.ts
+++ b/frontend/src/__tests__/autopilot.test.ts
@@ -16,6 +16,7 @@ import {
   autopilotChipTitle,
   depthLabel,
   liveRun,
+  mergeBlockerLabel,
   normalizeDepth,
 } from "../lib/autopilot";
 import {
@@ -27,7 +28,7 @@ import {
   nextStep,
   resetFollow,
 } from "../lib/stage";
-import type { AutopilotRun, Instance } from "../api/types";
+import type { AutopilotRun, Instance, MergeState } from "../api/types";
 
 const run = (over: Partial<AutopilotRun> = {}): AutopilotRun => ({
   depth: "pr",
@@ -350,6 +351,61 @@ describe("followAutopilot (go where the run is)", () => {
     expect(
       followAutopilot(inst({ autopilot: run({ step: "commit" }) }), { live: true })
     ).toBe("commit");
+  });
+});
+
+describe("the Merge button refuses to lie", () => {
+  const ms = (o: Partial<MergeState> = {}): MergeState => ({
+    number: 1, url: "https://x.test/1", state: "clean",
+    mergeable: true, checks: "ok", can_merge: true, blockers: [], ...o,
+  });
+  const at = (o: Partial<Instance>) =>
+    nextStep({ title: "t", status: "running", stage: "pr", ...o });
+
+  it("is clickable when GitHub says the merge would go through", () => {
+    const s = at({ merge_state: ms() });
+    expect(s?.label).toBe("Merge");
+    expect(s?.disabled).toBeFalsy();
+  });
+
+  it.each([
+    ["dirty", ["the branch has merge conflicts with its base"], "conflicts"],
+    ["behind", ["the branch is behind its base and must be updated first"], "behind base"],
+    ["draft", ["the pull request is still a draft"], "draft PR"],
+  ])("is UNCLICKABLE and names the blocker: %s", (state, blockers, short) => {
+    const m = ms({ state, can_merge: false, blockers: blockers as string[] });
+    const s = at({ merge_state: m });
+    expect(s?.disabled).toBe(true);
+    expect(s?.label).toBe("Merge blocked");
+    expect(s?.title).toContain(blockers[0]);
+    // …and the header names it compactly.
+    expect(mergeBlockerLabel(m)).toBe(short);
+  });
+
+  it("distinguishes a failing required check from a missing review", () => {
+    expect(mergeBlockerLabel(ms({ state: "blocked", checks: "failed" }))).toBe("checks ✗");
+    expect(mergeBlockerLabel(ms({ state: "blocked", checks: "pending" }))).toBe("checks…");
+    expect(mergeBlockerLabel(ms({ state: "blocked", checks: "ok" }))).toBe("review needed");
+  });
+
+  it("leaves the button alone when we could not find out", () => {
+    // merge_state absent = no token / no gh / a network fault. Blocking on that
+    // would be claiming knowledge we do not have.
+    expect(at({})?.label).toBe("Merge");
+    expect(at({ merge_state: null })?.disabled).toBeFalsy();
+  });
+
+  it("says 'checking…' while GitHub is still computing mergeability", () => {
+    expect(mergeBlockerLabel(ms({ state: "unknown", mergeable: null }))).toBe("checking…");
+  });
+
+  it("shows the blocker in the header instead of a useless 'PR open'", () => {
+    const s = liveStep({
+      title: "t", status: "running", stage: "pr",
+      merge_state: ms({ state: "dirty", can_merge: false, blockers: ["conflicts"] }),
+    });
+    expect(s?.tone).toBe("blocked");
+    expect(s?.label).toBe("conflicts");
   });
 });
 

--- a/frontend/src/__tests__/autopilot.test.ts
+++ b/frontend/src/__tests__/autopilot.test.ts
@@ -18,8 +18,8 @@ import {
   liveRun,
   normalizeDepth,
 } from "../lib/autopilot";
-import { fastTrackStep, nextStep } from "../lib/stage";
-import type { AutopilotRun } from "../api/types";
+import { clearStep, fastTrackStep, liveStep, markStep, nextStep } from "../lib/stage";
+import type { AutopilotRun, Instance } from "../api/types";
 
 const run = (over: Partial<AutopilotRun> = {}): AutopilotRun => ({
   depth: "pr",
@@ -193,6 +193,70 @@ describe("the guided button keeps working while armed", () => {
       autopilot: run(),
     });
     expect(s?.label).toBe("Push");
+  });
+});
+
+describe("liveStep (the pane header's live step)", () => {
+  const step = (o: Partial<Instance>) => liveStep({ title: "t", status: "running", ...o });
+
+  it("reads as ACTIVE while pre-commit hooks run", () => {
+    // Regression: this state used to render as a DISABLED grey pill reading
+    // "pre-commit" — the busiest moment in the workflow looked broken.
+    const s = step({ stage: "precommit" });
+    expect(s?.label).toBe("pre-commit");
+    expect(s?.tone).toBe("work");
+  });
+
+  it("marks a blocked commit as blocked, naming the hook", () => {
+    const s = step({ stage: "interrupt", failed_step: "Run Tests" });
+    expect(s?.tone).toBe("blocked");
+    expect(s?.title).toContain("Run Tests");
+  });
+
+  it("surfaces worktree setup above everything else", () => {
+    // Queued prompts are HELD during setup and the driver refuses to act, so it
+    // has to be visible.
+    expect(step({ stage: "agent", setup: { state: "running" } })?.label).toBe("setting up");
+    expect(step({ stage: "agent", setup: { state: "failed" } })?.tone).toBe("blocked");
+  });
+
+  it("shows running and failed verification checks", () => {
+    expect(step({ stage: "committed", check: { state: "running" } })?.label).toBe("checks");
+    expect(step({ stage: "committed", check: { state: "failed" } })?.tone).toBe("blocked");
+  });
+
+  it("says what an armed chain is waiting on, in the server's words", () => {
+    const s = step({
+      stage: "agent",
+      autopilot: run({ note: "prompt queue still has work" }),
+    });
+    expect(s?.label).toBe("prompt queue still has work");
+    expect(s?.target).toBe("→ PR");
+  });
+
+  it("reports a halted chain as blocked", () => {
+    const s = step({ stage: "agent", autopilot: run({ state: "halted", reason: "checks failed" }) });
+    expect(s?.tone).toBe("blocked");
+    expect(s?.title).toContain("checks failed");
+  });
+
+  it("offers an open PR as a link", () => {
+    const s = step({ stage: "pr", pr_url: "https://example.test/pr/1" });
+    expect(s?.tone).toBe("ok");
+    expect(s?.href).toBe("https://example.test/pr/1");
+  });
+
+  it("is null when nothing is happening", () => {
+    expect(step({ stage: "agent" })).toBeNull();
+    expect(step({ stage: "committed" })).toBeNull();
+  });
+
+  it("shows in-flight push/PR/merge, which have no stage of their own", () => {
+    markStep("t", "push");
+    expect(step({ stage: "committed" })?.label).toBe("pushing");
+    // …and clears itself once the stage catches up.
+    expect(step({ stage: "pushed" })).toBeNull();
+    clearStep("t");
   });
 });
 

--- a/frontend/src/__tests__/autopilot.test.ts
+++ b/frontend/src/__tests__/autopilot.test.ts
@@ -179,6 +179,36 @@ describe("the ⏩ control is a toggle", () => {
         fastTrackStep({ title: "t", status: "running", stage: "agent", ...o })
       ).toBeNull();
   });
+
+  it("stays cancellable even while provisioning or committing", () => {
+    // An intake-armed session spends its first minutes provisioning, which is
+    // precisely when you might change your mind — and the guards above used to
+    // hide the toggle there entirely, leaving no way to stop it at all.
+    for (const o of [
+      { status: "loading" },
+      { stage: "provisioning" },
+      { stage: "precommit" },
+    ]) {
+      const s = fastTrackStep({
+        title: "t",
+        status: "running",
+        stage: "agent",
+        autopilot: run(),
+        ...o,
+      });
+      expect(s, JSON.stringify(o)).not.toBeNull();
+      expect(s!.active).toBe(true);
+    }
+  });
+
+  it("still surfaces a halted run while provisioning", () => {
+    const s = fastTrackStep({
+      title: "t",
+      status: "loading",
+      autopilot: run({ state: "halted", reason: "checks failed" }),
+    });
+    expect(s?.label).toBe("⏩✗");
+  });
 });
 
 describe("the guided button keeps working while armed", () => {

--- a/frontend/src/__tests__/autopilot.test.ts
+++ b/frontend/src/__tests__/autopilot.test.ts
@@ -29,6 +29,7 @@ import {
   resetFollow,
 } from "../lib/stage";
 import type { AutopilotRun, Instance, MergeState } from "../api/types";
+import { useUi } from "../state/store";
 
 const run = (over: Partial<AutopilotRun> = {}): AutopilotRun => ({
   depth: "pr",
@@ -315,10 +316,14 @@ describe("followAutopilot (go where the run is)", () => {
 
   beforeEach(() => resetFollow());
 
-  it("switches to the terminal when the run reaches the commit step", () => {
-    // Seed the prior step, then transition — that is what a real run does.
+  it("switches that window to its terminal tab WITHOUT taking focus", () => {
+    // Autopilot runs unattended, often on a window you are not looking at, so
+    // yanking the view away from whatever you ARE doing is wrong. Setting the tab
+    // does the useful half.
     followAutopilot(inst({ autopilot: run({ step: "" }) }));
     expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBe("commit");
+    expect(useUi.getState().lastTab["ft"]).toBe("shell");
+    expect(useUi.getState().focused).not.toBe("ft");
   });
 
   it("fires only ONCE per step", () => {
@@ -328,19 +333,20 @@ describe("followAutopilot (go where the run is)", () => {
     expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBeNull();
   });
 
-  it("does not steal focus on a FIRST poll sighting", () => {
-    // Loading the page mid-commit must not yank you to that window.
-    expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBeNull();
+  it("switches the tab even on a FIRST poll sighting", () => {
+    // Setting a tab takes no focus, so there is nothing to protect against — and a
+    // page loaded mid-commit should still find the terminal tab selected.
+    expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBe("commit");
   });
 
-  it("does act on a first sighting from a LIVE event", () => {
-    // A live event IS the transition, so there is nothing stale about it.
+  it("never opens a browser tab on a first POLL sighting", () => {
+    // Opening a PR IS intrusive: a page load must not re-open one already seen.
     expect(
-      followAutopilot(inst({ autopilot: run({ step: "commit" }) }), { live: true })
-    ).toBe("commit");
+      followAutopilot(inst({ autopilot: run({ step: "pr", url: "https://x.test/1" }) }))
+    ).toBeNull();
   });
 
-  it("opens the PR when the run reaches the pr step", () => {
+  it("opens the PR on a real live transition", () => {
     followAutopilot(inst({ autopilot: run({ step: "commit" }) }), { live: true });
     expect(
       followAutopilot(inst({ autopilot: run({ step: "pr", url: "https://x.test/1" }) }))

--- a/frontend/src/__tests__/autopilot.test.ts
+++ b/frontend/src/__tests__/autopilot.test.ts
@@ -3,7 +3,7 @@
  * which stage satisfies which target, and on merge never being satisfied by an
  * observed stage. */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   DEPTHS,
   DEPTH_ORDER,
@@ -18,7 +18,15 @@ import {
   liveRun,
   normalizeDepth,
 } from "../lib/autopilot";
-import { clearStep, fastTrackStep, liveStep, markStep, nextStep } from "../lib/stage";
+import {
+  clearStep,
+  fastTrackStep,
+  followAutopilot,
+  liveStep,
+  markStep,
+  nextStep,
+  resetFollow,
+} from "../lib/stage";
 import type { AutopilotRun, Instance } from "../api/types";
 
 const run = (over: Partial<AutopilotRun> = {}): AutopilotRun => ({
@@ -287,6 +295,61 @@ describe("liveStep (the pane header's live step)", () => {
     // …and clears itself once the stage catches up.
     expect(step({ stage: "pushed" })).toBeNull();
     clearStep("t");
+  });
+});
+
+describe("followAutopilot (go where the run is)", () => {
+  const inst = (o: Partial<Instance>) => ({ title: "ft", ...o }) as Partial<Instance>;
+
+  beforeEach(() => resetFollow());
+
+  it("switches to the terminal when the run reaches the commit step", () => {
+    // Seed the prior step, then transition — that is what a real run does.
+    followAutopilot(inst({ autopilot: run({ step: "" }) }));
+    expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBe("commit");
+  });
+
+  it("fires only ONCE per step", () => {
+    followAutopilot(inst({ autopilot: run({ step: "" }) }));
+    expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBe("commit");
+    expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBeNull();
+    expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBeNull();
+  });
+
+  it("does not steal focus on a FIRST poll sighting", () => {
+    // Loading the page mid-commit must not yank you to that window.
+    expect(followAutopilot(inst({ autopilot: run({ step: "commit" }) }))).toBeNull();
+  });
+
+  it("does act on a first sighting from a LIVE event", () => {
+    // A live event IS the transition, so there is nothing stale about it.
+    expect(
+      followAutopilot(inst({ autopilot: run({ step: "commit" }) }), { live: true })
+    ).toBe("commit");
+  });
+
+  it("opens the PR when the run reaches the pr step", () => {
+    followAutopilot(inst({ autopilot: run({ step: "commit" }) }), { live: true });
+    expect(
+      followAutopilot(inst({ autopilot: run({ step: "pr", url: "https://x.test/1" }) }))
+    ).toBe("pr");
+  });
+
+  it("falls back to the session's own pr_url", () => {
+    followAutopilot(inst({ autopilot: run({ step: "push" }) }));
+    expect(
+      followAutopilot(inst({ autopilot: run({ step: "pr" }), pr_url: "https://y.test/2" }))
+    ).toBe("pr");
+  });
+
+  it("ignores runs that are not running, and re-arms cleanly after", () => {
+    expect(followAutopilot(inst({ autopilot: run({ state: "halted", step: "commit" }) }))).toBeNull();
+    expect(followAutopilot(inst({ autopilot: run({ state: "done", step: "commit" }) }))).toBeNull();
+    expect(followAutopilot(inst({}))).toBeNull();
+    // A halted run cleared the guard, so a fresh run's commit step fires again.
+    expect(
+      followAutopilot(inst({ autopilot: run({ step: "commit" }) }), { live: true })
+    ).toBe("commit");
   });
 });
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -59,6 +59,9 @@ export interface AutopilotRun {
   reason: string;
   source: string;
   item: string;
+  /** What the current pass is waiting on, in the server's own words ("waiting for
+   * checks to finish", "prompt queue still has work"). */
+  note?: string;
   skipped?: string[];
 }
 
@@ -125,6 +128,9 @@ export interface Caps {
 }
 
 export interface Config {
+  /** The resolved fast-track rung, for LABELLING the ⏩ button. The server still
+   * decides the actual depth when a request omits one. */
+  fasttrack_depth?: string;
   default_program: string;
   provisioning_available: boolean;
   caps: Caps;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -62,6 +62,8 @@ export interface AutopilotRun {
   /** What the current pass is waiting on, in the server's own words ("waiting for
    * checks to finish", "prompt queue still has work"). */
   note?: string;
+  /** The PR this run opened, so the client can bring it up exactly once. */
+  url?: string;
   skipped?: string[];
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -67,6 +67,23 @@ export interface AutopilotRun {
   skipped?: string[];
 }
 
+/** Whether a branch's PR can actually be merged, and what is stopping it.
+ *
+ * The absence of this object (null) means "we could not find out" — no token, no
+ * GitHub behind origin, no open PR, or a network fault. It never means "no": the
+ * UI must leave the merge affordance alone rather than claim knowledge. */
+export interface MergeState {
+  number: number;
+  url: string;
+  /** GitHub's mergeable_state: clean | dirty | blocked | behind | unstable | draft
+   * | unknown. */
+  state: string;
+  mergeable: boolean | null;
+  checks: "ok" | "failed" | "pending" | "none" | "unknown" | string;
+  can_merge: boolean;
+  blockers: string[];
+}
+
 export interface Instance {
   title: string;
   branch: string;
@@ -87,6 +104,8 @@ export interface Instance {
   has_origin: boolean;
   stage: Stage | string;
   pr_url: string | null;
+  /** Present only at the "pr" stage; null = could not find out. */
+  merge_state?: MergeState | null;
   failed_step?: string | null;
   /** The failing pre-commit hook's ID (not its display name — pre-commit's
    * `name:` is free text and cannot be mapped back to an id). Keys the retry. */

--- a/frontend/src/components/EventToasts.tsx
+++ b/frontend/src/components/EventToasts.tsx
@@ -13,15 +13,17 @@ import {
 } from "../state/queries";
 import { useUi } from "../state/store";
 import { fmtUsd } from "../lib/format";
-import { dropActivity, effectiveActivity, forceActivity } from "../lib/stage";
-import { offerUrl, selectSession } from "../lib/sessionActions";
+import {
+  dropActivity,
+  effectiveActivity,
+  followAutopilot,
+  forceActivity,
+} from "../lib/stage";
+import { selectSession } from "../lib/sessionActions";
 import { toast, type ToastOpts } from "../lib/toast";
 
 const BASE_TITLE = document.title || "MindFlock";
 const clarifyUnseen = new Set<string>(); // clarify sessions not yet looked at
-/** Last autopilot step seen per session, so switching to the terminal and opening
- * the PR each happen ONCE per step rather than on every event for that step. */
-const lastStep = new Map<string, string>();
 
 function instances(): Instance[] {
   return queryClient.getQueryData<Instance[]>(["instances"]) || [];
@@ -233,25 +235,25 @@ export function EventToasts() {
             : null,
         });
         if (isReplay(env)) return;
-
-        // Bring the user to whatever the run is doing, matching what the manual
-        // buttons already do for the same steps.
-        const step = String(d.step || "");
-        if (step === "commit" && lastStep.get(env.session) !== "commit") {
-          // Same as pressing Commit… by hand: focus the window and show its shell
-          // so the pre-commit hooks are watchable while they run.
-          useUi.getState().setLastTab(env.session, "shell");
-          selectSession(env.session);
-        }
-        if (step === "pr" && lastStep.get(env.session) !== "pr") {
-          const url = String(d.url || "");
-          // Same as the manual Make PR: open the PR. offerUrl falls back to a
-          // clickable toast when the popup blocker eats it — this is not running
-          // inside a click gesture, so that fallback is the normal path.
-          if (url) offerUrl(url, "PR opened for " + env.session);
-        }
-        lastStep.set(env.session, step);
-
+        // Follow the run to whatever it is doing (terminal on commit, the PR when
+        // it opens). Shared with the per-poll reconcile in App.tsx via one guard,
+        // so it happens exactly once per step whichever path notices first.
+        followAutopilot(
+          {
+            title: env.session,
+            autopilot: {
+              depth: String(d.depth || ""),
+              state: String(env.new || d.state || "running"),
+              step: String(d.step || ""),
+              reason: String(d.reason || ""),
+              note: String(d.note || ""),
+              url: String(d.url || ""),
+              source: String(d.source || "session"),
+              item: String(d.item || ""),
+            },
+          },
+          { live: true }
+        );
         if (String(env.new || "") === "halted")
           notifyOnce(env.session, "ftstop", "fast-track stopped on " + env.session, {
             onClick: () => selectSession(env.session),

--- a/frontend/src/components/EventToasts.tsx
+++ b/frontend/src/components/EventToasts.tsx
@@ -209,6 +209,34 @@ export function EventToasts() {
       })
     );
     unsubs.push(
+      // Autopilot steps reached the UI only on the next 4s poll, so "pushing" could
+      // be over before it appeared. Patch the cache from the socket instead — same
+      // shape and same before-the-replay-guard reasoning as stage_changed below.
+      ev.subscribe("session.autopilot_changed", (env) => {
+        const d = (env.data || {}) as Record<string, unknown>;
+        const depth = String(d.depth || "");
+        patchInstance(env.session, {
+          autopilot: depth
+            ? {
+                depth,
+                state: String(env.new || d.state || "running"),
+                step: String(d.step || ""),
+                reason: String(d.reason || ""),
+                note: String(d.note || ""),
+                source: String(d.source || "session"),
+                item: String(d.item || ""),
+                skipped: Array.isArray(d.skipped) ? (d.skipped as string[]) : [],
+              }
+            : null,
+        });
+        if (isReplay(env)) return;
+        if (String(env.new || "") === "halted")
+          notifyOnce(env.session, "ftstop", "fast-track stopped on " + env.session, {
+            onClick: () => selectSession(env.session),
+          });
+      })
+    );
+    unsubs.push(
       ev.subscribe("session.stage_changed", (env) => {
         // Patch the cache BEFORE the replay guard: a replayed stage is still the
         // truth for the cache (only the toast must be suppressed). This is the

--- a/frontend/src/components/EventToasts.tsx
+++ b/frontend/src/components/EventToasts.tsx
@@ -14,11 +14,14 @@ import {
 import { useUi } from "../state/store";
 import { fmtUsd } from "../lib/format";
 import { dropActivity, effectiveActivity, forceActivity } from "../lib/stage";
-import { selectSession } from "../lib/sessionActions";
+import { offerUrl, selectSession } from "../lib/sessionActions";
 import { toast, type ToastOpts } from "../lib/toast";
 
 const BASE_TITLE = document.title || "MindFlock";
 const clarifyUnseen = new Set<string>(); // clarify sessions not yet looked at
+/** Last autopilot step seen per session, so switching to the terminal and opening
+ * the PR each happen ONCE per step rather than on every event for that step. */
+const lastStep = new Map<string, string>();
 
 function instances(): Instance[] {
   return queryClient.getQueryData<Instance[]>(["instances"]) || [];
@@ -230,6 +233,25 @@ export function EventToasts() {
             : null,
         });
         if (isReplay(env)) return;
+
+        // Bring the user to whatever the run is doing, matching what the manual
+        // buttons already do for the same steps.
+        const step = String(d.step || "");
+        if (step === "commit" && lastStep.get(env.session) !== "commit") {
+          // Same as pressing Commit… by hand: focus the window and show its shell
+          // so the pre-commit hooks are watchable while they run.
+          useUi.getState().setLastTab(env.session, "shell");
+          selectSession(env.session);
+        }
+        if (step === "pr" && lastStep.get(env.session) !== "pr") {
+          const url = String(d.url || "");
+          // Same as the manual Make PR: open the PR. offerUrl falls back to a
+          // clickable toast when the popup blocker eats it — this is not running
+          // inside a click gesture, so that fallback is the normal path.
+          if (url) offerUrl(url, "PR opened for " + env.session);
+        }
+        lastStep.set(env.session, step);
+
         if (String(env.new || "") === "halted")
           notifyOnce(env.session, "ftstop", "fast-track stopped on " + env.session, {
             onClick: () => selectSession(env.session),

--- a/frontend/src/components/dialogs/CommitDialog.tsx
+++ b/frontend/src/components/dialogs/CommitDialog.tsx
@@ -9,7 +9,7 @@ import { instApi } from "../../api/client";
 import { freshStage } from "../../lib/stageWatch";
 import { useUi } from "../../state/store";
 import { errMsg } from "../../lib/format";
-import { rememberDepth, selectSession, startFastTrack } from "../../lib/sessionActions";
+import { selectSession, startFastTrack } from "../../lib/sessionActions";
 import { DEPTH_STEP_LABELS, SESSION_DEPTHS, normalizeDepth } from "../../lib/autopilot";
 
 /** Last commit message per session (pre-fills the prompt on retry).
@@ -105,16 +105,14 @@ export function CommitDialog() {
     // pane and show its shell tab).
     useUi.getState().setLastTab(title, "shell");
     selectSession(title);
-    if (chosen !== "commit") {
-      // Arm the chain instead of committing directly. The driver issues the very
-      // same commit (through the same shell one-liner) and then carries on, so
-      // the visible behaviour of this press is a superset of the plain path.
-      await startFastTrack(title, chosen, m);
-      void freshStage(title);
-      return;
-    }
+    // COMMIT NOW, then arm the rest. The earlier version only armed for a deeper
+    // rung and never POSTed /commit — but arming is arm-and-wait, so pressing
+    // "Commit & push" did nothing for 30s and then committed whatever the agent
+    // had written in the meantime, under the message typed before all of it. You
+    // pressed Commit; the commit has to happen.
     try {
       await instApi(title, "/commit", { json: { message: m } });
+      if (chosen !== "commit") await startFastTrack(title, chosen, m);
     } catch (err) {
       alert("Commit failed: " + errMsg(err));
     }
@@ -178,10 +176,11 @@ export function CommitDialog() {
           <select
             id="commit-depth"
             value={depth}
-            onChange={(e) => {
-              setDepth(e.target.value);
-              rememberDepth(e.target.value);
-            }}
+            // Deliberately NOT persisted: this pick applies to THIS commit. The
+            // previous version wrote a shared localStorage key that outranked
+            // Settings, so touching this dropdown once silently re-targeted every
+            // ⏩ button on the machine with no way to see or undo it.
+            onChange={(e) => setDepth(e.target.value)}
           >
             {SESSION_DEPTHS.map((d) => (
               <option key={d} value={d}>

--- a/frontend/src/components/dialogs/RecentDialog.tsx
+++ b/frontend/src/components/dialogs/RecentDialog.tsx
@@ -11,6 +11,10 @@ import { selectSession } from "../../lib/sessionActions";
 interface ClosedEntry {
   id: string;
   title?: string;
+  /** The branch the session owned. The server has always sent this; the row used
+   * to show only `title`, which for an ingested session is the bare slug
+   * ("shortcut-21018") and says nothing about what the work was. */
+  branch?: string;
   folder?: string;
   closed_at?: string | number;
   exists: boolean;
@@ -79,13 +83,35 @@ export function RecentDialog() {
               return (
                 <div className="recent-row" key={e.id}>
                   <div className="recent-info">
-                    <span className="recent-name" title={e.folder || ""}>
-                      {e.title || "(untitled)"}
+                    {/* The BRANCH is the headline: it carries the descriptive tail
+                        ("…/path-expansion-never-routes-cloudflare") that says what
+                        the session was for. The bare title is the slug, which for an
+                        ingested ticket is just its number. Deliberately NOT run
+                        through displayBranch() — that strips the prefix, and here the
+                        whole name is the point. */}
+                    <span
+                      className="recent-name"
+                      title={[
+                        e.branch ? "Branch: " + e.branch : "",
+                        e.title ? "Session: " + e.title : "",
+                        e.folder || "",
+                      ]
+                        .filter(Boolean)
+                        .join("\n")}
+                    >
+                      {e.branch || e.title || "(untitled)"}
                     </span>
-                    {e.in_place && <span className="ws-badge kind">in-place</span>}
-                    {e.provisioned && <span className="ws-badge kind">provisioned</span>}
-                    {gone && <span className="ws-badge gone">worktree gone</span>}
-                    <span className="recent-when muted">{fmtClosedAt(e.closed_at)}</span>
+                    <span className="recent-sub">
+                      {/* Keep the session identity visible: it is what Reopen acts on
+                          and what the wipe confirmation names. */}
+                      {e.branch && e.title && (
+                        <span className="recent-slug muted">{e.title}</span>
+                      )}
+                      {e.in_place && <span className="ws-badge kind">in-place</span>}
+                      {e.provisioned && <span className="ws-badge kind">provisioned</span>}
+                      {gone && <span className="ws-badge gone">worktree gone</span>}
+                      <span className="recent-when muted">{fmtClosedAt(e.closed_at)}</span>
+                    </span>
                   </div>
                   <div className="recent-actions">
                     <button

--- a/frontend/src/components/dialogs/smallDialogs.css
+++ b/frontend/src/components/dialogs/smallDialogs.css
@@ -461,20 +461,44 @@
   background: var(--bg);
 }
 
+/* Two lines: the branch on its own, then the identity/badges/timestamp beneath.
+   Stacking is what lets a 60-character branch name actually be READ — on one line
+   next to badges and a timestamp it just ellipsised away, which is the whole thing
+   the row exists to tell you. */
 .recent-info {
   flex: 1;
   min-width: 0;
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
 }
 
 .recent-name {
   font-size: 13px;
   font-weight: 600;
+  /* min-width:0 alongside overflow:hidden — a nowrap flex item's default
+     min-width:auto refuses to shrink below its content, so the ellipsis never
+     engages without it. */
+  min-width: 0;
+  max-width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+}
+
+.recent-sub {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.recent-slug {
+  font-size: 11px;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
 }
 
 .recent-when {

--- a/frontend/src/components/dialogs/smallDialogs.css
+++ b/frontend/src/components/dialogs/smallDialogs.css
@@ -42,6 +42,51 @@
   border-color: var(--accent);
 }
 
+/* Fast-track rung picker.
+   A <select> does NOT inherit the card's typography: the UA stylesheet sets the
+   `font` shorthand on form controls, so without this rule it rendered as a raw
+   Arial platform widget (square corners, ButtonFace grey) inside a rounded dark
+   card whose every other control is --bg + 1px --border + 7px radius.
+   `align-self: start` matters too: `#commit-form label` is a column flexbox with
+   the default `align-items: stretch`, which spread a four-option picker across
+   the whole 480px card with ~300px of dead space. */
+#commit-form #commit-depth {
+  align-self: start;
+  min-width: 210px;
+  max-width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 7px;
+  padding: 7px 10px;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+#commit-form #commit-depth:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+#commit-form #commit-depth:hover {
+  border-color: var(--accent);
+}
+
+/* Caption and hint on ONE line: the label is a column flexbox, so a bare text
+   node plus the hint span would otherwise stack into two rows and make this row
+   taller than the message row's caption. */
+#commit-form #commit-depth-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  gap: 4px 6px;
+}
+
+#commit-form #commit-depth-row > select {
+  grid-column: 1 / -1;
+}
+
 /* Rename dialog (single-line display name; same card style as #commit-form) */
 #rename-form {
   background: var(--panel);

--- a/frontend/src/components/grid/Pane.css
+++ b/frontend/src/components/grid/Pane.css
@@ -164,6 +164,23 @@
   .pane-head .tok {
     display: none;
   }
+
+  .pane-head .actions .stepnow-target {
+    display: none;
+  }
+
+  .pane-head .actions .stepnow-text {
+    max-width: 12ch;
+  }
+}
+
+/* Tightest layout: the dot alone still says "running / blocked", and the tooltip
+   still carries the detail. Deliberately NOT hidden with .nextstep at 420px —
+   once the action button is gone this is the only signal left. */
+@container (max-width: 360px) {
+  .pane-head .actions .stepnow-text {
+    display: none;
+  }
 }
 
 /* Between the fixed breakpoints a header can still overflow (long titles,
@@ -255,6 +272,12 @@
   align-items: center;
   gap: 6px;
   margin-left: 10px;
+  /* Was `flex: none` via `.tabs, .actions`. Now that this group can hold a text
+     label it has to be able to YIELD, or a verbose step pushes the usage chip and
+     the copy-history button out of the pane. */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .pane-head .actions .nextstep {
@@ -274,20 +297,105 @@
   filter: brightness(1.12);
 }
 
-/* Status-pill variant: shown in the same slot when there's no actionable next
-   step (provisioning / pre-commit running / paused / workspace gone), so the
-   action area is never an empty gap. Non-clickable, muted — clearly not the
-   primary accent button. */
-.pane-head .actions .nextstep.nextstep-status {
-  background: var(--panel-2);
-  color: var(--muted);
+/* Live step indicator — what is happening RIGHT NOW.
+   Replaces the old `.nextstep-status` pill, which filled the primary button's
+   slot with DISABLED GREY TEXT whenever there was no actionable next step. That
+   meant the busiest moment in the workflow (pre-commit hooks running) rendered as
+   a dead greyed-out button reading "pre-commit". This is deliberately NOT
+   button-shaped: it is a status line, so it never competes with the real action.
+   Colour and fill carry the meaning; motion is only ever a bonus. */
+.pane-head .actions .stepnow {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  /* Same yield-then-clip contract the context line uses, so a long label can
+     never push the cost chip or the copy button out of the header. */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
   font-weight: 500;
-  cursor: default;
-  filter: none;
+  color: var(--muted);
+  white-space: nowrap;
 }
 
-.pane-head .actions .nextstep.nextstep-status:hover {
-  filter: none;
+.pane-head .actions .stepnow-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 22ch;
+}
+
+.pane-head .actions .stepnow-target {
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+
+.pane-head .actions .stepnow-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* work: something is running. Accent + the house pulse cadence. */
+.pane-head .actions .stepnow.is-work {
+  color: var(--accent);
+}
+
+.pane-head .actions .stepnow.is-work .stepnow-dot {
+  animation: step-ping 1.4s ease-in-out infinite;
+}
+
+/* blocked: it needs a human. */
+.pane-head .actions .stepnow.is-blocked {
+  color: var(--red);
+}
+
+/* ok: a finished, good state (a PR is open). */
+.pane-head .actions .stepnow.is-ok {
+  color: var(--green, #3fb950);
+}
+
+/* quiet: true but inert (paused). Hollow dot, so "not running" is legible
+   without relying on colour or motion. */
+.pane-head .actions .stepnow.is-quiet .stepnow-dot {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px currentColor;
+}
+
+.pane-head .actions .stepnow.is-link {
+  cursor: pointer;
+}
+
+.pane-head .actions .stepnow.is-link:hover {
+  text-decoration: underline;
+}
+
+/* Matches the shape of the existing mic-pulse ring, accent-tokenised, at the
+   house 1.4s ease-in-out cadence (see cs-pulse). */
+@keyframes step-ping {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--accent-rgb), 0.55);
+  }
+
+  50% {
+    box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0);
+  }
+}
+
+/* Motion is decoration here — the dot's colour and fill already carry the state,
+   so removing it loses nothing. Honour both the OS setting and the app's own
+   reduce-motion preference. */
+@media (prefers-reduced-motion: reduce) {
+  .pane-head .actions .stepnow.is-work .stepnow-dot {
+    animation: none;
+  }
+}
+
+.no-motion .pane-head .actions .stepnow.is-work .stepnow-dot {
+  animation: none;
 }
 
 /* Fast-track (⏩): a SECONDARY control that sits beside the guided button and

--- a/frontend/src/components/grid/Pane.css
+++ b/frontend/src/components/grid/Pane.css
@@ -411,6 +411,22 @@
   animation: none;
 }
 
+/* Blocked: the action is known to be refusable, so the button says why and does
+   nothing. Muted like the old status pill, but it keeps a border so it still reads
+   as a control that exists rather than as absent — and the tooltip carries the
+   specific blockers. */
+.pane-head .actions .nextstep.nextstep-blocked {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  cursor: not-allowed;
+  font-weight: 500;
+}
+
+.pane-head .actions .nextstep.nextstep-blocked:hover {
+  filter: none;
+}
+
 /* Fast-track (⏩): a SECONDARY control that sits beside the guided button and
    arms the rest of the stack in one press. Deliberately an accent OUTLINE, not a
    filled accent — the guided next step must stay the one obvious default action,

--- a/frontend/src/components/grid/Pane.css
+++ b/frontend/src/components/grid/Pane.css
@@ -84,6 +84,10 @@
 
 .pane-head {
   flex-wrap: nowrap;
+  /* Backstop only. With the title able to shrink to 2.5rem and the container
+     queries below shedding the optional bits, this should never engage — but a
+     header that spills past the pane's rounded corner looks broken, so clip. */
+  overflow: hidden;
 }
 
 /* Normal right padding. (The old 54px gutter reserved room for the floating
@@ -92,10 +96,16 @@
   padding-right: 12px;
 }
 
+/* The title is the ONE thing in this header that yields.
+   `flex-shrink: 3` against the context line's 1 makes it absorb most of any
+   reduction, and the small floor lets it truncate hard — a 60-character session
+   name should cost its own characters, never the Commit button, the fast-track
+   toggle or the live-step indicator. Those are controls; the title is a label
+   whose full text is one hover away (title= carries it). */
 .pane-head .title {
   font-weight: 600;
-  flex: 0 1 auto;
-  min-width: 40px;
+  flex: 0 3 auto;
+  min-width: 2.5rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -272,12 +282,12 @@
   align-items: center;
   gap: 6px;
   margin-left: 10px;
-  /* Was `flex: none` via `.tabs, .actions`. Now that this group can hold a text
-     label it has to be able to YIELD, or a verbose step pushes the usage chip and
-     the copy-history button out of the pane. */
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
+  /* NEVER shrinks. Making this yield (so a verbose step label could not push the
+     usage chip out) meant a long session title clipped the controls instead —
+     the Commit button, the ⏩ toggle and the step indicator were sliced off the
+     right edge. The label is bounded by its own max-width and the container
+     queries below, so the group's width stays predictable without shrinking. */
+  flex: none;
 }
 
 .pane-head .actions .nextstep {
@@ -322,7 +332,10 @@
 .pane-head .actions .stepnow-text {
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 22ch;
+  /* Bounded because `.actions` no longer shrinks: the group's width has to be
+     predictable. The server's wait sentences run long ("waiting for CI to pass
+     before merging"), and the full text is in the tooltip. */
+  max-width: 15ch;
 }
 
 .pane-head .actions .stepnow-target {

--- a/frontend/src/components/grid/Pane.tsx
+++ b/frontend/src/components/grid/Pane.tsx
@@ -284,12 +284,17 @@ export function Pane({
         <div className="actions">
           {ns ? (
             <button
-              className={"nextstep" + (ns.hint ? " nextstep-hint" : "")}
+              className={
+                "nextstep" +
+                (ns.hint ? " nextstep-hint" : "") +
+                (ns.disabled ? " nextstep-blocked" : "")
+              }
               type="button"
+              disabled={!!ns.disabled}
               title={ns.title || "Do the next step"}
               onClick={(ev) => {
                 ev.stopPropagation();
-                ns.run();
+                if (!ns.disabled) ns.run();
               }}
             >
               {ns.label}

--- a/frontend/src/components/grid/Pane.tsx
+++ b/frontend/src/components/grid/Pane.tsx
@@ -11,7 +11,7 @@ import { refreshInstances, useConfig } from "../../state/queries";
 import { useUi } from "../../state/store";
 import { copyText } from "../../lib/clipboard";
 import { fmtUsd, displayBranch } from "../../lib/format";
-import { chipState, fastTrackStep, nextStep } from "../../lib/stage";
+import { chipState, fastTrackStep, liveStep, nextStep } from "../../lib/stage";
 import { cleanupMissing, selectSession } from "../../lib/sessionActions";
 import { getTerm, peekTerm, type TermHandle } from "../../lib/terminals";
 import { toast } from "../../lib/toast";
@@ -220,6 +220,7 @@ export function Pane({
   const chip = chipState(inst);
   const ns = nextStep(inst);
   const ft = fastTrackStep(inst);
+  const step = liveStep(inst);
   const q = inst.queue;
   const pending = q?.pending || 0;
   const limitedMs = q?.limited_until ? q.limited_until * 1000 - Date.now() : 0;
@@ -293,10 +294,24 @@ export function Pane({
             >
               {ns.label}
             </button>
-          ) : (
-            <button className="nextstep nextstep-status" type="button" disabled title={chip.title}>
-              {chip.label}
-            </button>
+          ) : null}
+          {step && (
+            <span
+              className={"stepnow is-" + step.tone + (step.href ? " is-link" : "")}
+              title={step.title}
+              onClick={
+                step.href
+                  ? (ev) => {
+                      ev.stopPropagation();
+                      window.open(step.href!, "_blank");
+                    }
+                  : undefined
+              }
+            >
+              <span className="stepnow-dot" aria-hidden="true" />
+              <span className="stepnow-text">{step.label}</span>
+              {step.target && <span className="stepnow-target">{step.target}</span>}
+            </span>
           )}
           {ft && (
             <button

--- a/frontend/src/components/settings/useSettings.tsx
+++ b/frontend/src/components/settings/useSettings.tsx
@@ -7,6 +7,7 @@ import { createContext, useCallback, useContext, useEffect, useState } from "rea
 import { api } from "../../api/client";
 import type { Json } from "../../api/types";
 import { toast } from "../../lib/toast";
+import { refreshConfig } from "../../state/queries";
 
 export const SECRET_MASK = "•••set";
 
@@ -43,6 +44,13 @@ export function useSettingsModel(open: boolean): SettingsModel {
           json: { [group]: { [field]: value } },
         });
         setSettings(r?.settings || {});
+        // Some settings are also reported on /api/config, which the whole app
+        // reads (caps, ide_name, the resolved fast-track rung). Invalidating it
+        // here — rather than per call site — is what makes a saved setting take
+        // effect in already-open windows instead of waiting for a reload. It was
+        // hand-rolled in exactly one screen before, which is precisely how the
+        // fast-track rows shipped without it.
+        void refreshConfig();
         toast("Saved " + field.replace(/_/g, " "));
       } catch (err) {
         toast("Save failed: " + ((err as Error).message || field));
@@ -57,6 +65,7 @@ export function useSettingsModel(open: boolean): SettingsModel {
       try {
         const r = await api<{ settings?: Json }>("/api/settings", { json: { [group]: patch } });
         setSettings(r?.settings || {});
+        void refreshConfig();
         if (okMsg) toast(okMsg);
       } catch (err) {
         toast("Save failed: " + ((err as Error).message || group));

--- a/frontend/src/components/sidebar/AutomationBar.tsx
+++ b/frontend/src/components/sidebar/AutomationBar.tsx
@@ -89,8 +89,13 @@ export function AutomationBar() {
           // `active` outranks the switch: a ticket forced from Intake is
           // genuinely being brought in even with auto ingestion switched off,
           // and "off" would be a lie about the work in flight.
+          // "dc-error", NOT a bare "error": `.error` is a GLOBAL class for error
+          // TEXT (`.error { min-height: 16px }`), and this element is a 9px circle.
+          // `.dc-dot` sets height but never min-height, so the global won
+          // uncontested and rendered the red state as a 9x16 OVAL — the one state
+          // that looked malformed, because it was the only one borrowing that name.
           "dc-dot " +
-          (netIssue ? "error" : active ? "on" : !desired ? "off" : "idle")
+          (netIssue ? "dc-error" : active ? "on" : !desired ? "off" : "idle")
         }
         title={
           active

--- a/frontend/src/components/sidebar/toolbars.css
+++ b/frontend/src/components/sidebar/toolbars.css
@@ -179,6 +179,14 @@
 #git-issue-bar .dc-dot {
   width: 9px;
   height: 9px;
+  /* Pin the box so no inherited or globally-scoped rule can deform the circle.
+     The red state used to carry a bare `error` class, and the app-wide
+     `.error { min-height: 16px }` (meant for error TEXT) beat an unset min-height
+     — producing a 9x16 oval in exactly one state. The state class is scoped now,
+     but stating these makes the shape robust rather than merely currently-correct. */
+  min-width: 0;
+  min-height: 0;
+  box-sizing: border-box;
   border-radius: 50%;
   flex: none;
 }
@@ -203,10 +211,12 @@
   background: var(--gold);
 }
 
-/* Browser offline, or the ingestion log shows recent connection failures. */
-#mindflock-bar .dc-dot.error,
-#pr-review-bar .dc-dot.error,
-#git-issue-bar .dc-dot.error {
+/* Browser offline, or the ingestion log shows recent connection failures.
+   Named `dc-error` rather than `error` so it cannot pick up the app-wide
+   error-TEXT rule (see the shape comment above). */
+#mindflock-bar .dc-dot.dc-error,
+#pr-review-bar .dc-dot.dc-error,
+#git-issue-bar .dc-dot.dc-error {
   background: var(--red);
   box-shadow: 0 0 6px var(--red);
 }

--- a/frontend/src/lib/autopilot.ts
+++ b/frontend/src/lib/autopilot.ts
@@ -99,7 +99,12 @@ export function autopilotChipTitle(run: AutopilotRun): string {
   const target = depthLabel(run.depth);
   if (run.state === "halted")
     return "Fast-track stopped: " + (run.reason || "unknown reason");
-  if (run.state === "done") return "Fast-track finished at " + target;
+  if (run.state === "done")
+    return (
+      "Fast-track finished at " +
+      target +
+      " — still on, and will pick up new work automatically."
+    );
   // Prefer the server's own sentence for what this pass is waiting on — it knows
   // whether it is the agent, the prompt queue, checks or a usage limit. Guessing
   // from an empty `step` made every legitimate pause read as "waiting on the

--- a/frontend/src/lib/autopilot.ts
+++ b/frontend/src/lib/autopilot.ts
@@ -33,15 +33,24 @@ export const DEPTH_LABELS: Record<string, string> = {
   merge: "Merge",
 };
 
-/** How the ladder reads in a dropdown, where each option continues the sentence
- * "take this…". The first rung names itself; the rest are "…then X". */
+/** How the ladder reads in a dropdown. No leading "…": inside a CLOSED select a
+ * leading ellipsis reads as text that has been clipped. */
 export const DEPTH_STEP_LABELS: Record<string, string> = {
   off: "Off",
   agent: "Agent only",
   commit: "Commit only",
-  push: "…then push",
-  pr: "…then open PR",
-  merge: "…then merge",
+  push: "Then push",
+  pr: "Then open PR",
+  merge: "Then merge",
+};
+
+/** Ultra-short target suffix for the pane header, where width is scarce. */
+export const DEPTH_SHORT: Record<string, string> = {
+  agent: "→ agent",
+  commit: "→ commit",
+  push: "→ push",
+  pr: "→ PR",
+  merge: "→ merge",
 };
 
 /** Which rung a given session stage PROVES is complete. Stages that mean "still
@@ -91,7 +100,15 @@ export function autopilotChipTitle(run: AutopilotRun): string {
   if (run.state === "halted")
     return "Fast-track stopped: " + (run.reason || "unknown reason");
   if (run.state === "done") return "Fast-track finished at " + target;
-  const where = run.step ? " (last step: " + run.step + ")" : " (waiting on the agent)";
+  // Prefer the server's own sentence for what this pass is waiting on — it knows
+  // whether it is the agent, the prompt queue, checks or a usage limit. Guessing
+  // from an empty `step` made every legitimate pause read as "waiting on the
+  // agent", so a deliberate wait looked like a hang.
+  const where = run.note
+    ? " — " + run.note
+    : run.step
+      ? " (last step: " + run.step + ")"
+      : " (waiting to start)";
   const skipped = run.skipped?.length
     ? "\nSkipped hooks: " + run.skipped.join(", ")
     : "";

--- a/frontend/src/lib/autopilot.ts
+++ b/frontend/src/lib/autopilot.ts
@@ -7,7 +7,7 @@
  * of special cases.
  */
 
-import type { AutopilotRun, Instance } from "../api/types";
+import type { AutopilotRun, Instance, MergeState } from "../api/types";
 
 export const DEPTH_ORDER = ["off", "agent", "commit", "push", "pr", "merge"] as const;
 
@@ -113,6 +113,28 @@ export function autopilotChipTitle(run: AutopilotRun): string {
     ? "\nSkipped hooks: " + run.skipped.join(", ")
     : "";
   return "Fast-tracking to " + target + where + "\nClick to stop." + skipped;
+}
+
+/** A short header label naming WHY a PR cannot merge.
+ *
+ * The full sentences live in `merge_state.blockers` and go in the tooltip; this is
+ * the ≤14-char version for a pane header where "PR open" would be true but
+ * useless when what you want to know is why Merge is greyed out. */
+export function mergeBlockerLabel(ms: MergeState): string {
+  switch (ms.state) {
+    case "dirty":
+      return "conflicts";
+    case "behind":
+      return "behind base";
+    case "draft":
+      return "draft PR";
+    case "blocked":
+      if (ms.checks === "failed") return "checks ✗";
+      if (ms.checks === "pending") return "checks…";
+      return "review needed";
+    default:
+      return ms.mergeable === null ? "checking…" : "can't merge";
+  }
 }
 
 /** A running chain on this session, or null. */

--- a/frontend/src/lib/sessionActions.ts
+++ b/frontend/src/lib/sessionActions.ts
@@ -12,7 +12,7 @@ import { freshStage } from "./stageWatch";
 import { useUi } from "../state/store";
 import { toast } from "./toast";
 import { errMsg } from "./format";
-import { markLoopReset } from "./stage";
+import { clearStep, markLoopReset, markStep } from "./stage";
 import { depthLabel, normalizeDepth } from "./autopilot";
 import { focusTerm, releaseTerms } from "./terminals";
 
@@ -304,6 +304,10 @@ export function commitSession(title: string) {
 export async function pushSession(title: string, force = false) {
   if (!title || !requireGit()) return;
   selectSession(title, { noKeyboard: true });
+  // Push/PR/merge have no stage of their own until the RESULT is observable, so
+  // without this marker the header showed the previous step for seconds and people
+  // pressed the button twice.
+  markStep(title, "push");
   try {
     await instApi(title, "/push-branch", { json: force ? { force: true } : {} });
   } catch (err) {
@@ -313,8 +317,10 @@ export async function pushSession(title: string, force = false) {
         confirm("Checks haven't passed for this commit (see the ✗ checks chip).\nPush anyway?")
       )
         return pushSession(title, true);
+      clearStep(title);
       return;
     }
+    clearStep(title);
     toast("Push failed: " + errMsg(err), { duration: 6000 });
   }
   // The old `setTimeout(refreshInstances, 1000)` could not observe anything: the
@@ -332,43 +338,33 @@ export async function pushSession(title: string, force = false) {
  * The cost is that the effect is not instant, so the pane must show the armed
  * chip immediately or the press reads as broken. */
 
-const DEPTH_KEY = "mf_fasttrack_depth";
-
-/** The rung to use when the caller didn't pick one: last local choice, then the
- * server setting, then "pr". */
+/** The rung the ⏩ button will stop at, for LABELLING only.
+ *
+ * Display-only on purpose. There used to be a sticky `localStorage` value that
+ * outranked the server setting — and the commit dialog wrote it on every dropdown
+ * change — so browsing that dropdown once pinned every ⏩ button on the machine
+ * forever and Settings appeared to do nothing. There is now exactly one
+ * authority: the server. It resolves the depth whenever a request omits one, and
+ * reports the resolved value on /api/config purely so the UI can name it. */
 export function resolveDepth(): string {
-  try {
-    const local = normalizeDepth(localStorage.getItem(DEPTH_KEY));
-    if (local && local !== "off") return local;
-  } catch {
-    /* private mode / disabled storage — fall through to the server setting */
-  }
   const cfg = queryClient.getQueryData<Config>(["config"]);
-  const fromSettings = normalizeDepth(
-    (cfg as { repository?: { fasttrack_depth?: string } } | undefined)?.repository
-      ?.fasttrack_depth
-  );
-  return fromSettings && fromSettings !== "off" ? fromSettings : "pr";
-}
-
-export function rememberDepth(depth: string) {
-  try {
-    localStorage.setItem(DEPTH_KEY, normalizeDepth(depth) || "");
-  } catch {
-    /* not worth surfacing — the server setting still applies next time */
-  }
+  return normalizeDepth(cfg?.fasttrack_depth) || "pr";
 }
 
 /** Arm the chain. `message` is only needed when there is uncommitted work and
  * nothing is on disk to reuse — the same rule POST /commit applies. */
 export async function startFastTrack(
   title: string,
-  depth: string,
+  depth?: string,
   message?: string,
   base?: string
 ) {
   if (!title || !requireGit()) return;
-  const d = normalizeDepth(depth) || "pr";
+  // An explicit pick (the commit dialog, an intake row) is honoured; otherwise the
+  // body carries NO depth and the server applies the configured rung. That is what
+  // makes changing Settings take effect on every open window immediately.
+  const chosen = normalizeDepth(depth || "");
+  const d = chosen || resolveDepth();
   // One up-front confirm for the irreversible rung, before anything is armed.
   if (d === "merge") {
     const where = base ? " into " + base : "";
@@ -393,7 +389,7 @@ export async function startFastTrack(
   try {
     const r = await instApi<{ autopilot?: AutopilotRun | null }>(title, "/fast-track", {
       json: {
-        depth: d,
+        ...(chosen ? { depth: chosen } : {}),
         ...(message ? { message } : {}),
         ...(base ? { base } : {}),
       },
@@ -451,6 +447,7 @@ export function makePrSession(title: string) {
  * showing them a modal about a CLI they never asked for. */
 export async function submitMakePr(title: string, base: string) {
   if (!title || !requireGit()) return;
+  markStep(title, "pr");
   try {
     const r = await instApi<MakePrResult>(title, "/make-pr", {
       json: base ? { base } : {},
@@ -467,6 +464,7 @@ export async function submitMakePr(title: string, base: string) {
       markLoopReset(title);
     }
   } catch (err) {
+    clearStep(title);
     toast("Make PR failed: " + errMsg(err), { duration: 6000 });
   }
   await freshStage(title);
@@ -477,6 +475,7 @@ export async function submitMakePr(title: string, base: string) {
 export async function mergeSession(title: string) {
   if (!title || !requireGit()) return;
   if (!confirm("Merge this branch's PR into staging?")) return;
+  markStep(title, "merge");
   try {
     const r = await instApi<MergePrResult>(title, "/merge-pr", { method: "POST" });
     if (r && r.ok === false) {
@@ -485,6 +484,7 @@ export async function mergeSession(title: string) {
       else toast(msg, { duration: 9000 });
     }
   } catch (err) {
+    clearStep(title);
     toast("Merge failed: " + errMsg(err), { duration: 6000 });
   }
   await freshStage(title);

--- a/frontend/src/lib/sessionActions.ts
+++ b/frontend/src/lib/sessionActions.ts
@@ -112,7 +112,7 @@ export function hasPrSupport(c?: Partial<Caps>): boolean {
 /** Open `url` in a new tab, and if the popup blocker ate it (we are in an
  * async continuation, not a click handler) fall back to a clickable toast —
  * the user's click then counts as the gesture. Never blocks the UI. */
-function offerUrl(url: string, msg: string) {
+export function offerUrl(url: string, msg: string) {
   const win = window.open(url, "_blank");
   if (win) {
     toast(msg, { duration: 6000 });

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -485,7 +485,15 @@ export function fastTrackStep(inst: Partial<Instance>): NextStep | null {
   if (!title) return null;
 
   const run = inst.autopilot;
-  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted"));
+  // "done" counts as ARMED: fast-track is a standing instruction, and a finished
+  // run wakes itself for another cycle as soon as the agent produces new work. It
+  // read as OFF before, which is why keeping it on felt impossible — the toggle
+  // said off while the instruction was still in force.
+  const armed = !!(
+    run &&
+    run.depth &&
+    (run.state === "running" || run.state === "halted" || run.state === "done")
+  );
   // AN ARMED RUN IS ALWAYS CANCELLABLE. The guards below hide the OFF state where
   // a press would be meaningless (still provisioning, a commit in flight), but
   // they must never hide the ON state: an intake-armed session spends its first
@@ -515,6 +523,19 @@ export function fastTrackStep(inst: Partial<Instance>): NextStep | null {
       title:
         autopilotChipTitle(run) + "\n\nClick ⏩✗ to start fast-track again.",
       run: () => startFastTrack(title, run.depth),
+    };
+
+  // Finished, but still watching for the next cycle.
+  if (run && run.depth && run.state === "done")
+    return {
+      label: "⏩",
+      active: true,
+      title:
+        "Fast-track finished at " +
+        depthLabel(run.depth) +
+        " and is still on: it picks up again as soon as the agent changes\n" +
+        "anything more.\n\nClick ⏩ to turn fast-track off.",
+      run: () => stopFastTrack(title),
     };
 
   const depth = resolveDepth();

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -15,7 +15,6 @@ import {
   mergeSession,
   pushSession,
   resolveDepth,
-  selectSession,
   startFastTrack,
   stopFastTrack,
 } from "./sessionActions";
@@ -443,19 +442,28 @@ export function followAutopilot(
   if (seen === step) return null;
   const first = seen === undefined;
   followed.set(title, step);
-  if (first && !opts?.live) return null; // seed only — never steal focus on load
+
   if (step === "commit") {
-    // Side effects are guarded: this runs once per session per poll, so a DOM
-    // hiccup here must never break the loop for every other session.
+    // SWITCH THE TAB, DO NOT TAKE FOCUS. Autopilot runs unattended and often on a
+    // window you are not looking at, so yanking the view away from whatever you
+    // ARE doing is wrong. Setting the tab is harmless and does the useful half:
+    // whenever you next look at that window, it is already showing the hooks.
+    // (The manual Commit dialog still focuses, because you asked for it there.)
+    //
+    // Fires even on a first sighting, including from a poll: with no focus theft
+    // there is nothing to protect against, and a page loaded mid-commit should
+    // still find the right tab selected.
     try {
       useUi.getState().setLastTab(title, "shell");
-      selectSession(title);
     } catch {
       /* following is a courtesy — never let it break the poll */
     }
     return "commit";
   }
   if (step === "pr") {
+    // Opening a browser tab IS intrusive, so this one stays limited to a real live
+    // transition: a page load must not re-open a PR you have already seen.
+    if (first && !opts?.live) return null;
     const url = String(run.url || "") || inst.pr_url || "";
     if (url) {
       try {

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -393,12 +393,22 @@ export function fastTrackStep(inst: Partial<Instance>): NextStep | null {
   const title = inst.title;
   const caps = queryClient.getQueryData<Config>(["config"])?.caps;
   if (caps && !caps.git) return null;
-  if (!title || inst.status === "loading" || inst.status === "paused") return null;
-  if (inst.workspace_missing) return null;
-  const stage = guidedStage(inst);
-  if (stage === "provisioning" || stage === "precommit") return null;
+  if (!title) return null;
 
   const run = inst.autopilot;
+  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted"));
+  // AN ARMED RUN IS ALWAYS CANCELLABLE. The guards below hide the OFF state where
+  // a press would be meaningless (still provisioning, a commit in flight), but
+  // they must never hide the ON state: an intake-armed session spends its first
+  // minutes provisioning, and that is precisely when you might change your mind.
+  // Hiding the toggle there left no way to stop it at all.
+  if (!armed) {
+    if (inst.status === "loading" || inst.status === "paused") return null;
+    if (inst.workspace_missing) return null;
+    const stage = guidedStage(inst);
+    if (stage === "provisioning" || stage === "precommit") return null;
+  }
+
   // Armed: show it ON and make the click turn it off.
   if (run && run.depth && run.state === "running")
     return {

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -17,7 +17,7 @@ import {
   startFastTrack,
   stopFastTrack,
 } from "./sessionActions";
-import { autopilotChipTitle, depthLabel } from "./autopilot";
+import { DEPTH_SHORT, autopilotChipTitle, depthLabel } from "./autopilot";
 
 /** Longest `failed_step` that still reads as a hook NAME rather than a line of
  * output, and so still belongs in the stage pill. "Run Tests (+3)" is 14. */
@@ -238,6 +238,146 @@ export interface NextStep {
    * fast-track control while a chain is armed, so the button you pressed stays
    * visible, visibly on, and clickable to turn back off. */
   active?: boolean;
+}
+
+/* --- Live step indicator ----------------------------------------------------
+ * What the top of a window says while work is actually happening.
+ *
+ * The header used to fill the primary button's slot with a DISABLED grey pill
+ * whenever `nextStep()` returned null — so the single busiest moment in the
+ * workflow (pre-commit hooks running) rendered as dead greyed-out text reading
+ * "pre-commit". This replaces it with a small indicator that reads as active,
+ * names the step, and — when a chain is armed — says what it is waiting on and
+ * where it is heading.
+ */
+
+export type StepTone = "work" | "blocked" | "ok" | "quiet";
+
+export interface LiveStep {
+  label: string;
+  tone: StepTone;
+  title: string;
+  /** Short "→ PR" target suffix while a chain is armed. */
+  target?: string;
+  /** Click opens the PR (only set when there is one to open). */
+  href?: string;
+}
+
+/** Verbs that are in flight but have no stage of their own.
+ *
+ * Push, make-PR and merge all type a command / call a route and return; the stage
+ * only moves once the RESULT is observable (origin matches, a PR exists). Between
+ * the click and that flip the header would otherwise still show the previous
+ * step, which is what made people press Push twice. Same self-clearing pattern as
+ * `reconcileLoopReset`: the entry dies when the stage moves past it or on TTL. */
+const inflight = new Map<string, { verb: "push" | "pr" | "merge"; at: number }>();
+const INFLIGHT_TTL_MS = 120_000;
+
+export function markStep(title: string, verb: "push" | "pr" | "merge") {
+  if (title) inflight.set(title, { verb, at: Date.now() });
+}
+
+export function clearStep(title: string) {
+  inflight.delete(title);
+}
+
+function inflightVerb(inst: Partial<Instance>): "push" | "pr" | "merge" | null {
+  const title = inst.title;
+  if (!title) return null;
+  const rec = inflight.get(title);
+  if (!rec) return null;
+  if (Date.now() - rec.at > INFLIGHT_TTL_MS) {
+    inflight.delete(title);
+    return null;
+  }
+  // The stage has caught up — the verb is done.
+  const stage = inst.stage || "";
+  if (
+    (rec.verb === "push" && (stage === "pushed" || stage === "pr")) ||
+    (rec.verb === "pr" && stage === "pr") ||
+    (rec.verb === "merge" && stage !== "pr")
+  ) {
+    inflight.delete(title);
+    return null;
+  }
+  return rec.verb;
+}
+
+/** The current step for a session, or null when nothing is happening. */
+export function liveStep(inst: Partial<Instance>): LiveStep | null {
+  const stage = guidedStage(inst);
+
+  if (inst.workspace_missing)
+    return { label: "workspace gone", tone: "blocked", title: "The workspace directory no longer exists." };
+  if (inst.status === "paused")
+    return { label: "paused", tone: "quiet", title: "Session paused — resume it to continue." };
+
+  // Worktree setup outranks everything: queued prompts are HELD while it runs,
+  // and the autopilot refuses to act at all, so it must be visible.
+  const setup = inst.setup;
+  if (setup?.state === "running")
+    return { label: "setting up", tone: "work", title: "Running the workspace setup commands." };
+  if (setup?.state === "failed")
+    return {
+      label: "setup failed",
+      tone: "blocked",
+      title:
+        "Workspace setup failed" +
+        (setup.failed_step ? " at " + setup.failed_step : "") +
+        ". Queued prompts are held until it succeeds.",
+    };
+
+  if (stage === "provisioning")
+    return { label: "provisioning", tone: "work", title: "Creating the workspace." };
+  if (stage === "precommit")
+    return { label: "pre-commit", tone: "work", title: "Running the pre-commit hooks." };
+  if (stage === "interrupt")
+    return {
+      label: "pre-commit ✗",
+      tone: "blocked",
+      title:
+        "A pre-commit hook blocked the commit" +
+        (inst.failed_step ? " at " + inst.failed_step : "") +
+        ".",
+    };
+
+  const verb = inflightVerb(inst);
+  if (verb === "push") return { label: "pushing", tone: "work", title: "Pushing the branch to origin." };
+  if (verb === "pr") return { label: "opening PR", tone: "work", title: "Opening the pull request." };
+  if (verb === "merge") return { label: "merging", tone: "work", title: "Merging the pull request." };
+
+  // Verification checks run while the stage still reads "committed", and the push
+  // route soft-rejects a push until they pass — so say so before Push is pressed.
+  const check = inst.check;
+  if (check?.state === "running")
+    return { label: "checks", tone: "work", title: "Running the verification check." };
+  if (check?.state === "failed")
+    return {
+      label: "checks ✗",
+      tone: "blocked",
+      title: "The verification check failed" + (check.failed_step ? " at " + check.failed_step : "") + ".",
+    };
+
+  // An armed chain: say what it is waiting on and where it is going.
+  const run = inst.autopilot;
+  if (run && run.depth && run.state === "running")
+    return {
+      label: run.note || "fast-tracking",
+      tone: "work",
+      title: autopilotChipTitle(run),
+      target: DEPTH_SHORT[run.depth] || "",
+    };
+  if (run && run.depth && run.state === "halted")
+    return { label: "fast-track ✗", tone: "blocked", title: autopilotChipTitle(run) };
+
+  if (stage === "pr")
+    return {
+      label: "PR open",
+      tone: "ok",
+      title: inst.pr_url ? "Open the pull request" : "A pull request is open for this branch.",
+      href: inst.pr_url || undefined,
+    };
+  return null;
 }
 
 /** The ⏩ sibling of the guided button: a per-session TOGGLE for autopilot.

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -9,15 +9,18 @@ import { toast } from "./toast";
 import {
   PR_FALLBACK_HINT,
   commitSession,
+  offerUrl,
   hasPrSupport,
   makePrSession,
   mergeSession,
   pushSession,
   resolveDepth,
+  selectSession,
   startFastTrack,
   stopFastTrack,
 } from "./sessionActions";
 import { DEPTH_SHORT, autopilotChipTitle, depthLabel } from "./autopilot";
+import { useUi } from "../state/store";
 
 /** Longest `failed_step` that still reads as a hook NAME rather than a line of
  * output, and so still belongs in the stage pill. "Run Tests (+3)" is 14. */
@@ -377,6 +380,70 @@ export function liveStep(inst: Partial<Instance>): LiveStep | null {
       title: inst.pr_url ? "Open the pull request" : "A pull request is open for this branch.",
       href: inst.pr_url || undefined,
     };
+  return null;
+}
+
+/* --- Follow an autopilot run ------------------------------------------------
+ * When the driver reaches a step, do what pressing that button by hand would do:
+ * the commit step focuses the window and shows its shell (so the pre-commit hooks
+ * are watchable), and the PR step opens the pull request.
+ *
+ * Driven from BOTH the `session.autopilot_changed` event (sub-second) and the 4s
+ * poll (guaranteed). Relying on the event alone made this depend on catching one
+ * transient message: the socket can be disconnected, the server's per-client queue
+ * drops events when full, and a page can load mid-commit. Both paths share the
+ * guard below, so it still happens exactly once per step.
+ */
+
+const followed = new Map<string, string>();
+
+export function resetFollow(title?: string) {
+  if (title) followed.delete(title);
+  else followed.clear();
+}
+
+/** React to an autopilot run reaching a new step. `live` marks a real-time event,
+ * where firing on a first sighting is correct; a poll seeds silently instead, so
+ * loading the page during a commit does not yank focus. */
+export function followAutopilot(
+  inst: Partial<Instance>,
+  opts?: { live?: boolean }
+): string | null {
+  const title = inst.title;
+  const run = inst.autopilot;
+  if (!title) return null;
+  if (!run || !run.depth || run.state !== "running") {
+    followed.delete(title);
+    return null;
+  }
+  const step = String(run.step || "");
+  const seen = followed.get(title);
+  if (seen === step) return null;
+  const first = seen === undefined;
+  followed.set(title, step);
+  if (first && !opts?.live) return null; // seed only — never steal focus on load
+  if (step === "commit") {
+    // Side effects are guarded: this runs once per session per poll, so a DOM
+    // hiccup here must never break the loop for every other session.
+    try {
+      useUi.getState().setLastTab(title, "shell");
+      selectSession(title);
+    } catch {
+      /* following is a courtesy — never let it break the poll */
+    }
+    return "commit";
+  }
+  if (step === "pr") {
+    const url = String(run.url || "") || inst.pr_url || "";
+    if (url) {
+      try {
+        offerUrl(url, "PR opened for " + title);
+      } catch {
+        /* a blocked/absent window must not break the loop */
+      }
+    }
+    return "pr";
+  }
   return null;
 }
 

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -19,7 +19,12 @@ import {
   startFastTrack,
   stopFastTrack,
 } from "./sessionActions";
-import { DEPTH_SHORT, autopilotChipTitle, depthLabel } from "./autopilot";
+import {
+  DEPTH_SHORT,
+  autopilotChipTitle,
+  depthLabel,
+  mergeBlockerLabel,
+} from "./autopilot";
 import { useUi } from "../state/store";
 
 /** Longest `failed_step` that still reads as a hook NAME rather than a line of
@@ -237,6 +242,10 @@ export interface NextStep {
   run: () => void;
   hint?: boolean;
   title?: string;
+  /** Rendered unclickable. Used when we KNOW the action would be refused — a merge
+   * whose PR has conflicts, a failing required check, or a missing review. Offering
+   * a button that cannot work is worse than showing why it cannot. */
+  disabled?: boolean;
   /** Rendered as an ON toggle (filled rather than outlined). Used by the ⏩
    * fast-track control while a chain is armed, so the button you pressed stays
    * visible, visibly on, and clickable to turn back off. */
@@ -373,13 +382,26 @@ export function liveStep(inst: Partial<Instance>): LiveStep | null {
   if (run && run.depth && run.state === "halted")
     return { label: "fast-track ✗", tone: "blocked", title: autopilotChipTitle(run) };
 
-  if (stage === "pr")
+  if (stage === "pr") {
+    const ms = inst.merge_state;
+    if (ms && !ms.can_merge)
+      // Say WHAT is blocking it, right in the header — "PR open" is true but
+      // useless when the thing you want to know is why Merge is greyed out.
+      return {
+        label: mergeBlockerLabel(ms),
+        tone: "blocked",
+        title:
+          "This PR cannot be merged yet:\n" +
+          (ms.blockers || []).map((b) => "• " + b).join("\n"),
+        href: inst.pr_url || ms.url || undefined,
+      };
     return {
       label: "PR open",
       tone: "ok",
       title: inst.pr_url ? "Open the pull request" : "A pull request is open for this branch.",
       href: inst.pr_url || undefined,
     };
+  }
   return null;
 }
 
@@ -569,6 +591,22 @@ export function nextStep(inst: Partial<Instance>): NextStep | null {
               run: () => window.open(inst.pr_url!, "_blank"),
             }
           : { label: "Merge ↗", hint: true, title: PR_FALLBACK_HINT, run: () => mergeSession(title) };
+      // Only offer Merge when GitHub says it would actually go through. `merge_state`
+      // absent means we could not find out (no token, no gh, a network fault) — in
+      // that case leave the button alone rather than block on a guess.
+      {
+        const ms = inst.merge_state;
+        if (ms && !ms.can_merge)
+          return {
+            label: "Merge blocked",
+            disabled: true,
+            title:
+              "This PR cannot be merged yet:\n" +
+              (ms.blockers || []).map((b) => "• " + b).join("\n") +
+              (inst.pr_url ? "\n\nOpen the PR to resolve it." : ""),
+            run: () => {},
+          };
+      }
       return { label: "Merge", run: () => mergeSession(title) };
     case "merged":
       return inst.pr_url

--- a/tests/unit/test_autopilot.py
+++ b/tests/unit/test_autopilot.py
@@ -41,6 +41,7 @@ def _snap(**over):
         "check": None,
         "check_required": False,
         "pr_checks": "ok",
+        "merge_blockers": [],
         "on_base_branch": False,
         "branch": "feature/x",
         "has_origin": True,
@@ -227,6 +228,33 @@ def test_unknown_ci_is_never_a_green_light():
         _rec(depth="merge"), _snap(stage="pr", pr_checks="unknown")
     )
     assert action == "wait"
+
+
+def test_a_named_merge_blocker_stops_the_run_and_says_which():
+    """The driver reads the same probe the merge button does, so the two can never
+    disagree about whether a merge would go through."""
+    action, detail = ap.next_action(
+        _rec(depth="merge"),
+        _snap(
+            stage="pr",
+            merge_blockers=["the branch has merge conflicts with its base"],
+        ),
+    )
+    assert action == "stop"
+    assert "merge conflicts" in detail["reason"]
+
+
+def test_a_blocker_that_is_only_a_running_check_waits():
+    action, detail = ap.next_action(
+        _rec(depth="merge"),
+        _snap(
+            stage="pr",
+            pr_checks="pending",
+            merge_blockers=["required checks are still running"],
+        ),
+    )
+    assert action == "wait"
+    assert "required checks" in detail["reason"]
 
 
 def test_a_repo_that_reports_no_checks_may_merge():

--- a/tests/unit/test_autopilot.py
+++ b/tests/unit/test_autopilot.py
@@ -619,3 +619,49 @@ def test_claiming_an_unknown_or_nameless_chain_is_refused():
     ap.arm("s1", "pr")
     assert ap.claim("s1", "") == (None, False)
     assert ap.claim("", "server-A") == (None, False)
+
+
+# --- A standing instruction, not a one-shot ----------------------------------
+def test_a_branch_that_already_has_a_pr_finishes_immediately():
+    """This is the situation that made fast-track feel impossible to keep on: the
+    stage already reads "pr", so the target is satisfied the moment you arm it."""
+    assert ap.next_action(_rec(depth="pr"), _snap(stage="pr"))[0] == "done"
+
+
+def test_rearm_starts_a_fresh_cycle_and_keeps_the_instruction():
+    ap.arm("s1", "pr", source="tix", item="sc-1", message="Fix the thing", now=1_000.0)
+    ap.update(
+        "s1", commits=3, step="pr", url="http://pr/1", skipped=["h"], issues={"push": 2}
+    )
+    ap.finish("s1")
+
+    woken = ap.rearm("s1", now=2_000.0)
+    assert woken is not None
+    # Per-CYCLE state is cleared, so a new pass cannot inherit a spent budget.
+    assert woken["state"] == "running"
+    assert woken["step"] == "" and woken["commits"] == 0
+    assert woken["url"] == "" and woken["skipped"] == [] and woken["issues"] == {}
+    assert woken["idle_since"] is None and woken["worked_at"] == 0.0
+    assert woken["step_since"] == 2_000.0
+    # Per-INSTRUCTION state survives.
+    assert woken["depth"] == "pr" and woken["message"] == "Fix the thing"
+    assert woken["source"] == "tix" and woken["item"] == "sc-1"
+
+
+def test_rearm_refuses_a_halted_run():
+    """A halt means a human has to look. Quietly resuming would bury the reason —
+    pressing the button is how you say you have dealt with it."""
+    ap.arm("s1", "pr")
+    ap.halt("s1", "the branch has merge conflicts")
+    assert ap.rearm("s1") is None
+    assert ap.get("s1")["state"] == "halted"
+
+
+def test_rearm_refuses_a_still_running_run():
+    ap.arm("s1", "pr")
+    assert ap.rearm("s1") is None, "a live run must not be reset under itself"
+
+
+def test_rearm_of_an_unknown_chain_is_refused():
+    assert ap.rearm("nope") is None
+    assert ap.rearm("") is None

--- a/tests/unit/test_autopilot.py
+++ b/tests/unit/test_autopilot.py
@@ -39,6 +39,10 @@ def _snap(**over):
         "limited": False,
         "queue_pending": False,
         "check": None,
+        "check_required": False,
+        "pr_checks": "ok",
+        "on_base_branch": False,
+        "branch": "feature/x",
         "has_origin": True,
         "now": 10_000.0,
     }
@@ -130,10 +134,57 @@ def test_prompt_queue_gates_the_commit():
 
 
 def test_clean_tree_after_the_agent_halts_loudly():
-    rec = _rec(idle_since=1.0)
+    """Only once this run actually SAW the agent work — see the next test."""
+    rec = _rec(idle_since=1.0, worked_at=9_000.0)
     action, detail = ap.next_action(rec, _snap(dirty=False, beyond_base=0))
     assert action == "stop"
     assert "without changing anything" in detail["reason"]
+
+
+def test_a_run_that_already_acted_never_accuses_the_agent():
+    """A session on its BASE branch lands in the agent branch permanently —
+    `_session_stage` collapses to "agent" whenever origin/<base>..HEAD is 0, which
+    it always is once the base branch has been pushed. A run that had committed AND
+    pushed therefore reported "the agent finished without changing anything", with
+    commits=1 and step="push" recorded right beside it."""
+    rec = _rec(commits=1, step="push", idle_since=1.0, worked_at=0.0)
+    action, detail = ap.next_action(
+        rec, _snap(dirty=False, beyond_base=0, on_base_branch=True, branch="main")
+    )
+    assert action == "stop"
+    assert "without changing anything" not in detail["reason"]
+    assert "main" in detail["reason"] and "make a branch" in detail["reason"]
+
+
+def test_a_run_that_landed_its_work_off_the_base_branch_is_done():
+    rec = _rec(commits=1, step="push", idle_since=1.0)
+    action, _ = ap.next_action(rec, _snap(dirty=False, beyond_base=0))
+    assert action == "done"
+
+
+def test_a_clean_tree_waits_when_the_agent_never_started():
+    """THE "stopping early" REGRESSION. Arming is normally the FIRST thing you do —
+    before the agent has written a line, or between turns. The old code halted
+    ~35s after every such press with "the agent finished without changing
+    anything", about an agent that had not begun."""
+    rec = _rec(idle_since=1.0, worked_at=0.0, commits=0)
+    action, detail = ap.next_action(rec, _snap(dirty=False, beyond_base=0))
+    assert action == "wait", "must never halt before the agent has done anything"
+    assert "waiting for the agent to start" in detail["reason"]
+
+
+def test_an_unmeasurable_commit_count_waits_rather_than_accusing():
+    """beyond_base None means "could not measure" (no base branch resolved). That
+    is not evidence that nothing happened, and must never be read as failure."""
+    rec = _rec(idle_since=1.0, worked_at=9_000.0)
+    action, _ = ap.next_action(rec, _snap(dirty=False, beyond_base=None))
+    assert action == "wait"
+
+
+def test_already_committed_work_is_done_not_an_accusation():
+    rec = _rec(depth="commit", idle_since=1.0, worked_at=9_000.0)
+    action, _ = ap.next_action(rec, _snap(dirty=False, beyond_base=3))
+    assert action == "done"
 
 
 def test_ladder_advances_committed_to_push_to_pr():
@@ -152,6 +203,37 @@ def test_pr_stage_only_merges_at_merge_depth():
     assert ap.next_action(_rec(depth="merge"), _snap(stage="pr"))[0] == "merge"
 
 
+# --- The merge rung waits for CI (the owner's stated requirement) -----------
+def test_merge_waits_for_pending_ci():
+    action, detail = ap.next_action(
+        _rec(depth="merge"), _snap(stage="pr", pr_checks="pending")
+    )
+    assert action == "wait"
+    assert "CI" in detail["reason"]
+
+
+def test_merge_stops_on_failed_ci():
+    action, detail = ap.next_action(
+        _rec(depth="merge"), _snap(stage="pr", pr_checks="failed")
+    )
+    assert action == "stop"
+    assert "CI failed" in detail["reason"]
+
+
+def test_unknown_ci_is_never_a_green_light():
+    """No token / API fault must not be mistaken for "nothing to wait for" — that
+    is how an autopilot merges unverified work."""
+    action, _ = ap.next_action(
+        _rec(depth="merge"), _snap(stage="pr", pr_checks="unknown")
+    )
+    assert action == "wait"
+
+
+def test_a_repo_that_reports_no_checks_may_merge():
+    action, _ = ap.next_action(_rec(depth="merge"), _snap(stage="pr", pr_checks="none"))
+    assert action == "merge"
+
+
 def test_agent_depth_completes_at_verified_idle():
     rec = _rec(depth="agent", idle_since=10_000.0)
     action, _ = ap.next_action(rec, _snap(now=10_000.0 + ap.IDLE_SETTLE_S + 1))
@@ -162,6 +244,59 @@ def test_precommit_stage_always_waits():
     """A commit is in flight and the shell owns the session."""
     for depth in ap.DEPTHS:
         assert ap.next_action(_rec(depth=depth), _snap(stage="precommit"))[0] == "wait"
+
+
+def test_a_session_on_its_base_branch_never_pushes():
+    """A run on `main` pushed 20 files straight to origin/main and the remote
+    reported "Bypassed rule violations … Changes must be made through a pull
+    request". There is no feature branch to PR from, so the chain must stop after
+    committing and say so."""
+    action, detail = ap.next_action(
+        _rec(), _snap(stage="committed", on_base_branch=True, branch="main")
+    )
+    assert action == "stop"
+    assert "main" in detail["reason"]
+    assert "make a branch" in detail["reason"]
+
+
+def test_committing_is_still_allowed_on_the_base_branch():
+    """Only pushing/PRing needs a branch — the commit itself is fine."""
+    assert (
+        ap.next_action(
+            _rec(depth="commit"), _snap(stage="committed", on_base_branch=True)
+        )[0]
+        == "done"
+    )
+
+
+def test_an_unknown_base_is_not_guessed_into_a_refusal():
+    action, _ = ap.next_action(
+        _rec(), _snap(stage="committed", on_base_branch=False, branch="")
+    )
+    assert action == "push"
+
+
+def test_a_trunk_branch_is_refused_even_if_the_base_did_not_resolve():
+    """Defence in depth. The base-branch guard relies on _session_base_branch; if
+    that resolves to "" the comparison silently passes and the trunk gets pushed —
+    and a bypass-silent remote ACCEPTS it, merely noting a PR was required. That
+    happened twice."""
+    for name in ("main", "master", "Main", "develop", "trunk"):
+        action, detail = ap.next_action(
+            _rec(), _snap(stage="committed", on_base_branch=False, branch=name)
+        )
+        assert action == "stop", name
+        assert name in detail["reason"]
+
+
+def test_a_feature_branch_still_pushes():
+    for name in ("feature/x", "fix/thing", "ethan/main-menu"):
+        assert (
+            ap.next_action(
+                _rec(), _snap(stage="committed", on_base_branch=False, branch=name)
+            )[0]
+            == "push"
+        ), name
 
 
 def test_missing_origin_stops_before_pushing():
@@ -179,6 +314,59 @@ def test_failed_checks_stop_the_run():
     assert "checks failed" in detail["reason"]
 
 
+def test_a_repo_with_no_check_command_pushes_immediately():
+    """The common case, and it must not wait on a check that will never run."""
+    action, _ = ap.next_action(
+        _rec(), _snap(stage="committed", check=None, check_required=False)
+    )
+    assert action == "push"
+
+
+def test_a_declared_check_is_STARTED_not_discovered_as_a_409():
+    """The push route soft-gates on the verification check: in a repo that declares
+    check_command it answers 409 "checks haven't passed for this commit" when the
+    result is missing or stale, and the driver turned any 4xx into a permanent
+    halt. So the ladder asks for the check instead of pushing into a refusal."""
+    action, _ = ap.next_action(
+        _rec(), _snap(stage="committed", check=None, check_required=True)
+    )
+    assert action == "run_check"
+
+
+def test_a_stale_check_result_is_re_run_not_trusted():
+    action, _ = ap.next_action(
+        _rec(),
+        _snap(
+            stage="committed",
+            check={"state": "ok", "stale": True},
+            check_required=True,
+        ),
+    )
+    assert action == "run_check"
+
+
+def test_a_fresh_green_check_pushes():
+    action, _ = ap.next_action(
+        _rec(),
+        _snap(
+            stage="committed",
+            check={"state": "ok", "stale": False},
+            check_required=True,
+        ),
+    )
+    assert action == "push"
+
+
+def test_agent_depth_never_commits_even_on_an_interrupt():
+    """A target of "agent only" must not run git commit. The interrupt branch used
+    to be dispatched first, so an allowlisted hook made it commit anyway."""
+    rec = _rec(depth="agent", retryable=["gitnexus-index"], commits=0)
+    action, _ = ap.next_action(
+        rec, _snap(stage="interrupt", failed_hook="gitnexus-index")
+    )
+    assert action != "commit"
+
+
 def test_running_checks_wait():
     action, _ = ap.next_action(
         _rec(), _snap(stage="committed", check={"state": "running"})
@@ -188,7 +376,7 @@ def test_running_checks_wait():
 
 # --- The retry / skip policy ------------------------------------------------
 def test_unlisted_hook_failure_stops_with_the_hook_named():
-    rec = _rec(retryable=["gitnexus-index"])
+    rec = _rec(retryable=["gitnexus-index"], commits=1)
     action, detail = ap.next_action(
         rec,
         _snap(stage="interrupt", failed_hook="run-tests", failed_step="Run Tests"),
@@ -197,10 +385,23 @@ def test_unlisted_hook_failure_stops_with_the_hook_named():
     assert "Run Tests" in detail["reason"]
 
 
+def test_the_first_commit_attempt_is_always_spent():
+    """A run that has not committed yet is looking at an EARLIER attempt's
+    interrupt — very often a stale .mindflock_commit_status from a manual commit.
+    Halting there aborted the press within seconds, blaming a failure the user
+    pressed the button to get past. Spend our own attempt first (exactly what the
+    manual Re-commit button does)."""
+    rec = _rec(retryable=[], commits=0)
+    action, _ = ap.next_action(
+        rec, _snap(stage="interrupt", failed_hook="run-tests", failed_step="Run Tests")
+    )
+    assert action == "commit"
+
+
 def test_test_hooks_are_never_skippable_even_if_configured():
     """The deny set is enforced at the decision, not only in the UI, so a
     hand-edited settings file cannot route around it."""
-    rec = _rec(retryable=["run-tests", "detect-secrets"])
+    rec = _rec(retryable=["run-tests", "detect-secrets"], commits=1)
     for hook in ("run-tests", "detect-secrets"):
         action, detail = ap.next_action(rec, _snap(stage="interrupt", failed_hook=hook))
         assert action == "stop", hook
@@ -248,7 +449,7 @@ def test_commit_attempts_are_bounded_overall():
 def test_unparseable_hook_id_stops_rather_than_guessing():
     """pre-commit's display `name:` is free text and does not map back to an id
     ("Black format" is not `black`), so a missing id can never be guessed."""
-    rec = _rec(retryable=["gitnexus-index"])
+    rec = _rec(retryable=["gitnexus-index"], commits=1)
     action, detail = ap.next_action(
         rec, _snap(stage="interrupt", failed_hook="", failed_step="Black format")
     )
@@ -298,11 +499,23 @@ def test_finish_marks_done():
 def test_prune_drops_records_for_dead_sessions():
     """Mandatory, not housekeeping: titles are REUSED after a delete, so a
     recreated session must not inherit the old target or attempt counters."""
-    ap.arm("alive", "pr")
-    ap.arm("dead", "merge")
-    assert ap.prune(["alive"]) == 1
+    ap.arm("alive", "pr", now=1_000.0)
+    ap.arm("dead", "merge", now=1_000.0)
+    # Past the arm grace, an unknown title is dropped.
+    assert ap.prune(["alive"], now=1_000.0 + ap.ARM_GRACE_S + 1) == 1
     assert ap.get("dead") is None
     assert ap.get("alive") is not None
+
+
+def test_prune_never_drops_a_freshly_armed_record():
+    """THE BUG THAT DISABLED ALL OF INTAKE. Every intake entry point arms BEFORE
+    its session exists (a forced start arms then clones; the pipeline arms from a
+    separate process). A prune that demanded the title be live right now deleted
+    every such record within one 5s pass, so picking a depth on a ticket silently
+    did nothing at all."""
+    ap.arm("sc-123-not-created-yet", "pr", source="tix", now=1_000.0)
+    assert ap.prune([], now=1_000.0 + 5.0) == 0
+    assert ap.get("sc-123-not-created-yet") is not None
 
 
 def test_normalize_tolerates_a_mangled_record():

--- a/tests/unit/test_autopilot.py
+++ b/tests/unit/test_autopilot.py
@@ -490,10 +490,25 @@ def test_halt_records_a_reason_and_stops_the_run():
     assert ap.next_action(got, _snap())[0] == "stop"
 
 
-def test_finish_marks_done():
+def test_finish_marks_done_and_clears_the_wait_note():
+    """`note` holds what the run was WAITING on, which is history the moment it
+    stops. Left behind, a finished record still read "pre-commit hooks are
+    running" right next to its own completion."""
     ap.arm("s1", "pr")
+    ap.update("s1", note="pre-commit hooks are running")
     ap.finish("s1")
-    assert ap.get("s1")["state"] == "done"
+    got = ap.get("s1")
+    assert got["state"] == "done"
+    assert got["note"] == ""
+
+
+def test_halt_clears_the_wait_note_too():
+    ap.arm("s1", "pr")
+    ap.update("s1", note="waiting for checks to finish")
+    ap.halt("s1", "checks failed")
+    got = ap.get("s1")
+    assert got["reason"] == "checks failed", "the halt reason is what a human reads"
+    assert got["note"] == "", "the stale wait reason must not sit beside it"
 
 
 def test_prune_drops_records_for_dead_sessions():

--- a/tests/unit/test_autopilot.py
+++ b/tests/unit/test_autopilot.py
@@ -537,3 +537,42 @@ def test_store_survives_a_corrupt_file(monkeypatch):
     # And a write repairs it.
     ap.arm("s1", "pr")
     assert ap.get("s1")["depth"] == "pr"
+
+
+# --- One driver per chain ----------------------------------------------------
+def test_two_servers_cannot_both_drive_one_chain():
+    """THE "stuck at agent just went idle" BUG. Two servers sharing this store (a
+    dev instance on another port) both ran the driver: each saw the other's boot id,
+    treated it as a restart, and reset the idle dwell EVERY pass, so the 30s settle
+    could never elapse. Both would also have acted — double-committing and
+    double-pushing the same worktree."""
+    ap.arm("s1", "pr", now=1_000.0)
+    a, took_a = ap.claim("s1", "server-A", now=1_000.0)
+    assert a is not None and took_a is True
+
+    # B is locked out while A's lease is fresh.
+    b, took_b = ap.claim("s1", "server-B", now=1_010.0)
+    assert b is None and took_b is False
+
+    # A keeps it, and holding it does NOT keep resetting the dwell.
+    ap.update("s1", idle_since=1_005.0)
+    again, took_again = ap.claim("s1", "server-A", now=1_020.0)
+    assert again is not None and took_again is False
+    assert again["idle_since"] == 1_005.0, "an owner must not reset its own dwell"
+
+
+def test_a_stale_lease_is_taken_over_and_the_dwell_re_earned():
+    ap.arm("s1", "pr", now=1_000.0)
+    ap.claim("s1", "server-A", now=1_000.0)
+    ap.update("s1", idle_since=1_005.0)
+    # A went away; past the staleness window B may take over.
+    b, took = ap.claim("s1", "server-B", now=1_000.0 + ap.LEASE_STALE_S + 1)
+    assert b is not None and took is True
+    assert b["idle_since"] is None, "a new driver must not inherit a dwell it never saw"
+
+
+def test_claiming_an_unknown_or_nameless_chain_is_refused():
+    assert ap.claim("nope", "server-A") == (None, False)
+    ap.arm("s1", "pr")
+    assert ap.claim("s1", "") == (None, False)
+    assert ap.claim("", "server-A") == (None, False)

--- a/tests/unit/test_fast_track_routes.py
+++ b/tests/unit/test_fast_track_routes.py
@@ -111,11 +111,18 @@ def test_the_agent_rung_is_intake_only(inst):
     assert "intake" in _body(resp)["error"]
 
 
-def test_a_dirty_tree_needs_a_message(inst, wt):
+def test_a_dirty_tree_gets_a_generated_message_rather_than_a_refusal(inst, wt):
+    """THE ⏩ REGRESSION. The button presses with no message, and
+    .mindflock_commit_msg only exists once something has committed THROUGH
+    MindFlock — so the single most common press ("I have work, carry it to a PR")
+    was rejected outright with a red toast. A generated subject beats a chain that
+    refuses to start."""
     (wt / "b.txt").write_text("uncommitted\n")
     resp = _post("ft-session", {"depth": "pr"})
-    assert resp.status_code == 400
-    assert _body(resp)["error"] == "commit message required"
+    assert resp.status_code == 200
+    msg = ap.get("ft-session")["message"]
+    assert msg, "a message must have been generated"
+    assert "ft-session" in msg
 
 
 def test_a_clean_tree_needs_no_message(inst):
@@ -124,12 +131,27 @@ def test_a_clean_tree_needs_no_message(inst):
     assert resp.status_code == 200
 
 
-def test_a_message_on_disk_is_reused(inst, wt):
+def test_a_message_from_a_BLOCKED_commit_is_reused(inst, wt):
+    """Reuse is for retrying a commit the hooks blocked, so it requires a pending
+    FAILURE — not merely a message file lying around."""
     (wt / "b.txt").write_text("uncommitted\n")
     (wt / server._COMMIT_MSG_FILE).write_text("recovered subject\n")
+    (wt / server._COMMIT_STATUS_FILE).write_text("1\n")
     resp = _post("ft-session", {"depth": "pr"})
     assert resp.status_code == 200
     assert ap.get("ft-session")["message"] == "recovered subject"
+
+
+def test_a_message_left_by_UNRELATED_work_is_not_adopted(inst, wt):
+    """The hazard this rule exists for: a message file survived earlier work and
+    the next thing armed silently inherited its subject. Caught in the wild about
+    to record one feature's files under a message describing a DB migration."""
+    (wt / "b.txt").write_text("uncommitted\n")
+    (wt / server._COMMIT_MSG_FILE).write_text("Refactor database schema\n")
+    (wt / server._COMMIT_STATUS_FILE).write_text("0\n")  # that commit SUCCEEDED
+    resp = _post("ft-session", {"depth": "pr"})
+    assert resp.status_code == 200
+    assert "Refactor database schema" not in ap.get("ft-session")["message"]
 
 
 def test_arming_captures_the_branch_for_drift_detection(inst):

--- a/tests/unit/test_fast_track_routes.py
+++ b/tests/unit/test_fast_track_routes.py
@@ -258,3 +258,47 @@ def test_per_item_depth_override_accepts_merge():
     assert server._start_depth_override({}) == ""
     with pytest.raises(ValueError):
         server._start_depth_override({"depth": "teleport"})
+
+
+def test_a_clean_tree_arm_still_gets_a_message_at_commit_time(inst, wt):
+    """Arming on a CLEAN tree is the natural way to use this — arm the session, let
+    the agent work — and the route records no message then, because there is
+    nothing to describe yet. The run used to halt with "no commit message to reuse"
+    at the very moment it was finally ready to commit."""
+    resp = _post("ft-session", {"depth": "pr"})
+    assert resp.status_code == 200
+    assert ap.get("ft-session")["message"] == "", "nothing to describe yet"
+
+    # The agent has since written something; the commit step must generate a
+    # subject rather than refuse.
+    (wt / "b.txt").write_text("the agent's work\n")
+    sent = {}
+    import backend.web.server as srv
+
+    orig = srv._commit_into_shell
+
+    def _capture(t, w, m, skip=""):
+        sent["msg"] = m
+        return None  # None == success; anything else is an error string
+
+    srv._commit_into_shell = _capture
+    try:
+        fields: dict = {}
+        ok = srv._autopilot_commit(
+            "ft-session", str(wt), ap.get("ft-session"), {}, fields
+        )
+    finally:
+        srv._commit_into_shell = orig
+    assert ok is True, "must not halt for want of a message"
+    assert sent["msg"], "a subject must have been generated"
+
+
+def test_an_intake_name_survives_a_re_arm(inst, wt):
+    """All three intake paths record the ticket / PR / issue NAME. Re-arming with
+    the button used to overwrite it with a generated "Work on <slug>", throwing
+    away the one genuinely descriptive subject available."""
+    ap.arm("ft-session", "pr", source="tix", message="Add phone numbers to intake")
+    (wt / "b.txt").write_text("uncommitted\n")
+    resp = _post("ft-session", {"depth": "pr"})
+    assert resp.status_code == 200
+    assert ap.get("ft-session")["message"] == "Add phone numbers to intake"

--- a/tests/unit/test_frontend_polish.py
+++ b/tests/unit/test_frontend_polish.py
@@ -217,3 +217,23 @@ def _rule(css: str, selector: str) -> str:
     got = _rules(css, selector)
     assert got, "no rule found for " + selector
     return got[0]
+
+
+def test_the_ingestion_dot_cannot_be_deformed_by_the_global_error_rule():
+    """The red state used to carry a bare `error` class. `.error` is the app-wide
+    rule for error TEXT and sets `min-height: 16px`; `.dc-dot` sets `height: 9px`
+    but no min-height, so the global won uncontested and rendered a 9x16 OVAL — in
+    exactly one state, because it was the only one borrowing that name."""
+    js = client.get("/app.js").text
+    css = client.get("/style.css").text
+    # The state class is scoped, and no bar emits a bare "error" state any more.
+    assert "dc-error" in js
+    assert '"dc-dot " + (netIssue ? "error"' not in js
+    # The styled selector matches the scoped name.
+    assert ".dc-dot.dc-error" in css
+    # And the circle pins its own box, so a future global leak cannot deform it.
+    dot = _rule(
+        css, "#mindflock-bar .dc-dot,\n#pr-review-bar .dc-dot,\n#git-issue-bar .dc-dot"
+    )
+    for decl in ("min-height: 0", "min-width: 0", "border-radius: 50%"):
+        assert decl in dot, decl

--- a/tests/unit/test_frontend_polish.py
+++ b/tests/unit/test_frontend_polish.py
@@ -171,3 +171,49 @@ def test_provisioning_placeholder_hint_is_repo_neutral():
     js = client.get("/app.js").text
     assert "The first provisioned run clones the base repo" in js
     assert "sitecheck-bot" not in js
+
+
+# --------------------------------------------------------------------------- #
+# Pane header: a long session title must cost its OWN characters, never the
+# controls beside it.
+# --------------------------------------------------------------------------- #
+
+
+def test_pane_header_shrinks_the_title_not_the_controls():
+    """A 60-character session name used to slice the Commit button, the fast-track
+    toggle and the live-step indicator off the right edge, because `.actions` was
+    made shrinkable so a verbose step label could not push the usage chip out. The
+    title is a LABEL whose full text is one hover away; those are CONTROLS."""
+    css = client.get("/style.css").text
+    # The title is the designated shrink target — factor 3 against the context
+    # line's 1 — and may truncate hard rather than hold its width.
+    title = _rule(css, ".pane-head .title")
+    assert "flex: 0 3 auto" in title, title
+    assert "text-overflow: ellipsis" in title
+    # EVERY .pane-head .actions rule must refuse to shrink; one that yields is
+    # what clipped the controls.
+    blocks = _rules(css, ".pane-head .actions")
+    assert blocks, "expected .pane-head .actions rules in the built CSS"
+    for b in blocks:
+        assert "flex: none" in b, b
+        assert "flex: 0 1 auto" not in b, b
+    # Its container can no longer shrink, so the step label bounds itself.
+    assert "max-width: 15ch" in _rule(css, ".pane-head .actions .stepnow-text")
+
+
+def _rules(css: str, selector: str) -> list:
+    """Every top-level rule body for an exact selector in the (unminified) CSS."""
+    out = []
+    needle = "\n" + selector + " {"
+    at = css.find(needle)
+    while at != -1:
+        end = css.find("\n}", at)
+        out.append(css[at : end + 2])
+        at = css.find(needle, end)
+    return out
+
+
+def _rule(css: str, selector: str) -> str:
+    got = _rules(css, selector)
+    assert got, "no rule found for " + selector
+    return got[0]

--- a/tests/unit/test_stage_freshness.py
+++ b/tests/unit/test_stage_freshness.py
@@ -143,6 +143,34 @@ def test_commit_command_is_byte_identical_without_a_skip():
     assert 'echo $rc > .mindflock_commit_status; rm -f "$L"' in cmd
 
 
+def test_a_landed_commit_clears_its_message_file():
+    """A leftover message must only survive a FAILURE. It used to survive success
+    and unrelated work, so the next commit arriving without a message silently
+    adopted a stale subject — a run was caught about to record one feature's files
+    under a message describing a database migration."""
+    cmd = server._commit_shell_command()
+    assert "[ $rc -eq 0 ] && rm -f .mindflock_commit_msg" in cmd
+    # …and only on success: the retry path still needs the message.
+    assert cmd.index("echo $rc") < cmd.index("rm -f .mindflock_commit_msg")
+
+
+def test_a_stale_message_is_not_adopted_after_a_success(tmp_path):
+    """`_pending_commit_message` mirrors GET /commit-message: offer the saved
+    message only while a failure is pending."""
+    (tmp_path / server._COMMIT_MSG_FILE).write_text("subject from other work\n")
+    # Last attempt SUCCEEDED -> nothing pending, so nothing to adopt.
+    (tmp_path / server._COMMIT_STATUS_FILE).write_text("0\n")
+    assert server._pending_commit_message(str(tmp_path)) == ""
+    # Last attempt FAILED -> the retry legitimately reuses it.
+    (tmp_path / server._COMMIT_STATUS_FILE).write_text("1\n")
+    assert server._pending_commit_message(str(tmp_path)) == "subject from other work"
+
+
+def test_no_recorded_attempt_means_no_message_to_adopt(tmp_path):
+    (tmp_path / server._COMMIT_MSG_FILE).write_text("orphan\n")
+    assert server._pending_commit_message(str(tmp_path)) == ""
+
+
 def test_commit_command_prefixes_skip_as_a_one_shot_env():
     cmd = server._commit_shell_command("gitnexus-index")
     assert "SKIP=gitnexus-index git commit -F .mindflock_commit_msg" in cmd


### PR DESCRIPTION
## Why

The fast-track / autopilot feature shipped with defects that together made it
look broken: it halted ~31s after every press claiming the agent had done
nothing, the Settings rung had no effect at all, the intake half silently did
nothing, and a session on `main` pushed straight to `origin/main`.

Found by auditing the driver against a scratch repo rather than by reading it,
plus evidence from a real halted run in the local store (`commits: 1`,
`step: "push"`, `reason: "the agent finished without changing anything"`).

## Halt semantics

A run may now only **halt** on evidence a human must act. Everything else waits
with a persisted reason, bounded by a deadline.

- A clean tree no longer means "the agent did nothing" until the run has actually
  seen the agent work (`worked_at`) or produced a commit. Arming is normally the
  first thing you do, and the activity probe reports idle 8s after a static pane.
- `beyond_base` distinguishes *measured zero* from *could not measure* (`None`).
  It was hard-coded `0` on any exception and is structurally `0` for a session
  whose branch is its base.
- Once a run has acted, the accusatory sentence is unreachable. A session on its
  base branch collapses to stage `agent` permanently, because
  `origin/<base>..HEAD` is `0` once the trunk is pushed.
- **Autopilot refuses to push or PR from the base branch**, and from any branch
  named `main`/`master`/`trunk`/`develop` whatever the configured base resolves
  to. Without this a run on `main` pushed to `origin/main`; a bypass-silent
  ruleset accepts that and merely notes a PR was required.
- A declared `check_command` is now **run** (new `run_check` verb) rather than
  discovered as the push route's 409 and turned into a permanent halt.
- The first commit attempt of a run is always spent, so a stale
  `.mindflock_commit_status` cannot abort the press within seconds.
- Holds are visible and bounded (`note`); per-verb caps stop a refused push being
  retyped every 15s forever; the retry allowlist is re-read every pass.
- `prune()` keeps records younger than `ARM_GRACE_S`. Every intake entry point
  arms **before** its session exists, so the old liveness-only prune deleted every
  intake record within one 5s pass.
- The merge rung waits for CI: green merges, failure stops, and `unknown` (no
  token, API fault) is pending — never a green light.

## Settings

Three faults compounded, so the rung you configured never applied: `/api/config`
never carried `repository.fasttrack_depth`; a `localStorage` value outranked it
(written by the commit dialog on *every* dropdown change); and the client always
sent an explicit depth, so the server's resolver was dead code. The server is now
the only authority, config reports the resolved rung for labels only, and
`refreshConfig()` is centralised in the settings save path.

## Commit messages

A landed commit clears `.mindflock_commit_msg`, and a saved message is only reused
while a **failure** is pending. It previously survived success and unrelated work,
so a commit arriving without a message inherited a stale subject — caught about to
record 19 files of this feature under a message describing a DB migration.

## UI

The disabled grey pill that filled the primary action slot during real work
(rendering "pre-commit" as dead greyed-out text) is replaced by a live step
indicator that reads as active, names the current step, and says what an armed
chain is waiting on. The fast-track control is a real toggle that stays visible
and turns off, and no longer takes over the guided button, so manual control is
never removed. The commit dialog's rung picker has styling, and it commits
immediately rather than only arming.

Also fixes `live_stage.watch` storing a record before `asyncio.create_task`,
which raises in a worker thread — the first autopilot commit poisoned the watcher
table and silently returned the whole app to 4s stage latency.

## Testing

4022 backend + 228 frontend tests pass. New coverage is regression-shaped: each
test names the symptom it prevents.

## Note on history

The work in this branch was briefly on `main` as `948f4c1` and `5cbd58f` — pushed
directly by the very bug this PR fixes. `main` has been restored to `c70fa3a`; the
original commits are preserved locally on `backup/autopilot-direct-pushes`. The
squashed tree here is byte-identical to what was on `main`.
