### PR TITLE
Fast-track turns itself off when its task ends; boot windows drag

### DIFF
--- a/backend/web/core/autopilot.py
+++ b/backend/web/core/autopilot.py
@@ -76,7 +76,6 @@ __all__ = [
     "snapshot",
     "dto",
     "claim",
-    "rearm",
 ]
 
 _FileName = "autopilot.json"
@@ -395,9 +394,20 @@ def next_action(rec: dict, snap: dict) -> Tuple[str, dict]:
     if stage == "precommit":
         return "wait", {"reason": "pre-commit hooks are running"}
 
-    # Target already met?
+    # Target already met — but FINISH only if this run actually did the work.
+    #
+    # A branch that already has an open PR satisfies a "pr" target the instant you
+    # arm it, so finishing there means the press accomplished nothing and the toggle
+    # switched itself off again. A run that has not acted yet stays armed and waits
+    # for the agent instead; it completes when it has genuinely carried the work,
+    # which is the point at which turning itself off is the right thing to do.
     if reaches(stage, depth):
-        return "done", {}
+        if int(rec.get("commits") or 0) > 0 or rec.get("step"):
+            return "done", {}
+        return "wait", {
+            "reason": "already at %s — waiting for new work" % stage_achieved(stage),
+            "idle_wait": True,
+        }
 
     # A blocked commit: retry, skip, or halt.
     # A target of "agent only" must never run git commit — dispatch it before the
@@ -613,55 +623,6 @@ def get(title: str) -> Optional[dict]:
     with _LOCK:
         entry = _load().get(title)
     return _normalize(entry) if entry is not None else None
-
-
-def rearm(title: str, now: Optional[float] = None) -> Optional[dict]:
-    """Wake a FINISHED run for another cycle, keeping its target.
-
-    Fast-track is a standing instruction, not a one-shot. A branch that already has
-    an open PR reads as stage "pr", so arming it satisfied the target immediately
-    and the run went ``done`` — and a done record is inert, so when the agent then
-    did more work nothing carried it anywhere. You had to re-press the button after
-    every single cycle.
-
-    Everything per-CYCLE is cleared (step, counters, skipped hooks, the dwell, the
-    PR url) so the new pass starts clean and cannot inherit an old attempt budget.
-    Everything per-INSTRUCTION is kept: the depth, the message, where it came from,
-    the retryable hooks, the branch.
-
-    Deliberately does NOT wake a HALTED run — that one stopped because a human
-    needs to look at it, and quietly resuming would bury the reason. Pressing the
-    button is how you say you have dealt with it.
-    """
-    if not title:
-        return None
-    ts = float(now if now is not None else time.time())
-    with _LOCK:
-        data = _load()
-        if title not in data:
-            return None
-        rec = _normalize(data[title])
-        if rec.get("state") != "done":
-            return None
-        rec.update(
-            state="running",
-            step="",
-            reason="",
-            note="",
-            url="",
-            attempts={},
-            issues={},
-            skipped=[],
-            commits=0,
-            idle_since=None,
-            worked_at=0.0,
-            step_since=ts,
-            acted_at=0.0,
-            updated=ts,
-        )
-        data[title] = rec
-        _save(data)
-    return dict(rec)
 
 
 def claim(title: str, owner: str, now: Optional[float] = None):

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -1563,26 +1563,12 @@ def _autopilot_observe(title: str):
     rec = _autopilot.get(title)
     if rec is None:
         return
-    if rec.get("state") == "done":
-        # STANDING INSTRUCTION, not a one-shot. A branch that already has an open PR
-        # reads as stage "pr", so arming satisfied the target at once and the run
-        # went done — then the agent did more work and nothing carried it anywhere,
-        # because a done record is inert. Wake it when there is new uncommitted work:
-        # after a finished cycle the tree is clean (the commit consumed it), so dirt
-        # means the agent has been busy again.
-        try:
-            _wt_rearm = ENGINE.instances[title].GetWorktreePath()
-        except Exception:  # noqa: BLE001
-            return
-        if not _wt_rearm or not _is_dirty(_wt_rearm):
-            return
-        woken = _autopilot.rearm(title)
-        if woken is None:
-            return
-        rec = woken
-        _emit_autopilot_event(title)
-    elif rec.get("state") != "running":
-        return  # halted: a human has to look at it before it moves again
+    if rec.get("state") != "running":
+        # Finished or halted: the run has had its go, either way. It turns itself
+        # OFF for that window rather than lingering armed — and the record stays so
+        # the outcome (and a halt's reason) is still readable. Pressing the button
+        # is how you start another one.
+        return
     if not _autopilot.normalize_depth(rec.get("depth")) in _autopilot.DEPTHS:
         return
     inst = ENGINE.instances.get(title)
@@ -1745,7 +1731,14 @@ def _autopilot_wait(title, rec, snap, detail, now) -> None:
             _autopilot.update(title, worked_at=now)
     _autopilot_note(title, rec, detail.get("reason") or "")
     step = rec.get("step") or "agent"
-    deadline = _AUTOPILOT_DEADLINES.get(step, _AUTOPILOT_DEADLINES["agent"])
+    # A run that has not acted yet is WAITING TO BE NEEDED, not making slow progress
+    # through a step — so it gets the generous arm budget rather than the agent
+    # step's. This is the "armed on a branch whose PR already exists" case: it may
+    # legitimately sit idle for a long time before there is anything to carry.
+    if not rec.get("step") and int(rec.get("commits") or 0) <= 0:
+        deadline = _autopilot.ARM_WAIT_DEADLINE_S
+    else:
+        deadline = _AUTOPILOT_DEADLINES.get(step, _AUTOPILOT_DEADLINES["agent"])
     since = float(rec.get("step_since") or 0.0)
     if since and now - since > deadline:
         _autopilot_halt(

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22803,7 +22803,7 @@ function autopilotChipTitle(run) {
   if (run.state === "halted")
     return "Fast-track stopped: " + (run.reason || "unknown reason");
   if (run.state === "done")
-    return "Fast-track finished at " + target + " — still on, and will pick up new work automatically.";
+    return "Fast-track finished at " + target + " and switched itself off.";
   const where = run.note ? " — " + run.note : run.step ? " (last step: " + run.step + ")" : " (waiting to start)";
   const skipped = ((_a2 = run.skipped) == null ? void 0 : _a2.length) ? "\nSkipped hooks: " + run.skipped.join(", ") : "";
   return "Fast-tracking to " + target + where + "\nClick to stop." + skipped;
@@ -23444,7 +23444,7 @@ function fastTrackStep(inst) {
   if (caps2 && !caps2.git) return null;
   if (!title) return null;
   const run = inst.autopilot;
-  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted" || run.state === "done"));
+  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted"));
   if (!armed) {
     if (inst.status === "loading" || inst.status === "paused") return null;
     if (inst.workspace_missing) return null;
@@ -23464,13 +23464,6 @@ function fastTrackStep(inst) {
       hint: true,
       title: autopilotChipTitle(run) + "\n\nClick ⏩✗ to start fast-track again.",
       run: () => startFastTrack(title, run.depth)
-    };
-  if (run && run.depth && run.state === "done")
-    return {
-      label: "⏩",
-      active: true,
-      title: "Fast-track finished at " + depthLabel(run.depth) + " and is still on: it picks up again as soon as the agent changes\nanything more.\n\nClick ⏩ to turn fast-track off.",
-      run: () => stopFastTrack(title)
     };
   const depth = resolveDepth();
   return {
@@ -27841,18 +27834,28 @@ function Pane({
     );
   }
   if (loading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "pane loading-pane", "data-title": title, children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pane-head", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "title", children: displayName }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "branch", children: inst.branch ? "(" + displayBranch(inst) + ")" : "" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "state", children: "provisioning…" })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pane-body", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "provisioning", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "spinner" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Provisioning workspace…" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "The first provisioned run clones the base repo — this can take a while." })
-      ] }) })
-    ] });
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "section",
+      {
+        ref: paneRef,
+        className: "pane loading-pane" + (dragging ? " dragging" : ""),
+        "data-title": title,
+        ...paneDrag,
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pane-head", ...headDrag, children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "grip", title: "Drag to move this window", children: "⠿" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "title", children: displayName }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "branch", children: inst.branch ? "(" + displayBranch(inst) + ")" : "" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "state", children: "provisioning…" })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pane-body", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "provisioning", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "spinner" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Provisioning workspace…" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "muted", children: "The first provisioned run clones the base repo — this can take a while." })
+          ] }) })
+        ]
+      }
+    );
   }
   const chip = chipState(inst);
   const ns = nextStep(inst);

--- a/frontend/src/__tests__/autopilot.test.ts
+++ b/frontend/src/__tests__/autopilot.test.ts
@@ -138,6 +138,7 @@ describe("chip text", () => {
 
   it("marks a finished run", () => {
     expect(autopilotChipLabel(run({ state: "done" }))).toBe("auto ✓");
+    expect(autopilotChipTitle(run({ state: "done" }))).toContain("switched itself off");
   });
 });
 
@@ -211,15 +212,22 @@ describe("the ⏩ control is a toggle", () => {
     }
   });
 
-  it("reads a FINISHED run as still armed", () => {
-    // Fast-track is a standing instruction: a done run wakes itself when the agent
-    // produces more work. Showing it OFF is why keeping it on felt impossible —
-    // a branch with an existing PR finishes instantly, every time.
+  it("turns itself OFF once the run has finished its task", () => {
     const s = fastTrackStep({
       title: "t", status: "running", stage: "pr", autopilot: run({ state: "done" }),
     });
-    expect(s?.active).toBe(true);
-    expect(s?.title).toContain("picks up again");
+    expect(s?.active).toBeFalsy();
+    // …and offers to start a fresh one.
+    expect(s?.title).toContain("Fast-track:");
+  });
+
+  it("turns itself OFF when the run failed, but still says why", () => {
+    const s = fastTrackStep({
+      title: "t", status: "running", stage: "interrupt",
+      autopilot: run({ state: "halted", reason: "checks failed" }),
+    });
+    expect(s?.active).toBeFalsy();
+    expect(s?.title).toContain("checks failed");
   });
 
   it("still surfaces a halted run while provisioning", () => {

--- a/frontend/src/components/grid/Pane.tsx
+++ b/frontend/src/components/grid/Pane.tsx
@@ -197,9 +197,19 @@ export function Pane({
   }
 
   if (loading) {
+    // Draggable while it boots. Provisioning is the LONGEST a window is ever in
+    // one state — a cold clone runs for minutes — and it was the one state you
+    // could not move or drop onto, so you had to wait it out before arranging your
+    // grid. Nothing about the drag touches the session; it is pure layout.
     return (
-      <section className="pane loading-pane" data-title={title}>
-        <div className="pane-head">
+      <section
+        ref={paneRef as React.RefObject<HTMLElement>}
+        className={"pane loading-pane" + (dragging ? " dragging" : "")}
+        data-title={title}
+        {...paneDrag}
+      >
+        <div className="pane-head" {...headDrag}>
+          <span className="grip" title="Drag to move this window">⠿</span>
           <span className="title">{displayName}</span>
           <span className="branch">{inst.branch ? "(" + displayBranch(inst) + ")" : ""}</span>
           <span className="state">provisioning…</span>

--- a/frontend/src/lib/autopilot.ts
+++ b/frontend/src/lib/autopilot.ts
@@ -100,11 +100,7 @@ export function autopilotChipTitle(run: AutopilotRun): string {
   if (run.state === "halted")
     return "Fast-track stopped: " + (run.reason || "unknown reason");
   if (run.state === "done")
-    return (
-      "Fast-track finished at " +
-      target +
-      " — still on, and will pick up new work automatically."
-    );
+    return "Fast-track finished at " + target + " and switched itself off.";
   // Prefer the server's own sentence for what this pass is waiting on — it knows
   // whether it is the agent, the prompt queue, checks or a usage limit. Guessing
   // from an empty `step` made every legitimate pause read as "waiting on the

--- a/frontend/src/lib/stage.ts
+++ b/frontend/src/lib/stage.ts
@@ -493,15 +493,11 @@ export function fastTrackStep(inst: Partial<Instance>): NextStep | null {
   if (!title) return null;
 
   const run = inst.autopilot;
-  // "done" counts as ARMED: fast-track is a standing instruction, and a finished
-  // run wakes itself for another cycle as soon as the agent produces new work. It
-  // read as OFF before, which is why keeping it on felt impossible — the toggle
-  // said off while the instruction was still in force.
-  const armed = !!(
-    run &&
-    run.depth &&
-    (run.state === "running" || run.state === "halted" || run.state === "done")
-  );
+  // Only a LIVE run is armed. A run that has finished its task — or failed at it —
+  // turns itself off for this window; the outcome stays readable in the header, and
+  // pressing the button is how you start another. A halted one still shows here so
+  // its reason is one hover away rather than vanishing silently.
+  const armed = !!(run && run.depth && (run.state === "running" || run.state === "halted"));
   // AN ARMED RUN IS ALWAYS CANCELLABLE. The guards below hide the OFF state where
   // a press would be meaningless (still provisioning, a commit in flight), but
   // they must never hide the ON state: an intake-armed session spends its first
@@ -531,19 +527,6 @@ export function fastTrackStep(inst: Partial<Instance>): NextStep | null {
       title:
         autopilotChipTitle(run) + "\n\nClick ⏩✗ to start fast-track again.",
       run: () => startFastTrack(title, run.depth),
-    };
-
-  // Finished, but still watching for the next cycle.
-  if (run && run.depth && run.state === "done")
-    return {
-      label: "⏩",
-      active: true,
-      title:
-        "Fast-track finished at " +
-        depthLabel(run.depth) +
-        " and is still on: it picks up again as soon as the agent changes\n" +
-        "anything more.\n\nClick ⏩ to turn fast-track off.",
-      run: () => stopFastTrack(title),
     };
 
   const depth = resolveDepth();

--- a/tests/unit/test_autopilot.py
+++ b/tests/unit/test_autopilot.py
@@ -194,14 +194,22 @@ def test_ladder_advances_committed_to_push_to_pr():
 
 
 def test_target_reached_is_done_not_another_step():
-    assert ap.next_action(_rec(depth="commit"), _snap(stage="committed"))[0] == "done"
-    assert ap.next_action(_rec(depth="push"), _snap(stage="pushed"))[0] == "done"
-    assert ap.next_action(_rec(depth="pr"), _snap(stage="pr"))[0] == "done"
+    """…once the run has actually carried the work (commits/step recorded)."""
+    acted = {"commits": 1, "step": "commit"}
+    assert (
+        ap.next_action(_rec(depth="commit", **acted), _snap(stage="committed"))[0]
+        == "done"
+    )
+    assert (
+        ap.next_action(_rec(depth="push", **acted), _snap(stage="pushed"))[0] == "done"
+    )
+    assert ap.next_action(_rec(depth="pr", **acted), _snap(stage="pr"))[0] == "done"
 
 
 def test_pr_stage_only_merges_at_merge_depth():
-    assert ap.next_action(_rec(depth="pr"), _snap(stage="pr"))[0] == "done"
-    assert ap.next_action(_rec(depth="merge"), _snap(stage="pr"))[0] == "merge"
+    acted = {"commits": 1, "step": "pr"}
+    assert ap.next_action(_rec(depth="pr", **acted), _snap(stage="pr"))[0] == "done"
+    assert ap.next_action(_rec(depth="merge", **acted), _snap(stage="pr"))[0] == "merge"
 
 
 # --- The merge rung waits for CI (the owner's stated requirement) -----------
@@ -291,7 +299,8 @@ def test_committing_is_still_allowed_on_the_base_branch():
     """Only pushing/PRing needs a branch — the commit itself is fine."""
     assert (
         ap.next_action(
-            _rec(depth="commit"), _snap(stage="committed", on_base_branch=True)
+            _rec(depth="commit", commits=1, step="commit"),
+            _snap(stage="committed", on_base_branch=True),
         )[0]
         == "done"
     )
@@ -622,46 +631,26 @@ def test_claiming_an_unknown_or_nameless_chain_is_refused():
 
 
 # --- A standing instruction, not a one-shot ----------------------------------
-def test_a_branch_that_already_has_a_pr_finishes_immediately():
-    """This is the situation that made fast-track feel impossible to keep on: the
-    stage already reads "pr", so the target is satisfied the moment you arm it."""
-    assert ap.next_action(_rec(depth="pr"), _snap(stage="pr"))[0] == "done"
+def test_a_branch_that_already_has_a_pr_stays_armed_and_waits():
+    """The situation that made fast-track feel impossible to keep on: the stage
+    already reads "pr", so the target is satisfied the moment you arm it. Finishing
+    there means the press accomplished nothing and the toggle switched itself back
+    off. A run that has not acted waits for work instead; it only finishes — and
+    turns itself off — once it has genuinely carried something."""
+    action, detail = ap.next_action(_rec(depth="pr"), _snap(stage="pr"))
+    assert action == "wait"
+    assert "waiting for new work" in detail["reason"]
 
 
-def test_rearm_starts_a_fresh_cycle_and_keeps_the_instruction():
-    ap.arm("s1", "pr", source="tix", item="sc-1", message="Fix the thing", now=1_000.0)
-    ap.update(
-        "s1", commits=3, step="pr", url="http://pr/1", skipped=["h"], issues={"push": 2}
-    )
+def test_a_finished_run_is_left_alone_rather_than_woken():
+    """A run that has had its go turns OFF for that window. The record stays so the
+    outcome is readable, but nothing resumes it behind your back — pressing the
+    button is how you start another."""
+    ap.arm("s1", "pr")
+    ap.update("s1", commits=1, step="pr")
     ap.finish("s1")
-
-    woken = ap.rearm("s1", now=2_000.0)
-    assert woken is not None
-    # Per-CYCLE state is cleared, so a new pass cannot inherit a spent budget.
-    assert woken["state"] == "running"
-    assert woken["step"] == "" and woken["commits"] == 0
-    assert woken["url"] == "" and woken["skipped"] == [] and woken["issues"] == {}
-    assert woken["idle_since"] is None and woken["worked_at"] == 0.0
-    assert woken["step_since"] == 2_000.0
-    # Per-INSTRUCTION state survives.
-    assert woken["depth"] == "pr" and woken["message"] == "Fix the thing"
-    assert woken["source"] == "tix" and woken["item"] == "sc-1"
-
-
-def test_rearm_refuses_a_halted_run():
-    """A halt means a human has to look. Quietly resuming would bury the reason —
-    pressing the button is how you say you have dealt with it."""
-    ap.arm("s1", "pr")
-    ap.halt("s1", "the branch has merge conflicts")
-    assert ap.rearm("s1") is None
-    assert ap.get("s1")["state"] == "halted"
-
-
-def test_rearm_refuses_a_still_running_run():
-    ap.arm("s1", "pr")
-    assert ap.rearm("s1") is None, "a live run must not be reset under itself"
-
-
-def test_rearm_of_an_unknown_chain_is_refused():
-    assert ap.rearm("nope") is None
-    assert ap.rearm("") is None
+    got = ap.get("s1")
+    assert got["state"] == "done"
+    # Inert: next_action refuses to do anything further with it.
+    assert ap.next_action(got, _snap(stage="agent", dirty=True))[0] == "done"
+    assert not hasattr(ap, "rearm"), "a finished run is not woken any more"

--- a/tests/unit/test_frontend_polish.py
+++ b/tests/unit/test_frontend_polish.py
@@ -237,3 +237,19 @@ def test_the_ingestion_dot_cannot_be_deformed_by_the_global_error_rule():
     )
     for decl in ("min-height: 0", "min-width: 0", "border-radius: 50%"):
         assert decl in dot, decl
+
+
+def test_a_booting_window_can_be_dragged():
+    """Provisioning is the LONGEST a window is ever in one state — a cold clone runs
+    for minutes — and it was the one state you could neither move nor drop onto, so
+    arranging the grid meant waiting it out. The drag is pure layout; it touches
+    nothing about the session."""
+    js = client.get("/app.js").text
+    # The loading pane renders the same grip affordance as every other pane.
+    assert "loading-pane" in js
+    # Both halves of the drag contract reach it: the header starts a drag, the
+    # section accepts a drop. Asserted via the rendered class + the shared handler
+    # names surviving into the bundle.
+    assert "Drag to move this window" in js
+    # A dragged loading pane dims like any other (the .dragging class is applied).
+    assert "pane loading-pane" in js


### PR DESCRIPTION
Two behaviour fixes.

## Fast-track turns off when its task ends

A run that has succeeded or failed no longer reads as armed — only a live run does.
The record stays, so the outcome and a halt's reason remain readable in the header,
and pressing the button starts another.

On its own that would have reintroduced the problem the standing-instruction change
was made to solve: a branch which already has an open PR satisfies a `pr` target the
*instant* you arm it, so the run finished having accomplished nothing and the toggle
switched straight back off.

The fix belongs at the other end. `reaches()` now only **finishes** a run that
actually carried the work (a commit or a step recorded). A run that has not acted
stays armed and waits, so "already at the target" and "job done" stop being the same
state — which is what conflated them before.

That removes the need to wake finished runs, so `rearm()` is gone: nothing resumes a
run behind your back. A run still waiting to be needed is charged against the
generous arm budget rather than the agent step's, since sitting idle on an
already-satisfied branch is not slow progress through a step.

## Booting windows drag

The loading pane rendered no grip and neither half of the drag contract, so the state
a window spends the **longest** in — a cold clone runs for minutes — was the only one
you could not move or drop onto. Arranging the grid meant waiting it out. It now
carries the same grip, handlers and `dragging` class as every other pane. Pure
layout; nothing about the session is touched.

## Testing

4036 backend (nothing deselected) + 247 frontend.

Incidentally: the venv had been carrying stale `0.1.12` install metadata, which is
what had `test_version_single_sourced_from_pyproject` failing locally all along.
`uv sync --group web --group dev` (how CI installs) fixed it, so the suite is now
genuinely clean with nothing skipped.