### PR TITLE
Release 0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14] - 2026-08-07
+
+### Fixed
+
+- **Fast-track switches itself off once its task ends.** A run that has succeeded
+  or failed no longer reads as armed, so the toggle tells you whether anything is
+  actually going to happen. The record is kept, so the outcome — and a halt's
+  reason — stays readable, and pressing the button starts another run.
+
+  Doing only that would have brought back the problem the run had been made to
+  survive: a branch which already has an open PR satisfies a "PR" target the
+  *instant* you arm it, so the run finished having accomplished nothing and the
+  toggle flipped straight back off. A run is now only **finished** once it has
+  actually carried the work — a commit or a step recorded — and one that has not
+  acted stays armed and waits. "Already at the target" and "the job is done" had
+  been the same state; separating them is what lets both behaviours hold at once.
+
+- **A booting window can be dragged.** Provisioning is the state a window spends
+  the longest in — a cold clone runs for minutes — and it was the only one that
+  rendered no grip and neither half of the drag contract, so it could be neither
+  moved nor dropped onto. Arranging the grid meant waiting it out.
+
 ## [0.1.13] - 2026-08-07
 
 ### Added
@@ -1112,7 +1134,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.13...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.14
 [0.1.13]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.13
 [0.1.12]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.12
 [0.1.11]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.11

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.13"
+version = "0.1.14"
 description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump across all four manifests plus `uv.lock` via `scripts/bump-version.py
patch`, and the CHANGELOG `[Unreleased]` section rolled into `[0.1.14]`.

Ships the two fixes merged in #51:

- **Fast-track switches itself off once its task ends** — a run that has succeeded
  or failed no longer reads as armed. A run is only *finished* once it has actually
  carried the work, so a branch that already has an open PR no longer satisfies the
  target the instant you arm it and switch straight back off.
- **A booting window can be dragged** — provisioning is the state a window spends
  the longest in, and it was the only one that could be neither moved nor dropped
  onto.

Cut as 0.1.14 rather than folded into 0.1.13: that tag was published 30 minutes ago
with 9 assets and `/latest` resolves to it, and the desktop installer filenames are
version-less permanent URLs — so re-cutting it would leave the same version number
carrying different bits for anyone who had already downloaded.

`scripts/bump-version.py --check` reports all manifests at 0.1.14. Suite green with
nothing deselected: 4036 backend, 247 frontend.

Merging this tags `v0.1.14`, which triggers the release build.