### PR TITLE
Add a dev-only Site traffic dashboard to Settings

### DIFF
--- a/backend/web/addons/__init__.py
+++ b/backend/web/addons/__init__.py
@@ -29,6 +29,7 @@ from .notify import NotifyAddon
 from .settings import SettingsAddon
 from .ticket_ingestion import TicketIngestionAddon
 from .templates import TemplatesAddon
+from .traffic import TrafficAddon
 
 __all__ = [
     "Addon",
@@ -51,6 +52,7 @@ def build_addons(ctx: AppContext) -> List[Addon]:
         ConnectionsAddon(ctx),
         TemplatesAddon(ctx),
         NotifyAddon(ctx),
+        TrafficAddon(ctx),
     ]
 
 

--- a/backend/web/addons/traffic.py
+++ b/backend/web/addons/traffic.py
@@ -1,0 +1,297 @@
+"""Traffic addon: MindFlock's own public reach, over HTTP.
+
+Exposes ``GET /api/traffic`` — GitHub stars/forks, per-release download counts,
+and per-day click counts for the tracked ``mindflock.ai/go/<slug>`` redirects
+(see the ``webpage/worker`` Cloudflare Worker in the marketing-site repo) — so
+the desktop app's dev-only Settings → Site traffic screen has one endpoint to
+poll instead of stitching three sources together in the browser.
+
+Every upstream call is best-effort: a GitHub rate limit or the click-tracking
+worker being unreachable degrades that ONE section (``errors.github`` /
+``errors.clicks``) rather than 500ing the whole payload — the two sections
+share nothing else, so there is no reason a click-tracking hiccup should hide
+stars the request already has.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from .base import Addon, AppContext, FrontendDescriptor
+
+#: The product's own repo — never the user's workspace. Every other GitHub
+#: integration in this codebase (github_pr.py, github_issues.py) resolves
+#: owner/repo from a workspace's git remote; this addon has no workspace, it
+#: always means MindFlock/MindFlock.
+_REPO = "MindFlock/MindFlock"
+_GITHUB_API = "https://api.github.com"
+_CLICKS_STATS_URL = "https://mindflock.ai/go/_stats"
+_HTTP_TIMEOUT_S = 15
+
+#: Cached payload lifetime. Longer than Doctor's 30s on purpose: this hits
+#: GitHub's REST API (60 req/hr unauthenticated, higher with a token) and an
+#: external Worker, neither of which needs to be re-asked every settings-panel
+#: open. ``?refresh=1`` bypasses it for a manual Refresh click.
+_CACHE_TTL_S = 300.0
+
+
+async def _token() -> str:
+    """A GitHub token if one is configured, else ``""`` — never raises.
+
+    Best-effort and read-only: unlike the PR/issue integrations this addon
+    never needs write scope, so a missing token just means unauthenticated
+    GitHub calls (60/hr, plenty for a screen nobody polls in a loop).
+    """
+    try:
+        from backend.config.secrets import resolve_secret_sync
+
+        return resolve_secret_sync(
+            settings_getter=lambda s: s.github.token,
+            env_vars=("GH_TOKEN", "GITHUB_TOKEN"),
+        ).strip()
+    except Exception:  # noqa: BLE001 — an unresolvable token is a normal state
+        return ""
+
+
+async def _get_json(url: str, *, token: str = "", accept: str = "") -> tuple[int, Any]:
+    """One GET -> ``(status, decoded_body)``; ``(0, error_string)`` when the
+    request never completed. Mirrors the seam in ``core/github_pr.py``, kept
+    separate because this addon calls two different hosts, not one API.
+
+    ``accept`` overrides the default GitHub media type — needed for the
+    stargazers endpoint, which only includes each star's timestamp under the
+    ``application/vnd.github.star+json`` media type.
+    """
+    import aiohttp
+
+    if accept:
+        headers = {"Accept": accept}
+    elif "github.com" in url:
+        headers = {"Accept": "application/vnd.github+json"}
+    else:
+        headers = {}
+    if token:
+        headers["Authorization"] = "Bearer {}".format(token)
+    try:
+        timeout = aiohttp.ClientTimeout(total=_HTTP_TIMEOUT_S)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers=headers) as resp:
+                try:
+                    data = await resp.json(content_type=None)
+                except Exception:  # noqa: BLE001 — non-JSON error page
+                    data = await resp.text()
+                return resp.status, data
+    except Exception as err:  # noqa: BLE001 — network faults are routine here
+        return 0, str(err)
+
+
+async def _fetch_repo(token: str) -> tuple[Optional[dict], str]:
+    status, data = await _get_json(
+        "{}/repos/{}".format(_GITHUB_API, _REPO), token=token
+    )
+    if status == 200 and isinstance(data, dict):
+        return {
+            "stars": data.get("stargazers_count"),
+            "forks": data.get("forks_count"),
+            "open_issues": data.get("open_issues_count"),
+            "url": data.get("html_url") or "https://github.com/" + _REPO,
+        }, ""
+    msg = data.get("message") if isinstance(data, dict) else str(data)
+    return None, "GitHub repo lookup failed ({}): {}".format(status, msg)
+
+
+async def _fetch_releases(token: str) -> tuple[list, int, str]:
+    """Per-release asset download counts, newest first, plus the all-time sum.
+
+    One page of up to 100 covers every release this project has cut so far
+    with room to spare; if that ever stops being true, download counts merely
+    stop at the 100th-newest release rather than the endpoint breaking.
+    """
+    status, data = await _get_json(
+        "{}/repos/{}/releases?per_page=100".format(_GITHUB_API, _REPO), token=token
+    )
+    if status != 200 or not isinstance(data, list):
+        msg = data.get("message") if isinstance(data, dict) else str(data)
+        return [], 0, "GitHub releases lookup failed ({}): {}".format(status, msg)
+
+    releases = []
+    total = 0
+    for rel in data:
+        if not isinstance(rel, dict):
+            continue
+        assets = []
+        rel_total = 0
+        for a in rel.get("assets") or []:
+            if not isinstance(a, dict):
+                continue
+            n = int(a.get("download_count") or 0)
+            assets.append({"name": a.get("name"), "downloads": n})
+            rel_total += n
+        releases.append(
+            {
+                "tag": rel.get("tag_name"),
+                "published_at": rel.get("published_at"),
+                "prerelease": bool(rel.get("prerelease")),
+                "assets": assets,
+                "total_downloads": rel_total,
+            }
+        )
+        total += rel_total
+    return releases, total, ""
+
+
+#: Bounds the stargazers pagination below. 30 pages * 100/page = 3,000 stars
+#: of history — comfortably past what this project has today, and a request
+#: nobody is waiting on synchronously (the whole payload is cached 5 minutes).
+_STAR_HISTORY_MAX_PAGES = 30
+
+
+async def _fetch_star_history(token: str) -> tuple[list, str]:
+    """Cumulative GitHub stars by day, oldest first.
+
+    The plain repo endpoint only has the CURRENT star count — no history. The
+    stargazers endpoint has per-star timestamps, but only under the
+    ``application/vnd.github.star+json`` media type (the default media type
+    drops ``starred_at`` entirely). Each stargazer is one +1 event; grouping
+    those by day and running a cumulative sum reconstructs the growth curve
+    the same way star-history-style tools do.
+    """
+    accept = "application/vnd.github.star+json"
+    by_day: dict[str, int] = {}
+    for page in range(1, _STAR_HISTORY_MAX_PAGES + 1):
+        status, data = await _get_json(
+            "{}/repos/{}/stargazers?per_page=100&page={}".format(
+                _GITHUB_API, _REPO, page
+            ),
+            token=token,
+            accept=accept,
+        )
+        if status != 200 or not isinstance(data, list):
+            if page == 1:
+                msg = data.get("message") if isinstance(data, dict) else str(data)
+                return [], "GitHub star history lookup failed ({}): {}".format(
+                    status, msg
+                )
+            break  # a later page failing still leaves an honest partial history
+        if not data:
+            break
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            starred_at = str(entry.get("starred_at") or "")
+            if len(starred_at) < 10:
+                continue
+            day = starred_at[:10]  # "2026-08-10T12:34:56Z" -> "2026-08-10"
+            by_day[day] = by_day.get(day, 0) + 1
+        if len(data) < 100:
+            break  # last page
+
+    if not by_day:
+        return [], ""
+
+    running = 0
+    history = []
+    for day in sorted(by_day):
+        running += by_day[day]
+        history.append({"day": day, "stars": running})
+    return history, ""
+
+
+async def _fetch_clicks(days: int) -> dict:
+    status, data = await _get_json("{}?days={}".format(_CLICKS_STATS_URL, days))
+    if status != 200 or not isinstance(data, dict):
+        detail = data.get("error") if isinstance(data, dict) else data
+        return {
+            "days": days,
+            "series": [],
+            "totals_by_slug": {},
+            "error": str(detail or status),
+        }
+
+    series = data.get("series") or []
+    totals: dict[str, int] = {}
+    for row in series:
+        if not isinstance(row, dict):
+            continue
+        slug = str(row.get("slug") or "")
+        totals[slug] = totals.get(slug, 0) + int(row.get("clicks") or 0)
+    return {"days": days, "series": series, "totals_by_slug": totals, "error": ""}
+
+
+class TrafficAddon(Addon):
+    id = "traffic"
+    label = "Site traffic"
+
+    def __init__(self, ctx: Optional[AppContext] = None) -> None:
+        super().__init__(ctx)
+        self._cache: Optional[dict] = None
+        self._cached_at: float = 0.0
+        self._router = self._build_router()
+
+    async def _payload(self, *, days: int, refresh: bool) -> dict:
+        now = time.monotonic()
+        if (
+            not refresh
+            and self._cache is not None
+            and self._cache.get("_days") == days
+            and now - self._cached_at < _CACHE_TTL_S
+        ):
+            return self._cache
+
+        token = await _token()
+        repo, repo_err = await _fetch_repo(token)
+        releases, downloads_total, releases_err = await _fetch_releases(token)
+        star_history, star_history_err = await _fetch_star_history(token)
+        clicks = await _fetch_clicks(days)
+
+        github_err = repo_err or releases_err or star_history_err
+        payload = {
+            "generated": time.time(),
+            "repo": repo,
+            "star_history": star_history,
+            "releases": releases,
+            "downloads_total": downloads_total,
+            "clicks": clicks,
+            "errors": {
+                "github": github_err or None,
+                "clicks": clicks.get("error") or None,
+            },
+            "_days": days,
+        }
+        self._cache = payload
+        self._cached_at = now
+        return payload
+
+    def _build_router(self) -> APIRouter:
+        router = APIRouter(prefix="/api")
+
+        @router.get("/traffic")
+        async def get_traffic(days: int = 90, refresh: bool = False) -> JSONResponse:
+            days = max(1, min(90, days))
+            payload = await self._payload(days=days, refresh=refresh)
+            return JSONResponse({k: v for k, v in payload.items() if k != "_days"})
+
+        return router
+
+    @property
+    def router(self) -> APIRouter:
+        return self._router
+
+    def frontend(self):
+        return [
+            FrontendDescriptor(
+                id="traffic",
+                label="Site traffic",
+                where="settings",
+                module=None,
+                api_base="/api/traffic",
+                order=95,
+                # Hand-wired into the settings dialog (dev-shell gated), same
+                # as Doctor — the generic slot renderer skips "settings".
+                builtin_ui=True,
+            )
+        ]

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -21559,6 +21559,24 @@ function useUsage(enabled = true) {
 function refreshInstances() {
   return queryClient.invalidateQueries({ queryKey: ["instances"] });
 }
+function useTraffic(enabled, days = 90) {
+  return useQuery({
+    queryKey: ["traffic", days],
+    queryFn: () => api("/api/traffic?days=" + days),
+    enabled,
+    staleTime: 6e4,
+    placeholderData: (prev) => prev,
+    retry: false
+  });
+}
+function refreshTraffic(days = 90) {
+  return queryClient.fetchQuery({
+    queryKey: ["traffic", days],
+    queryFn: () => api("/api/traffic?days=" + days + "&refresh=1"),
+    staleTime: 0,
+    retry: false
+  });
+}
 function patchInstance(title, patch) {
   queryClient.setQueryData(
     ["instances"],
@@ -24423,6 +24441,10 @@ async function isFullScreen() {
 function bridge() {
   if (typeof window === "undefined") return void 0;
   return window.mfshell;
+}
+function isDevShell() {
+  var _a2;
+  return ((_a2 = bridge()) == null ? void 0 : _a2.dev) === true;
 }
 function hasNativeWindowControls() {
   var _a2;
@@ -33838,6 +33860,361 @@ function UninstallSection() {
     }, children: isWindows ? "Open Windows uninstall…" : "Uninstall MindFlock…" })
   ] });
 }
+const DAYS_OPTIONS = [30, 90];
+const SLUG_LABEL = {
+  mac: "macOS download",
+  windows: "Windows download",
+  linux: "Linux download",
+  github: "GitHub",
+  releases: "Releases page",
+  latest: "Latest release",
+  producthunt: "Product Hunt",
+  nxgn: "NxGn Tools"
+};
+function slugLabel(slug) {
+  return SLUG_LABEL[slug] || slug;
+}
+function fmtInt(n) {
+  if (n == null) return "—";
+  return n.toLocaleString();
+}
+function fmtDate(iso) {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleDateString(void 0, { year: "numeric", month: "short", day: "numeric" });
+  } catch {
+    return iso;
+  }
+}
+function dailyTotals(series) {
+  const byDay = /* @__PURE__ */ new Map();
+  for (const row of series) {
+    let bucket = byDay.get(row.day);
+    if (!bucket) {
+      bucket = { day: row.day, total: 0, bySlug: {} };
+      byDay.set(row.day, bucket);
+    }
+    bucket.total += row.clicks;
+    bucket.bySlug[row.slug] = (bucket.bySlug[row.slug] || 0) + row.clicks;
+  }
+  return Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day));
+}
+function StarsChart({ points }) {
+  const [hoverIdx, setHoverIdx] = reactExports.useState(null);
+  if (points.length === 0) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No star history available — the stargazers API requires a GitHub token (Settings → Connections). The current total above still works without one." });
+  }
+  if (points.length === 1) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Only one day of star history so far — check back once there's a trend." });
+  }
+  const w = 640;
+  const h = 160;
+  const padL = 4;
+  const padB = 18;
+  const plotH = h - padB;
+  const max = Math.max(1, ...points.map((p) => p.stars));
+  const stepX = (w - padL) / (points.length - 1);
+  const xAt = (i) => padL + i * stepX;
+  const yAt = (v) => plotH - v / max * (plotH - 8);
+  const pathD = points.map((p, i) => `${i === 0 ? "M" : "L"}${xAt(i).toFixed(2)},${yAt(p.stars).toFixed(2)}`).join(" ");
+  const handleMove = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const relX = (e.clientX - rect.left) / rect.width * w;
+    const idx = Math.max(0, Math.min(points.length - 1, Math.round((relX - padL) / stepX)));
+    setHoverIdx(idx);
+  };
+  const hovered = hoverIdx != null ? points[hoverIdx] : null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-wrap", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "svg",
+      {
+        className: "traffic-chart",
+        viewBox: `0 0 ${w} ${h}`,
+        preserveAspectRatio: "none",
+        role: "img",
+        "aria-label": `Cumulative GitHub stars, ${fmtDate(points[0].day)} through ${fmtDate(points[points.length - 1].day)}`,
+        onMouseMove: handleMove,
+        onMouseLeave: () => setHoverIdx(null),
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: pathD, className: "traffic-line", fill: "none" }),
+          hoverIdx != null && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: xAt(hoverIdx), y1: 0, x2: xAt(hoverIdx), y2: plotH, className: "traffic-crosshair" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("circle", { cx: xAt(hoverIdx), cy: yAt(points[hoverIdx].stars), r: 4, className: "traffic-line-dot" })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: plotH, x2: w, y2: plotH, className: "traffic-baseline" })
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(points[0].day) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(points[points.length - 1].day) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-tooltip", "aria-live": "polite", children: hovered ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: fmtDate(hovered.day) }),
+      " — ",
+      fmtInt(hovered.stars),
+      " star",
+      hovered.stars === 1 ? "" : "s"
+    ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Hover the line for the star count on that date." }) })
+  ] });
+}
+function releasesChronological(releases) {
+  return releases.filter((r) => r.published_at).slice().sort((a, b) => a.published_at < b.published_at ? -1 : a.published_at > b.published_at ? 1 : 0);
+}
+function ReleasesChart({ releases }) {
+  const chrono = reactExports.useMemo(() => releasesChronological(releases), [releases]);
+  const [hover, setHover] = reactExports.useState(null);
+  if (!chrono.length) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No published releases yet." });
+  }
+  const max = Math.max(1, ...chrono.map((r) => r.total_downloads));
+  const w = 640;
+  const h = 160;
+  const padL = 4;
+  const padB = 18;
+  const plotH = h - padB;
+  const barGap = 3;
+  const barW = Math.max(1, (w - padL) / chrono.length - barGap);
+  const hovered = hover != null ? chrono[hover] : null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-wrap", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "svg",
+      {
+        className: "traffic-chart",
+        viewBox: `0 0 ${w} ${h}`,
+        preserveAspectRatio: "none",
+        role: "img",
+        "aria-label": `Downloads per release, ${chrono[0].tag} through ${chrono[chrono.length - 1].tag}`,
+        onMouseLeave: () => setHover(null),
+        children: [
+          chrono.map((r, i) => {
+            const barH = Math.max(1, r.total_downloads / max * (plotH - 8));
+            const x = padL + i * (barW + barGap);
+            const y = plotH - barH;
+            return /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "rect",
+              {
+                x,
+                y,
+                width: barW,
+                height: barH,
+                rx: Math.min(3, barW / 2),
+                className: "traffic-bar" + (hover === i ? " hover" : ""),
+                onMouseEnter: () => setHover(i)
+              },
+              r.tag
+            );
+          }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: plotH, x2: w, y2: plotH, className: "traffic-baseline" })
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(chrono[0].published_at) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(chrono[chrono.length - 1].published_at) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-tooltip", "aria-live": "polite", children: hovered ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: hovered.tag }),
+      " (",
+      fmtDate(hovered.published_at),
+      ") —",
+      " ",
+      fmtInt(hovered.total_downloads),
+      " download",
+      hovered.total_downloads === 1 ? "" : "s",
+      hovered.assets.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tooltip-detail", children: [
+        " ",
+        "(",
+        hovered.assets.filter((a) => a.downloads > 0).sort((a, b) => b.downloads - a.downloads).map((a) => `${a.name}: ${a.downloads}`).join(", ") || "no downloads yet",
+        ")"
+      ] })
+    ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Hover a bar for that release's per-asset breakdown." }) })
+  ] });
+}
+function ClicksChart({ series }) {
+  const days = reactExports.useMemo(() => dailyTotals(series), [series]);
+  const [hover, setHover] = reactExports.useState(null);
+  if (!days.length) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No clicks recorded in this window yet." });
+  }
+  const max = Math.max(1, ...days.map((d) => d.total));
+  const w = 640;
+  const h = 160;
+  const padL = 4;
+  const padB = 18;
+  const plotH = h - padB;
+  const barGap = 2;
+  const barW = Math.max(1, (w - padL) / days.length - barGap);
+  const hovered = hover != null ? days[hover] : null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-wrap", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "svg",
+      {
+        className: "traffic-chart",
+        viewBox: `0 0 ${w} ${h}`,
+        preserveAspectRatio: "none",
+        role: "img",
+        "aria-label": `Daily clicks across all tracked links, ${days[0].day} through ${days[days.length - 1].day}`,
+        onMouseLeave: () => setHover(null),
+        children: [
+          days.map((d, i) => {
+            const barH = Math.max(1, d.total / max * (plotH - 8));
+            const x = padL + i * (barW + barGap);
+            const y = plotH - barH;
+            return /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "rect",
+              {
+                x,
+                y,
+                width: barW,
+                height: barH,
+                rx: Math.min(3, barW / 2),
+                className: "traffic-bar" + (hover === i ? " hover" : ""),
+                onMouseEnter: () => setHover(i)
+              },
+              d.day
+            );
+          }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: plotH, x2: w, y2: plotH, className: "traffic-baseline" })
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[0].day) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[days.length - 1].day) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-tooltip", "aria-live": "polite", children: hovered ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: fmtDate(hovered.day) }),
+      " — ",
+      fmtInt(hovered.total),
+      " click",
+      hovered.total === 1 ? "" : "s",
+      Object.keys(hovered.bySlug).length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tooltip-detail", children: [
+        " ",
+        "(",
+        Object.entries(hovered.bySlug).sort((a, b) => b[1] - a[1]).map(([slug, n]) => `${slugLabel(slug)}: ${n}`).join(", "),
+        ")"
+      ] })
+    ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Hover a bar for that day's breakdown." }) })
+  ] });
+}
+function Traffic(_) {
+  var _a2, _b2;
+  const [days, setDays] = reactExports.useState(90);
+  const [refreshing, setRefreshing] = reactExports.useState(false);
+  const q = useTraffic(true, days);
+  const data = q.data;
+  const clickTotalsSorted = reactExports.useMemo(() => {
+    if (!data) return [];
+    return Object.entries(data.clicks.totals_by_slug).sort((a, b) => b[1] - a[1]);
+  }, [data]);
+  const doRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await refreshTraffic(days);
+      await q.refetch();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Site traffic" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Reach across mindflock.ai and the GitHub repo — pulled live from GitHub's API and the click-tracking Worker on mindflock.ai/go/*. Visible in this dev build only." }),
+    q.isLoading && !data && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Loading…" }),
+    q.isError && !data && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Could not load traffic data. Check your connection and retry." }),
+    data && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      (data.errors.github || data.errors.clicks) && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-warn", children: [
+        data.errors.github && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          "GitHub: ",
+          data.errors.github
+        ] }),
+        data.errors.clicks && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          "Click tracking: ",
+          data.errors.clicks
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tiles", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt((_a2 = data.repo) == null ? void 0 : _a2.stars) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-label", children: "GitHub stars" })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt((_b2 = data.repo) == null ? void 0 : _b2.forks) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-label", children: "Forks" })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt(data.downloads_total) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-label", children: "Total downloads (all releases)" })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt(clickTotalsSorted.reduce((s, [, n]) => s + n, 0)) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tile-label", children: [
+            "Tracked link clicks (",
+            data.clicks.days,
+            "d)"
+          ] })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "GitHub stars over time" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(StarsChart, { points: data.star_history ?? [] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row traffic-range-row", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "usage-periods traffic-range", children: DAYS_OPTIONS.map((d) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            type: "button",
+            className: "usage-period" + (days === d ? " active" : ""),
+            onClick: () => setDays(d),
+            children: [
+              d,
+              "d"
+            ]
+          },
+          d
+        )) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "test-row", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className: "test-btn", onClick: doRefresh, disabled: refreshing, children: refreshing ? "Refreshing…" : "Refresh" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Cached ~5 min server-side to stay under GitHub's rate limit — this bypasses it." })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ClicksChart, { series: data.clicks.series }),
+      clickTotalsSorted.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "set-section-title", children: [
+          "Clicks by link (",
+          data.clicks.days,
+          "d)"
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "traffic-table", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("th", { children: "Link" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "Clicks" })
+          ] }) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: clickTotalsSorted.map(([slug, n]) => /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { children: slugLabel(slug) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt(n) })
+          ] }, slug)) })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Downloads over time" }),
+      data.releases.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No releases found." }) : /* @__PURE__ */ jsxRuntimeExports.jsx(ReleasesChart, { releases: data.releases }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Downloads by version" }),
+      data.releases.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No releases found." }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "traffic-table", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { children: "Version" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { children: "Published" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "Downloads" })
+        ] }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: data.releases.map((r) => /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("td", { children: [
+            r.tag,
+            r.prerelease && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-pre", children: " pre-release" })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("td", { children: fmtDate(r.published_at) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt(r.total_downloads) })
+        ] }, r.tag)) })
+      ] })
+    ] })
+  ] });
+}
 const SCREENS = [
   { key: "general", label: "General", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(General, { ...p }) },
   { key: "connections", label: "Connections", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(Connections, { ...p }) },
@@ -33852,7 +34229,11 @@ const SCREENS = [
   { key: "mobile", label: "Mobile", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(Mobile, { ...p }) },
   { key: "doctor", label: "Doctor", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(Doctor, { ...p }) },
   { key: "logs", label: "System logs", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(SystemLogs, { ...p }) },
-  { key: "advanced", label: "Advanced", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(Advanced, { ...p }) }
+  { key: "advanced", label: "Advanced", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(Advanced, { ...p }) },
+  // Maintainer-only: MindFlock's own reach (stars, downloads, tracked-link
+  // clicks), not something an end user's build needs — filtered out below
+  // unless this is a --mindflock-dev shell.
+  { key: "traffic", label: "Site traffic", el: (p) => /* @__PURE__ */ jsxRuntimeExports.jsx(Traffic, { ...p }) }
 ];
 function SettingsDialog({ onOpenSysLogsPane }) {
   const open = useUi((s) => s.openDialog === "settings");
@@ -33861,10 +34242,11 @@ function SettingsDialog({ onOpenSysLogsPane }) {
   const [screen, setScreen] = reactExports.useState("general");
   const model = useSettingsModel(open);
   const openDialogFor = useUi((s) => s.openDialogFor);
+  const screens = reactExports.useMemo(() => SCREENS.filter((s) => s.key !== "traffic" || isDevShell()), []);
   const gotoScreen = (name) => {
     const tab = LEGACY_SCREEN_TABS[name];
     if (tab) openDialogFor("intake", tab);
-    else setScreen(SCREENS.some((s) => s.key === name) ? name : "general");
+    else setScreen(screens.some((s) => s.key === name) ? name : "general");
   };
   reactExports.useEffect(() => {
     if (!open) return;
@@ -33873,8 +34255,8 @@ function SettingsDialog({ onOpenSysLogsPane }) {
       openDialogFor("intake", tab);
       return;
     }
-    setScreen(target && SCREENS.some((s) => s.key === target) ? target : "general");
-  }, [open, target, openDialogFor]);
+    setScreen(target && screens.some((s) => s.key === target) ? target : "general");
+  }, [open, target, openDialogFor, screens]);
   reactExports.useEffect(() => {
     if (!open) return;
     const onKey = (e) => {
@@ -33909,7 +34291,7 @@ function SettingsDialog({ onOpenSysLogsPane }) {
           /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "settings-close", onClick: closeDialog, children: "Close" })
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "settings-body", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("nav", { id: "settings-nav", "aria-label": "Settings sections", children: SCREENS.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          /* @__PURE__ */ jsxRuntimeExports.jsx("nav", { id: "settings-nav", "aria-label": "Settings sections", children: screens.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsx(
             "button",
             {
               type: "button",
@@ -33920,7 +34302,7 @@ function SettingsDialog({ onOpenSysLogsPane }) {
             },
             s.key
           )) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "settings-screens", children: SCREENS.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "settings-screens", children: screens.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsx(
             "section",
             {
               className: "set-screen" + (screen === s.key ? " active" : ""),

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -8708,7 +8708,176 @@ body.no-ticketing .ik-panel[data-caps-need~="ticketing"]>.caps-gate[data-caps-ga
 .surface-swatch .sw-dot {
   border-radius: 5px;
 }
-} /* 280 */ @layer theme{
+} /* 280 */ @layer components{
+
+/* Settings → Site traffic (dev shell only). Stat tiles, a single-hue click
+   chart, and two data tables — no chart library, consistent with the rest of
+   the app's hand-rolled, zero-dep components. */
+
+.traffic-warn {
+  border: 1px solid var(--red);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--red);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.traffic-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.traffic-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--panel, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.traffic-tile-num {
+  font-size: 20px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.traffic-tile-label {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.traffic-range-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.traffic-range {
+  width: auto;
+  min-width: 110px;
+}
+
+.traffic-chart-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.traffic-chart {
+  width: 100%;
+  height: 160px;
+  display: block;
+}
+
+/* Sequential magnitude-over-time, one series — the app's single accent hue is
+   the correct encoding (see dataviz skill: categorical color is for identity,
+   not a lone metric). Per-link identity lives in the table below instead. */
+.traffic-bar {
+  fill: var(--accent);
+  opacity: 0.72;
+  transition: opacity 0.1s;
+}
+
+.traffic-bar.hover {
+  opacity: 1;
+}
+
+.traffic-baseline {
+  stroke: var(--border);
+  stroke-width: 1;
+}
+
+/* Cumulative stars line (StarsChart) — thin 2px stroke, single accent hue
+   (one series, magnitude-over-time — same "no categorical palette needed"
+   reasoning as the bar charts). Crosshair + dot track the pointer since a
+   line has no discrete mark to hover per-datapoint. */
+.traffic-line {
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-crosshair {
+  stroke: var(--border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-line-dot {
+  fill: var(--accent);
+  stroke: var(--panel, var(--bg));
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-chart-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.traffic-tooltip {
+  min-height: 18px;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.traffic-tooltip-detail {
+  color: var(--muted);
+}
+
+.traffic-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.traffic-table th {
+  text-align: left;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  padding: 4px 8px 6px 0;
+}
+
+.traffic-table td {
+  padding: 5px 8px 5px 0;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.traffic-table th.num,
+.traffic-table td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding-right: 0;
+}
+
+.traffic-pre {
+  font-size: 10px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  margin-left: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+} /* 290 */ @layer theme{
 /* ---------------------------------------------------------------------------
  * Region hues — the one file that knows how a multi-color theme set reaches
  * the pixels.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -124,6 +124,13 @@ export interface Instance {
   activity: Activity | string;
   activity_since: number;
   last_turn: string | null;
+  /** First line of the newest USER prompt (≤120 chars) — pinned above the
+   * agent terminal so you always see what the session was asked to do.
+   * Optional: an older server doesn't send it. */
+  last_prompt?: string | null;
+  /** The same prompt's whole body (capped ~4000 chars) — the pin's
+   * hover/click expansion. */
+  last_prompt_full?: string | null;
   setup: SetupSummary | null;
   check: SetupSummary | null;
   ports: { base: number; count: number } | null;
@@ -224,3 +231,47 @@ export interface DoctorCheck {
 }
 
 export type Json = Record<string, unknown>;
+
+/** GET /api/traffic (backend/web/addons/traffic.py) — GitHub stars/forks,
+ * per-release download counts, and click totals for the mindflock.ai/go/
+ * tracked links. `errors.*` is set when that ONE section's upstream failed;
+ * the rest of the payload still renders. */
+export interface TrafficReleaseAsset {
+  name: string;
+  downloads: number;
+}
+
+export interface TrafficStarPoint {
+  day: string;
+  stars: number;
+}
+
+export interface TrafficRelease {
+  tag: string;
+  published_at: string | null;
+  prerelease: boolean;
+  assets: TrafficReleaseAsset[];
+  total_downloads: number;
+}
+
+export interface TrafficClickRow {
+  day: string;
+  slug: string;
+  os: string;
+  clicks: number;
+}
+
+export interface TrafficResponse {
+  generated: number;
+  repo: { stars: number | null; forks: number | null; open_issues: number | null; url: string } | null;
+  star_history: TrafficStarPoint[];
+  releases: TrafficRelease[];
+  downloads_total: number;
+  clicks: {
+    days: number;
+    series: TrafficClickRow[];
+    totals_by_slug: Record<string, number>;
+    error: string;
+  };
+  errors: { github: string | null; clicks: string | null };
+}

--- a/frontend/src/components/settings/SettingsDialog.tsx
+++ b/frontend/src/components/settings/SettingsDialog.tsx
@@ -8,10 +8,11 @@
  * "issues")` opens Intake on the matching tab instead of a blank pane, which
  * matters because the server hands those keys back on Connections cards. */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useUi } from "../../state/store";
 import { SettingsCtx, useSettingsModel } from "./useSettings";
 import { LEGACY_SCREEN_TABS } from "../intake/IntakeDialog";
+import { isDevShell } from "../../lib/shell";
 import { General } from "./screens/General";
 import { Appearance } from "./screens/Appearance";
 import { Mobile } from "./screens/Mobile";
@@ -26,6 +27,7 @@ import { Security } from "./screens/Security";
 import { Doctor } from "./screens/Doctor";
 import { SystemLogs } from "./screens/SystemLogs";
 import { Advanced } from "./screens/Advanced";
+import { Traffic } from "./screens/Traffic";
 
 export interface ScreenProps {
   active: boolean;
@@ -50,6 +52,10 @@ const SCREENS: Array<{ key: string; label: string; el: (p: ScreenProps) => React
   { key: "doctor", label: "Doctor", el: (p) => <Doctor {...p} /> },
   { key: "logs", label: "System logs", el: (p) => <SystemLogs {...p} /> },
   { key: "advanced", label: "Advanced", el: (p) => <Advanced {...p} /> },
+  // Maintainer-only: MindFlock's own reach (stars, downloads, tracked-link
+  // clicks), not something an end user's build needs — filtered out below
+  // unless this is a --mindflock-dev shell.
+  { key: "traffic", label: "Site traffic", el: (p) => <Traffic {...p} /> },
 ];
 
 export function SettingsDialog({ onOpenSysLogsPane }: { onOpenSysLogsPane?: () => void }) {
@@ -59,6 +65,9 @@ export function SettingsDialog({ onOpenSysLogsPane }: { onOpenSysLogsPane?: () =
   const [screen, setScreen] = useState("general");
   const model = useSettingsModel(open);
   const openDialogFor = useUi((s) => s.openDialogFor);
+  // Site traffic is MindFlock's own maintainer dashboard — hidden from nav,
+  // deep-link and fallback resolution alike unless this is a dev-shell build.
+  const screens = useMemo(() => SCREENS.filter((s) => s.key !== "traffic" || isDevShell()), []);
 
   // A retired screen key hands off to Intake rather than selecting nothing (which
   // rendered a blank right-hand pane, since .set-screen.active would match no
@@ -66,7 +75,7 @@ export function SettingsDialog({ onOpenSysLogsPane }: { onOpenSysLogsPane?: () =
   const gotoScreen = (name: string) => {
     const tab = LEGACY_SCREEN_TABS[name];
     if (tab) openDialogFor("intake", tab);
-    else setScreen(SCREENS.some((s) => s.key === name) ? name : "general");
+    else setScreen(screens.some((s) => s.key === name) ? name : "general");
   };
 
   useEffect(() => {
@@ -77,8 +86,8 @@ export function SettingsDialog({ onOpenSysLogsPane }: { onOpenSysLogsPane?: () =
       openDialogFor("intake", tab);
       return;
     }
-    setScreen(target && SCREENS.some((s) => s.key === target) ? target : "general");
-  }, [open, target, openDialogFor]);
+    setScreen(target && screens.some((s) => s.key === target) ? target : "general");
+  }, [open, target, openDialogFor, screens]);
 
   useEffect(() => {
     if (!open) return;
@@ -121,7 +130,7 @@ export function SettingsDialog({ onOpenSysLogsPane }: { onOpenSysLogsPane?: () =
           </div>
           <div id="settings-body">
             <nav id="settings-nav" aria-label="Settings sections">
-              {SCREENS.map((s) => (
+              {screens.map((s) => (
                 <button
                   key={s.key}
                   type="button"
@@ -134,7 +143,7 @@ export function SettingsDialog({ onOpenSysLogsPane }: { onOpenSysLogsPane?: () =
               ))}
             </nav>
             <div id="settings-screens">
-              {SCREENS.map((s) => (
+              {screens.map((s) => (
                 <section
                   key={s.key}
                   className={"set-screen" + (screen === s.key ? " active" : "")}

--- a/frontend/src/components/settings/screens/Traffic.tsx
+++ b/frontend/src/components/settings/screens/Traffic.tsx
@@ -1,0 +1,464 @@
+/** Settings → Site traffic (dev shell only): GitHub stars/forks, per-release
+ * download counts, and click totals for the mindflock.ai/go/ tracked links
+ * (macOS/Windows/Linux buttons, GitHub, Product Hunt, NxGn — see the Worker in
+ * the webpage repo's worker/ directory). This is the maintainer's own reach
+ * dashboard, not something an end user's build needs, hence the dev-shell
+ * gate in SettingsDialog.tsx via isDevShell(). */
+
+import { useMemo, useState } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { refreshTraffic, useTraffic } from "../../../state/queries";
+import type { TrafficClickRow, TrafficRelease, TrafficStarPoint } from "../../../api/types";
+import type { ScreenProps } from "../SettingsDialog";
+
+const DAYS_OPTIONS = [30, 90] as const;
+
+const SLUG_LABEL: Record<string, string> = {
+  mac: "macOS download",
+  windows: "Windows download",
+  linux: "Linux download",
+  github: "GitHub",
+  releases: "Releases page",
+  latest: "Latest release",
+  producthunt: "Product Hunt",
+  nxgn: "NxGn Tools",
+};
+
+function slugLabel(slug: string): string {
+  return SLUG_LABEL[slug] || slug;
+}
+
+function fmtInt(n: number | null | undefined): string {
+  if (n == null) return "—";
+  return n.toLocaleString();
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  } catch {
+    return iso;
+  }
+}
+
+/** Collapse the flat (day, slug) rows into one totals-per-day series for the
+ * bar chart — a single magnitude over time, so one hue (--accent) is the
+ * correct encoding; per-slug identity lives in the table below instead of a
+ * categorical palette this design system doesn't otherwise have. */
+function dailyTotals(series: TrafficClickRow[]): Array<{ day: string; total: number; bySlug: Record<string, number> }> {
+  const byDay = new Map<string, { day: string; total: number; bySlug: Record<string, number> }>();
+  for (const row of series) {
+    let bucket = byDay.get(row.day);
+    if (!bucket) {
+      bucket = { day: row.day, total: 0, bySlug: {} };
+      byDay.set(row.day, bucket);
+    }
+    bucket.total += row.clicks;
+    bucket.bySlug[row.slug] = (bucket.bySlug[row.slug] || 0) + row.clicks;
+  }
+  return Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day));
+}
+
+/** Cumulative GitHub stars over time — the one line chart on this screen,
+ * next to the bar charts for clicks and downloads. A running total is
+ * naturally a line (it only goes up), whereas per-day clicks and per-release
+ * downloads are discrete counts better read as bars — so the mark follows
+ * the data's shape rather than matching the neighboring charts for
+ * consistency's own sake. Tracks the pointer continuously (a crosshair)
+ * instead of the bar charts' per-bar hover, since there's no discrete mark to
+ * land on between points. */
+function StarsChart({ points }: { points: TrafficStarPoint[] }) {
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  if (points.length === 0) {
+    return (
+      <p className="set-hint">
+        No star history available — the stargazers API requires a GitHub token (Settings →
+        Connections). The current total above still works without one.
+      </p>
+    );
+  }
+  if (points.length === 1) {
+    return <p className="set-hint">Only one day of star history so far — check back once there's a trend.</p>;
+  }
+
+  const w = 640;
+  const h = 160;
+  const padL = 4;
+  const padB = 18;
+  const plotH = h - padB;
+  const max = Math.max(1, ...points.map((p) => p.stars));
+  const stepX = (w - padL) / (points.length - 1);
+  const xAt = (i: number) => padL + i * stepX;
+  const yAt = (v: number) => plotH - (v / max) * (plotH - 8);
+  const pathD = points.map((p, i) => `${i === 0 ? "M" : "L"}${xAt(i).toFixed(2)},${yAt(p.stars).toFixed(2)}`).join(" ");
+
+  const handleMove = (e: ReactMouseEvent<SVGSVGElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const relX = ((e.clientX - rect.left) / rect.width) * w;
+    const idx = Math.max(0, Math.min(points.length - 1, Math.round((relX - padL) / stepX)));
+    setHoverIdx(idx);
+  };
+
+  const hovered = hoverIdx != null ? points[hoverIdx] : null;
+
+  return (
+    <div className="traffic-chart-wrap">
+      <svg
+        className="traffic-chart"
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`Cumulative GitHub stars, ${fmtDate(points[0].day)} through ${fmtDate(points[points.length - 1].day)}`}
+        onMouseMove={handleMove}
+        onMouseLeave={() => setHoverIdx(null)}
+      >
+        <path d={pathD} className="traffic-line" fill="none" />
+        {hoverIdx != null && (
+          <>
+            <line x1={xAt(hoverIdx)} y1={0} x2={xAt(hoverIdx)} y2={plotH} className="traffic-crosshair" />
+            <circle cx={xAt(hoverIdx)} cy={yAt(points[hoverIdx].stars)} r={4} className="traffic-line-dot" />
+          </>
+        )}
+        <line x1={0} y1={plotH} x2={w} y2={plotH} className="traffic-baseline" />
+      </svg>
+      <div className="traffic-chart-axis">
+        <span>{fmtDate(points[0].day)}</span>
+        <span>{fmtDate(points[points.length - 1].day)}</span>
+      </div>
+      <div className="traffic-tooltip" aria-live="polite">
+        {hovered ? (
+          <>
+            <strong>{fmtDate(hovered.day)}</strong> — {fmtInt(hovered.stars)} star{hovered.stars === 1 ? "" : "s"}
+          </>
+        ) : (
+          <span className="set-hint">Hover the line for the star count on that date.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Oldest-first releases with a known publish date — undated (draft) releases
+ * have no time-axis position, so the chart drops them; the table below still
+ * lists everything. */
+function releasesChronological(releases: TrafficRelease[]): TrafficRelease[] {
+  return releases
+    .filter((r) => r.published_at)
+    .slice()
+    .sort((a, b) => (a.published_at! < b.published_at! ? -1 : a.published_at! > b.published_at! ? 1 : 0));
+}
+
+function ReleasesChart({ releases }: { releases: TrafficRelease[] }) {
+  const chrono = useMemo(() => releasesChronological(releases), [releases]);
+  const [hover, setHover] = useState<number | null>(null);
+
+  if (!chrono.length) {
+    return <p className="set-hint">No published releases yet.</p>;
+  }
+
+  const max = Math.max(1, ...chrono.map((r) => r.total_downloads));
+  const w = 640;
+  const h = 160;
+  const padL = 4;
+  const padB = 18;
+  const plotH = h - padB;
+  const barGap = 3;
+  const barW = Math.max(1, (w - padL) / chrono.length - barGap);
+
+  const hovered = hover != null ? chrono[hover] : null;
+
+  return (
+    <div className="traffic-chart-wrap">
+      <svg
+        className="traffic-chart"
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`Downloads per release, ${chrono[0].tag} through ${chrono[chrono.length - 1].tag}`}
+        onMouseLeave={() => setHover(null)}
+      >
+        {chrono.map((r, i) => {
+          const barH = Math.max(1, (r.total_downloads / max) * (plotH - 8));
+          const x = padL + i * (barW + barGap);
+          const y = plotH - barH;
+          return (
+            <rect
+              key={r.tag}
+              x={x}
+              y={y}
+              width={barW}
+              height={barH}
+              rx={Math.min(3, barW / 2)}
+              className={"traffic-bar" + (hover === i ? " hover" : "")}
+              onMouseEnter={() => setHover(i)}
+            />
+          );
+        })}
+        <line x1={0} y1={plotH} x2={w} y2={plotH} className="traffic-baseline" />
+      </svg>
+      <div className="traffic-chart-axis">
+        <span>{fmtDate(chrono[0].published_at)}</span>
+        <span>{fmtDate(chrono[chrono.length - 1].published_at)}</span>
+      </div>
+      <div className="traffic-tooltip" aria-live="polite">
+        {hovered ? (
+          <>
+            <strong>{hovered.tag}</strong> ({fmtDate(hovered.published_at)}) —{" "}
+            {fmtInt(hovered.total_downloads)} download{hovered.total_downloads === 1 ? "" : "s"}
+            {hovered.assets.length > 0 && (
+              <span className="traffic-tooltip-detail">
+                {" "}
+                (
+                {hovered.assets
+                  .filter((a) => a.downloads > 0)
+                  .sort((a, b) => b.downloads - a.downloads)
+                  .map((a) => `${a.name}: ${a.downloads}`)
+                  .join(", ") || "no downloads yet"}
+                )
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="set-hint">Hover a bar for that release's per-asset breakdown.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ClicksChart({ series }: { series: TrafficClickRow[] }) {
+  const days = useMemo(() => dailyTotals(series), [series]);
+  const [hover, setHover] = useState<number | null>(null);
+
+  if (!days.length) {
+    return <p className="set-hint">No clicks recorded in this window yet.</p>;
+  }
+
+  const max = Math.max(1, ...days.map((d) => d.total));
+  const w = 640;
+  const h = 160;
+  const padL = 4;
+  const padB = 18;
+  const plotH = h - padB;
+  const barGap = 2;
+  const barW = Math.max(1, (w - padL) / days.length - barGap);
+
+  const hovered = hover != null ? days[hover] : null;
+
+  return (
+    <div className="traffic-chart-wrap">
+      <svg
+        className="traffic-chart"
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`Daily clicks across all tracked links, ${days[0].day} through ${days[days.length - 1].day}`}
+        onMouseLeave={() => setHover(null)}
+      >
+        {days.map((d, i) => {
+          const barH = Math.max(1, (d.total / max) * (plotH - 8));
+          const x = padL + i * (barW + barGap);
+          const y = plotH - barH;
+          return (
+            <rect
+              key={d.day}
+              x={x}
+              y={y}
+              width={barW}
+              height={barH}
+              rx={Math.min(3, barW / 2)}
+              className={"traffic-bar" + (hover === i ? " hover" : "")}
+              onMouseEnter={() => setHover(i)}
+            />
+          );
+        })}
+        <line x1={0} y1={plotH} x2={w} y2={plotH} className="traffic-baseline" />
+      </svg>
+      <div className="traffic-chart-axis">
+        <span>{fmtDate(days[0].day)}</span>
+        <span>{fmtDate(days[days.length - 1].day)}</span>
+      </div>
+      <div className="traffic-tooltip" aria-live="polite">
+        {hovered ? (
+          <>
+            <strong>{fmtDate(hovered.day)}</strong> — {fmtInt(hovered.total)} click
+            {hovered.total === 1 ? "" : "s"}
+            {Object.keys(hovered.bySlug).length > 0 && (
+              <span className="traffic-tooltip-detail">
+                {" "}
+                (
+                {Object.entries(hovered.bySlug)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([slug, n]) => `${slugLabel(slug)}: ${n}`)
+                  .join(", ")}
+                )
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="set-hint">Hover a bar for that day's breakdown.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function Traffic(_: ScreenProps) {
+  const [days, setDays] = useState<(typeof DAYS_OPTIONS)[number]>(90);
+  const [refreshing, setRefreshing] = useState(false);
+  const q = useTraffic(true, days);
+  const data = q.data;
+
+  const clickTotalsSorted = useMemo(() => {
+    if (!data) return [];
+    return Object.entries(data.clicks.totals_by_slug).sort((a, b) => b[1] - a[1]);
+  }, [data]);
+
+  const doRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await refreshTraffic(days);
+      await q.refetch();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <>
+      <h3 className="set-section-title">Site traffic</h3>
+      <p className="set-hint">
+        Reach across mindflock.ai and the GitHub repo — pulled live from GitHub's API and the
+        click-tracking Worker on mindflock.ai/go/*. Visible in this dev build only.
+      </p>
+
+      {q.isLoading && !data && <p className="set-hint">Loading…</p>}
+      {q.isError && !data && (
+        <p className="set-hint">Could not load traffic data. Check your connection and retry.</p>
+      )}
+
+      {data && (
+        <>
+          {(data.errors.github || data.errors.clicks) && (
+            <div className="traffic-warn">
+              {data.errors.github && <div>GitHub: {data.errors.github}</div>}
+              {data.errors.clicks && <div>Click tracking: {data.errors.clicks}</div>}
+            </div>
+          )}
+
+          <div className="traffic-tiles">
+            <div className="traffic-tile">
+              <span className="traffic-tile-num">{fmtInt(data.repo?.stars)}</span>
+              <span className="traffic-tile-label">GitHub stars</span>
+            </div>
+            <div className="traffic-tile">
+              <span className="traffic-tile-num">{fmtInt(data.repo?.forks)}</span>
+              <span className="traffic-tile-label">Forks</span>
+            </div>
+            <div className="traffic-tile">
+              <span className="traffic-tile-num">{fmtInt(data.downloads_total)}</span>
+              <span className="traffic-tile-label">Total downloads (all releases)</span>
+            </div>
+            <div className="traffic-tile">
+              <span className="traffic-tile-num">
+                {fmtInt(clickTotalsSorted.reduce((s, [, n]) => s + n, 0))}
+              </span>
+              <span className="traffic-tile-label">Tracked link clicks ({data.clicks.days}d)</span>
+            </div>
+          </div>
+
+          <h3 className="set-section-title">GitHub stars over time</h3>
+          {/* A server running code from before this field existed answers without
+              it — a real possibility for a locally-running dev backend, not just
+              a type-system technicality — so this is the one spot the API
+              response is treated as untrusted rather than the TrafficResponse
+              type. */}
+          <StarsChart points={data.star_history ?? []} />
+
+          <div className="set-row traffic-range-row">
+            <div className="usage-periods traffic-range">
+              {DAYS_OPTIONS.map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  className={"usage-period" + (days === d ? " active" : "")}
+                  onClick={() => setDays(d)}
+                >
+                  {d}d
+                </button>
+              ))}
+            </div>
+            <span className="test-row">
+              <button type="button" className="test-btn" onClick={doRefresh} disabled={refreshing}>
+                {refreshing ? "Refreshing…" : "Refresh"}
+              </button>
+              <span className="set-hint">
+                Cached ~5 min server-side to stay under GitHub's rate limit — this bypasses it.
+              </span>
+            </span>
+          </div>
+
+          <ClicksChart series={data.clicks.series} />
+
+          {clickTotalsSorted.length > 0 && (
+            <>
+              <h3 className="set-section-title">Clicks by link ({data.clicks.days}d)</h3>
+              <table className="traffic-table">
+                <thead>
+                  <tr>
+                    <th>Link</th>
+                    <th className="num">Clicks</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {clickTotalsSorted.map(([slug, n]) => (
+                    <tr key={slug}>
+                      <td>{slugLabel(slug)}</td>
+                      <td className="num">{fmtInt(n)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+
+          <h3 className="set-section-title">Downloads over time</h3>
+          {data.releases.length === 0 ? (
+            <p className="set-hint">No releases found.</p>
+          ) : (
+            <ReleasesChart releases={data.releases} />
+          )}
+
+          <h3 className="set-section-title">Downloads by version</h3>
+          {data.releases.length === 0 ? (
+            <p className="set-hint">No releases found.</p>
+          ) : (
+            <table className="traffic-table">
+              <thead>
+                <tr>
+                  <th>Version</th>
+                  <th>Published</th>
+                  <th className="num">Downloads</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.releases.map((r) => (
+                  <tr key={r.tag}>
+                    <td>
+                      {r.tag}
+                      {r.prerelease && <span className="traffic-pre"> pre-release</span>}
+                    </td>
+                    <td>{fmtDate(r.published_at)}</td>
+                    <td className="num">{fmtInt(r.total_downloads)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/screens/traffic.css
+++ b/frontend/src/components/settings/screens/traffic.css
@@ -1,0 +1,167 @@
+/* Settings → Site traffic (dev shell only). Stat tiles, a single-hue click
+   chart, and two data tables — no chart library, consistent with the rest of
+   the app's hand-rolled, zero-dep components. */
+
+.traffic-warn {
+  border: 1px solid var(--red);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--red);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.traffic-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.traffic-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--panel, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.traffic-tile-num {
+  font-size: 20px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.traffic-tile-label {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.traffic-range-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.traffic-range {
+  width: auto;
+  min-width: 110px;
+}
+
+.traffic-chart-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.traffic-chart {
+  width: 100%;
+  height: 160px;
+  display: block;
+}
+
+/* Sequential magnitude-over-time, one series — the app's single accent hue is
+   the correct encoding (see dataviz skill: categorical color is for identity,
+   not a lone metric). Per-link identity lives in the table below instead. */
+.traffic-bar {
+  fill: var(--accent);
+  opacity: 0.72;
+  transition: opacity 0.1s;
+}
+
+.traffic-bar.hover {
+  opacity: 1;
+}
+
+.traffic-baseline {
+  stroke: var(--border);
+  stroke-width: 1;
+}
+
+/* Cumulative stars line (StarsChart) — thin 2px stroke, single accent hue
+   (one series, magnitude-over-time — same "no categorical palette needed"
+   reasoning as the bar charts). Crosshair + dot track the pointer since a
+   line has no discrete mark to hover per-datapoint. */
+.traffic-line {
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-crosshair {
+  stroke: var(--border);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-line-dot {
+  fill: var(--accent);
+  stroke: var(--panel, var(--bg));
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-chart-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.traffic-tooltip {
+  min-height: 18px;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.traffic-tooltip-detail {
+  color: var(--muted);
+}
+
+.traffic-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.traffic-table th {
+  text-align: left;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  padding: 4px 8px 6px 0;
+}
+
+.traffic-table td {
+  padding: 5px 8px 5px 0;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.traffic-table th.num,
+.traffic-table td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding-right: 0;
+}
+
+.traffic-pre {
+  font-size: 10px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  margin-left: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/frontend/src/lib/shell.ts
+++ b/frontend/src/lib/shell.ts
@@ -47,6 +47,14 @@ export function inShell(): boolean {
   return !!bridge();
 }
 
+/** True inside a `--mindflock-dev` desktop-shell build (see electron/main.js
+ * `DEV`); false in a production shell build and in a plain browser. Gates
+ * settings that make sense for MindFlock's own maintainer but not for an end
+ * user's build — e.g. the Site traffic panel. */
+export function isDevShell(): boolean {
+  return bridge()?.dev === true;
+}
+
 /** True inside the desktop shell on macOS. Prefer
  * {@link hasNativeWindowControls} for layout decisions — see its note. */
 export function isMacShell(): boolean {

--- a/frontend/src/state/queries.ts
+++ b/frontend/src/state/queries.ts
@@ -5,7 +5,7 @@
 
 import { QueryClient, useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
-import type { Config, DevicesResponse, Instance, UsageResponse } from "../api/types";
+import type { Config, DevicesResponse, Instance, TrafficResponse, UsageResponse } from "../api/types";
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -99,6 +99,34 @@ export function useUsage(enabled = true) {
 /** Imperative refresh after any action that changes the session set. */
 export function refreshInstances() {
   return queryClient.invalidateQueries({ queryKey: ["instances"] });
+}
+
+/** Settings → Site traffic (dev shell only): stars/forks, per-release
+ * download counts, and click totals for the /go/ tracked links. The backend
+ * addon already caches this for 5 minutes against GitHub's rate limit, so
+ * the query's own staleTime just avoids a redundant fetch on every dialog
+ * reopen within that window. `enabled` keeps this from ever firing for a
+ * user who can't see the screen — no point spending the addon's cache TTL on
+ * requests nobody reads. */
+export function useTraffic(enabled: boolean, days = 90) {
+  return useQuery({
+    queryKey: ["traffic", days],
+    queryFn: () => api<TrafficResponse>("/api/traffic?days=" + days),
+    enabled,
+    staleTime: 60_000,
+    placeholderData: (prev) => prev,
+    retry: false,
+  });
+}
+
+/** The Refresh button on Site traffic: bypass the addon's cache. */
+export function refreshTraffic(days = 90) {
+  return queryClient.fetchQuery({
+    queryKey: ["traffic", days],
+    queryFn: () => api<TrafficResponse>("/api/traffic?days=" + days + "&refresh=1"),
+    staleTime: 0,
+    retry: false,
+  });
 }
 
 /** Merge new fields into ONE cached session row, with no round trip.

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -53,6 +53,7 @@
 @import "../components/capsGate.css" layer(components); /* 270 */
 @import "../components/dialogs/DeviceDialog.css" layer(components); /* 270 */
 @import "../components/settings/screens/Appearance.css" layer(components); /* 280 */
+@import "../components/settings/screens/traffic.css" layer(components); /* 290 */
 
 @import "./regions.css" layer(theme);
 @import "./theme-light.css" layer(theme); /* 190 */

--- a/tests/unit/test_addons.py
+++ b/tests/unit/test_addons.py
@@ -31,6 +31,7 @@ def test_manifest_lists_migrated_addons():
         "connections",
         "templates",
         "notify",
+        "traffic",
     ]
     # Each UI addon contributes a frontend descriptor with a known slot. The
     # "connections" addon is API-only (its list renders inline in the Settings →


### PR DESCRIPTION
## Summary
- New Settings → **Site traffic** screen (visible only in `--mindflock-dev` shell builds, via a new `isDevShell()` helper): GitHub stars/forks, per-release download counts, and click totals for the `mindflock.ai/go/*` tracked links, in one place instead of stitching GitHub + the release page + the webpage repo together by hand.
- Cumulative **GitHub stars over time** as a line chart, reconstructed from the stargazers API's per-star timestamps (the plain repo endpoint only has the current total). Requires a GitHub token to populate — without one it shows a clear fallback message rather than breaking; the current star count works either way.
- Clicks-per-day and downloads-per-release as bar charts, each with a hover breakdown.
- New `backend/web/addons/traffic.py` addon: fans out to GitHub's REST API and the webpage repo's click-tracking Cloudflare Worker (`/go/_stats`), caches the combined payload 5 minutes, and degrades each section independently if one upstream call fails.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full backend test suite: 4036 passed
- [x] `tests/unit/test_addons.py` updated for the new `traffic` addon in the manifest
- [x] `tests/unit/test_frontend_settings_revamp.py` (settings screen ordering) still passes — `traffic` appended last, doesn't disturb existing order assertions
- [x] Verified live against the real GitHub API and a running local backend; fixed a real bug found in the process (`star_history` missing from a stale-running server's response no longer crashes the screen — the frontend treats that field as untrusted at the API boundary)
- [x] `black` clean, `detect-secrets` clean