### PR TITLE
Pin the prompt above each pane, and give the history a page of its own

### DIFF
--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -289,6 +289,27 @@ class BaseProvider:
         Implementations must be cheap — this is called from the UI poll."""
         return None
 
+    def last_prompt_snippet(self, session_name: str, workdir: str) -> Optional[str]:
+        """A one-line snippet of the newest USER prompt (first meaningful
+        line, ≤120 chars) — what the human last asked this session to do; the
+        panes pin it above the terminal. Same cheapness contract as
+        :meth:`last_turn_snippet`. Default: no transcript to read."""
+        return None
+
+    def last_prompt_full(self, session_name: str, workdir: str) -> Optional[str]:
+        """The newest USER prompt's whole body (capped ~4000 chars) — the
+        pinned line's hover/click expansion. Must come from the same entry
+        :meth:`last_prompt_snippet` reported. Default: no transcript."""
+        return None
+
+    def find_prompt_full(
+        self, session_name: str, workdir: str, prefix: str
+    ) -> Optional[str]:
+        """Full body of the newest USER prompt starting with ``prefix`` (a
+        width-truncated line from the terminal), for expanding OLDER prompts
+        than the latest. Default: no transcript to search."""
+        return None
+
     # --- per-session resume thread ----------------------------------------- #
     def resume_thread_id(self, session_name: str) -> str:
         """The conversation/session id recorded for THIS window, or ``""``.

--- a/backend/providers/claude.py
+++ b/backend/providers/claude.py
@@ -356,7 +356,18 @@ class ClaudeProvider(BaseProvider):
         return _claude_transcript_tokens(workdir, since_ts, until_ts, shared_cwd)
 
     def last_turn_snippet(self, session_name: str, workdir: str) -> Optional[str]:
-        return _claude_last_turn_snippet(workdir)
+        return _claude_last_turn_snippet(workdir, session_name)
+
+    def last_prompt_snippet(self, session_name: str, workdir: str) -> Optional[str]:
+        return _claude_last_prompt_snippet(workdir, session_name)
+
+    def last_prompt_full(self, session_name: str, workdir: str) -> Optional[str]:
+        return _claude_last_prompt_full(workdir, session_name)
+
+    def find_prompt_full(
+        self, session_name: str, workdir: str, prefix: str
+    ) -> Optional[str]:
+        return _claude_find_prompt_full(workdir, prefix, session_name)
 
 
 def _keychain_login_evidence() -> bool:
@@ -812,6 +823,9 @@ def _claude_project_dirs(workdir: str):
 # --------------------------------------------------------------------------- #
 _LAST_TURN_TTL = 10.0
 _LAST_TURN_TAIL_BYTES = 128 * 1024  # newest entries live at the file's end
+# Deeper window for user-prompt scans: the prompt sits BEFORE the whole
+# turn's tool output, which can run to megabytes (see _snippet_from_transcript).
+_LAST_PROMPT_TAIL_BYTES = 8 * 1024 * 1024
 _LAST_TURN_CACHE = (
     {}
 )  # workdir -> {"checked": epoch, "sig": (path, mtime, size), "snippet": str|None}
@@ -901,19 +915,63 @@ def _newest_transcript(workdir: str) -> Optional[tuple]:
     return newest
 
 
-def _snippet_from_transcript(path: str, size: int) -> Optional[str]:
+def _session_transcript(workdir: str, session_name: str = "") -> Optional[tuple]:
+    """THIS WINDOW's transcript for ``workdir``, as ``(mtime, size, path)``.
+
+    Several windows can run in one directory (in-place sessions and window
+    copies on the same repo), and every one of them writes into the same
+    ``projects/<cwd-slug>/`` dir — so "newest .jsonl by mtime" is whichever
+    sibling typed last, not this window's conversation. The activity hooks
+    record each window's Claude session id under its tmux session name
+    (thread_markers), and Claude names the transcript after that id, so the
+    marker points straight at the right file.
+
+    Falls back to :func:`_newest_transcript` when there is no marker (hookless
+    launches, other providers' windows) or the file it names is gone."""
+    import os
+
+    if session_name:
+        try:
+            from . import thread_markers
+
+            tid = thread_markers.read(session_name)  # validated token, path-safe
+        except Exception:  # noqa: BLE001 — markers are enrichment only
+            tid = ""
+        if tid:
+            for proj in _claude_project_dirs(workdir):
+                p = os.path.join(proj, tid + ".jsonl")
+                try:
+                    st = os.stat(p)
+                except OSError:
+                    continue
+                return (st.st_mtime, st.st_size, p)
+    return _newest_transcript(workdir)
+
+
+def _snippet_from_transcript(
+    path: str, size: int, role: Optional[str] = None, full: bool = False
+) -> Optional[str]:
     """One-line snippet of the newest conversational turn in one transcript
     ``.jsonl``, scanned tail-first (reading only the last
-    ``_LAST_TURN_TAIL_BYTES`` of a large file). None when the file is
-    unreadable or holds no conversational turn."""
+    ``_LAST_TURN_TAIL_BYTES`` of a large file). ``role`` restricts the scan to
+    that entry type ("user" → the newest human prompt); ``full`` returns the
+    accepted entry's whole body (capped) instead of its first line — the same
+    entry either way, so the pin's one-liner and its expansion always agree.
+    None when the file is unreadable or holds no matching turn."""
     import json
     import os
 
+    # A role-filtered scan (the pinned prompt) needs a much deeper window
+    # than the any-role snippet: one busy agent turn writes megabytes of
+    # tool_result entries after the human's message, and a 128K tail then
+    # holds no user prompt at all. Still tail-first — the newest matching
+    # entry is usually found long before the window is exhausted.
+    tail_bytes = _LAST_TURN_TAIL_BYTES if role is None else _LAST_PROMPT_TAIL_BYTES
     snippet = None
     try:
         with open(path, "rb") as f:
-            if size > _LAST_TURN_TAIL_BYTES:
-                f.seek(-_LAST_TURN_TAIL_BYTES, os.SEEK_END)
+            if size > tail_bytes:
+                f.seek(-tail_bytes, os.SEEK_END)
                 tail = f.read().decode("utf-8", "replace")
                 lines = tail.splitlines()[1:]  # drop the partial first line
             else:
@@ -926,33 +984,138 @@ def _snippet_from_transcript(path: str, size: int) -> Optional[str]:
                 obj = json.loads(line)
             except ValueError:
                 continue
+            if role is not None and (
+                not isinstance(obj, dict) or obj.get("type") != role
+            ):
+                continue
+            if role is not None and obj.get("toolUseResult") is not None:
+                continue  # tool output the transcript files under "user"
             text = _entry_text(obj)
             if text is None:
                 continue
-            snippet = _snippet_from_text(text)
-            if snippet:
+            if role == "user":
+                # Newer transcripts label real prompts promptSource:"typed";
+                # slash-command echoes carry null. Only a PRESENT non-typed
+                # value skips — older formats lack the field entirely.
+                ps = obj.get("promptSource")
+                if ps is not None and ps != "typed":
+                    continue
+                head = text.lstrip()
+                # Skip the ENTRY (not just the line): command/stdout echoes
+                # ("<local-command-stdout>remote: …") and interruption stubs
+                # are user-typed only in the transcript's eyes — the lines
+                # after their marker are output, never a prompt.
+                if head.startswith("<") or head.startswith("[Request interrupted"):
+                    continue
+            s = _snippet_from_text(text)
+            if s:
+                snippet = str(text).strip()[:4000] if full else s
                 break
     except OSError:
         snippet = None
     return snippet
 
 
-def _claude_last_turn_snippet(workdir: str) -> Optional[str]:
-    """One-line snippet of the newest conversational turn in ``workdir``'s
-    transcripts (newest .jsonl by mtime, scanned tail-first). Never raises."""
+def _claude_last_turn_snippet(workdir: str, session_name: str = "") -> Optional[str]:
+    """One-line snippet of the newest conversational turn in THIS window's
+    transcript (see :func:`_session_transcript`), scanned tail-first. Never
+    raises."""
+    return _cached_transcript_snippet(workdir, None, session_name=session_name)
+
+
+def _claude_last_prompt_snippet(workdir: str, session_name: str = "") -> Optional[str]:
+    """One-line snippet of the newest USER prompt in THIS window's transcript
+    — what the human last asked for, for the panes' pinned-prompt line. Never
+    raises."""
+    return _cached_transcript_snippet(workdir, "user", session_name=session_name)
+
+
+def _claude_last_prompt_full(workdir: str, session_name: str = "") -> Optional[str]:
+    """The newest USER prompt's whole body (capped at 4000 chars) — the
+    pinned-prompt line's hover/click expansion. Never raises."""
+    return _cached_transcript_snippet(
+        workdir, "user", full=True, session_name=session_name
+    )
+
+
+def _claude_find_prompt_full(
+    workdir: str, prefix: str, session_name: str = ""
+) -> Optional[str]:
+    """Full body of the newest USER prompt whose text starts with ``prefix``
+    (whitespace-normalized; a trailing … from the TUI's width truncation is
+    stripped). Backs the desktop prompt bar's expansion for OLDER prompts —
+    the snapshot only carries the latest one. Never raises."""
+    import json
+    import os
+    import re
+
+    def norm(s: str) -> str:
+        return re.sub(r"\s+", " ", s).strip()
+
+    want = norm(prefix).rstrip("…").rstrip()
+    if len(want) < 8:  # too short to identify a specific prompt
+        return None
+    try:
+        newest = _session_transcript(workdir, session_name)
+        if newest is None:
+            return None
+        path, size = newest[2], newest[1]
+        with open(path, "rb") as f:
+            if size > _LAST_PROMPT_TAIL_BYTES:
+                f.seek(-_LAST_PROMPT_TAIL_BYTES, os.SEEK_END)
+                lines = f.read().decode("utf-8", "replace").splitlines()[1:]
+            else:
+                lines = f.read().decode("utf-8", "replace").splitlines()
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(obj, dict) or obj.get("type") != "user":
+                continue
+            if obj.get("toolUseResult") is not None:
+                continue
+            ps = obj.get("promptSource")
+            if ps is not None and ps != "typed":
+                continue
+            text = _entry_text(obj)
+            if text is None:
+                continue
+            head = text.lstrip()
+            if head.startswith("<") or head.startswith("[Request interrupted"):
+                continue
+            if norm(text).startswith(want):
+                return str(text).strip()[:4000]
+    except Exception:  # noqa: BLE001 — a lookup miss, never an error
+        pass
+    return None
+
+
+def _cached_transcript_snippet(
+    workdir: str, role: Optional[str], full: bool = False, session_name: str = ""
+) -> Optional[str]:
+    """Shared mtime-guarded cache for the last-turn / last-prompt snippets.
+    The any-role slot keeps the bare-workdir key (the cache's original,
+    externally observed shape); role-filtered slots get a suffixed key, and
+    the window's session name is part of the key too — siblings sharing a
+    workdir read different transcripts and must not share a cache slot."""
     import time
 
+    key = workdir if role is None else workdir + "\n" + role + (":full" if full else "")
+    if session_name:
+        key += "\x00" + session_name
     try:
         now = time.time()
-        cached = _LAST_TURN_CACHE.get(workdir)
+        cached = _LAST_TURN_CACHE.get(key)
         if cached and now - cached["checked"] < _LAST_TURN_TTL:
             return cached["snippet"]
 
-        newest = _newest_transcript(workdir)
+        newest = _session_transcript(workdir, session_name)
         if newest is None:
-            _last_turn_cache_put(
-                workdir, {"checked": now, "sig": None, "snippet": None}
-            )
+            _last_turn_cache_put(key, {"checked": now, "sig": None, "snippet": None})
             return None
 
         sig = (newest[2], newest[0], newest[1])
@@ -960,8 +1123,8 @@ def _claude_last_turn_snippet(workdir: str) -> Optional[str]:
             cached["checked"] = now  # unchanged file — just re-arm the TTL
             return cached["snippet"]
 
-        snippet = _snippet_from_transcript(newest[2], newest[1])
-        _last_turn_cache_put(workdir, {"checked": now, "sig": sig, "snippet": snippet})
+        snippet = _snippet_from_transcript(newest[2], newest[1], role, full)
+        _last_turn_cache_put(key, {"checked": now, "sig": sig, "snippet": snippet})
         return snippet
     except Exception:  # noqa: BLE001 — triage hint only; never break the poll
         return None

--- a/backend/web/core/agent_state.py
+++ b/backend/web/core/agent_state.py
@@ -57,6 +57,59 @@ def _session_last_turn(inst) -> Optional[str]:
         return None
 
 
+def _session_last_prompt(inst) -> Optional[str]:
+    """One-line snippet of the newest USER prompt — what the human last asked
+    this session to do (the panes pin it above the terminal). Same sourcing
+    and caching as :func:`_session_last_turn`. None when unavailable."""
+    try:
+        if not inst.Started():
+            return None
+        wt = inst.GetWorktreePath()
+        if not wt:
+            return None
+        name = tmux.to_mindflock_tmux_name(inst.Title)
+        return providers.resolve(
+            getattr(inst, "Program", "") or ""
+        ).last_prompt_snippet(name, wt)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _session_last_prompt_full(inst) -> Optional[str]:
+    """The newest USER prompt's whole body — the pinned line's expansion.
+    Same sourcing and caching as :func:`_session_last_prompt`."""
+    try:
+        if not inst.Started():
+            return None
+        wt = inst.GetWorktreePath()
+        if not wt:
+            return None
+        name = tmux.to_mindflock_tmux_name(inst.Title)
+        return providers.resolve(getattr(inst, "Program", "") or "").last_prompt_full(
+            name, wt
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _session_find_prompt(inst, prefix: str) -> Optional[str]:
+    """Full body of the newest USER prompt starting with ``prefix`` — lets the
+    desktop prompt bar expand OLDER prompts than the latest (their full
+    bodies aren't in the snapshot). None when unavailable/unmatched."""
+    try:
+        if not inst.Started():
+            return None
+        wt = inst.GetWorktreePath()
+        if not wt:
+            return None
+        name = tmux.to_mindflock_tmux_name(inst.Title)
+        return providers.resolve(getattr(inst, "Program", "") or "").find_prompt_full(
+            name, wt, prefix
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
 # Layered activity detection (roadmap A1). Per-title rolling record of the
 # agent pane: {hash, changed_epoch, state, streak}. Authoritative signals (exit
 # marker, foreground process, provider hook marker) are consulted first; the

--- a/backend/web/core/pending.py
+++ b/backend/web/core/pending.py
@@ -178,6 +178,8 @@ def rows(engine=None) -> list:
                 "activity": "offline",
                 "activity_since": 0.0,
                 "last_turn": None,
+                "last_prompt": None,
+                "last_prompt_full": None,
                 "setup": None,
                 "check": None,
                 "ports": None,

--- a/backend/web/core/session_stats.py
+++ b/backend/web/core/session_stats.py
@@ -6,9 +6,10 @@ files):
 * :func:`_session_tokens` — the four token figures + estimated USD cost shown
   per session (cached ~20s, windowed by the session's creation time so copies
   sharing a worktree each get their own conversation's numbers);
-* :func:`_agent_transcript_text` — the newest conversation rendered as plain
-  text for the "Copy all" / history endpoint (the agent TUI runs on tmux's
-  alternate screen, so tmux itself accumulates no scrollback).
+* :func:`_agent_transcript_text` — one window's conversation (selected by its
+  thread marker, not by mtime) rendered as plain text for the "Copy all" /
+  history endpoint (the agent TUI runs on tmux's alternate screen, so tmux
+  itself accumulates no scrollback).
 
 Split out of ``backend.web.server`` (which re-imports these names — the
 routes, tick loops, and tests reference them through the server namespace).
@@ -17,8 +18,6 @@ routes, tick loops, and tests reference them through the server namespace).
 from __future__ import annotations
 
 import json
-import os
-import re
 import time
 from typing import Dict, Optional
 
@@ -151,50 +150,35 @@ def _session_tokens(inst) -> dict:
         return dict(zero)
 
 
-def _agent_transcript_text(workdir: str):
-    """Newest Claude Code conversation for ``workdir``, rendered as plain text.
+def _agent_transcript_text(workdir: str, session_name: str = ""):
+    """One Claude Code conversation in ``workdir``, rendered as plain text.
 
     The agent TUI sits on tmux's ALTERNATE screen, so the tmux pane accumulates
     no history (history_size stays 0) and capture-pane only sees the visible
     frame. The full conversation lives in Claude Code's transcript files:
     ``<config-root>/projects/<cwd-slug>/*.jsonl`` — the same layout the usage
-    scanner in providers/claude.py walks. Returns None when no transcript
-    exists (e.g. non-Claude provider); never raises.
+    scanner in providers/claude.py walks.
+
+    WHICH file is the window's own: several sessions can run in one directory
+    and they all write into that same project dir, so ``session_name`` (the
+    window's tmux session) selects its conversation via the recorded thread
+    marker; only without one does this fall back to the newest by mtime.
+    Returns None when no transcript exists (e.g. non-Claude provider); never
+    raises.
     """
     if not workdir:
         return None
-    encoded = re.sub(r"[^a-zA-Z0-9]", "-", workdir)
-    roots = set()
-    cfg = os.environ.get("CLAUDE_CONFIG_DIR")
-    if cfg:
-        roots.add(cfg)
-    home = os.environ.get("HOME", "")
-    if home and os.path.isdir(home):
-        for n in os.listdir(home):
-            if n.startswith(".claude"):
-                d = os.path.join(home, n)
-                if os.path.isdir(d):
-                    roots.add(d)
-    newest = None  # (mtime, path): one file is ONE conversation; take latest
-    for root in roots:
-        proj = os.path.join(root, "projects", encoded)
-        if not os.path.isdir(proj):
-            continue
-        for fn in os.listdir(proj):
-            if not fn.endswith(".jsonl"):
-                continue
-            p = os.path.join(proj, fn)
-            try:
-                mt = os.path.getmtime(p)
-            except OSError:
-                continue
-            if newest is None or mt > newest[0]:
-                newest = (mt, p)
+    try:
+        from backend.providers.claude import _session_transcript
+
+        newest = _session_transcript(workdir, session_name)
+    except Exception:  # noqa: BLE001 — history is best-effort
+        return None
     if newest is None:
         return None
     parts = []
     try:
-        with open(newest[1], errors="replace") as f:
+        with open(newest[2], errors="replace") as f:
             for line in f:
                 try:
                     obj = json.loads(line)
@@ -214,6 +198,14 @@ def _agent_transcript_text(workdir: str):
                                 texts.append(t)
                 if not texts:
                     continue  # tool_use / tool_result-only turns: skip the noise
+                if obj["type"] == "user":
+                    # Slash-command plumbing the CLI files as "user" messages
+                    # (<command-name>/model</command-name>, its
+                    # <local-command-stdout> echo, caveat banners). They are
+                    # not conversation; rendering them as prompts is noise.
+                    head = "\n".join(texts).lstrip()
+                    if head.startswith("<"):
+                        continue
                 who = "User" if obj["type"] == "user" else "Claude"
                 parts.append("## " + who + "\n" + "\n".join(texts))
     except OSError:

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -152,6 +152,9 @@ from backend.web.core.agent_state import (
     _precommit_lock_is_live,
     _precommit_lock_path,
     _proc_cpu_snapshot,
+    _session_find_prompt,
+    _session_last_prompt,
+    _session_last_prompt_full,
     _session_last_turn,
     _session_stage,
 )
@@ -796,6 +799,18 @@ def _agent_activity_cached(inst, title: str) -> str:
 def _session_last_turn_cached(inst) -> Optional[str]:
     """``_session_last_turn(inst)`` memoized per session (last-turn timestamp)."""
     return _probe_cached("last_turn", inst, lambda: _session_last_turn(inst))
+
+
+def _session_last_prompt_cached(inst) -> Optional[str]:
+    """``_session_last_prompt(inst)`` memoized per session."""
+    return _probe_cached("last_prompt", inst, lambda: _session_last_prompt(inst))
+
+
+def _session_last_prompt_full_cached(inst) -> Optional[str]:
+    """``_session_last_prompt_full(inst)`` memoized per session."""
+    return _probe_cached(
+        "last_prompt_full", inst, lambda: _session_last_prompt_full(inst)
+    )
 
 
 # ---- /api/events state tick (F6) ------------------------------------------ #
@@ -2312,6 +2327,10 @@ def _session_snapshot(i, queues: dict) -> dict:
     d["activity_since"] = float(_act_rec.get("changed_epoch") or 0.0)
     # L3: latest-turn snippet (≤120 chars) for N-session triage, or null.
     d["last_turn"] = _session_last_turn_cached(i)
+    # The newest USER prompt (first line) — the panes pin it above the
+    # terminal — and its whole body for the pin's hover/click expansion.
+    d["last_prompt"] = _session_last_prompt_cached(i)
+    d["last_prompt_full"] = _session_last_prompt_full_cached(i)
     # O2/O3/O4: worktree setup + verification-gate state and the port block.
     try:
         wt = i.GetWorktreePath()
@@ -2346,6 +2365,8 @@ _SNAPSHOT_PROBE_KEYS = (
     "activity",
     "activity_since",
     "last_turn",
+    "last_prompt",
+    "last_prompt_full",
     "setup",
     "check",
 )
@@ -2381,6 +2402,8 @@ def _session_snapshot_cheap(i, queues: dict, prev: Optional[dict] = None) -> dic
     _act_rec = _ACTIVITY_CACHE.get(i.Title) or {}
     d["activity_since"] = float(_act_rec.get("changed_epoch") or 0.0)
     d["last_turn"] = None
+    d["last_prompt"] = None
+    d["last_prompt_full"] = None
     d["setup"] = None
     d["check"] = None
     pb = _ports.get(i.Title)
@@ -6412,19 +6435,45 @@ async def shell_ws(ws: WebSocket, title: str) -> None:
 # _agent_transcript_text moved to core.session_stats (imported above).
 
 
+@app.get("/api/instances/{title}/prompt")
+def pane_prompt(title: str, q: str = "") -> JSONResponse:
+    """Full body of the newest USER prompt starting with ``q`` (the TUI's
+    width-truncated pinned row) — the desktop prompt bar's expansion for
+    prompts older than the latest. ``{"text": null}`` on no match."""
+    inst = ENGINE.instances.get(title)
+    if inst is None:
+        return JSONResponse({"error": "instance not found"}, status_code=404)
+    return JSONResponse({"text": _session_find_prompt(inst, q)})
+
+
 @app.get("/api/instances/{title}/history")
 def pane_history(title: str, pane: str = "agent") -> PlainTextResponse:
     """Full tmux scrollback of the agent/shell pane as plain text.
 
     The web terminals attach to tmux, so xterm.js only ever holds one screen —
     the real history lives in tmux on the server. The pane-header "Copy all"
-    button fetches this and puts it on the clipboard, which is how you capture
-    far more than a screenful (drag-selection can't scroll through tmux
-    history; see attachDragAutoScroll in app.js).
+    button copies this to the clipboard, and the history overlay
+    (frontend HistoryOverlay.tsx) renders it as a scrollable, selectable page
+    (drag-selection can't scroll through tmux history in the live terminal).
     """
     inst = ENGINE.instances.get(title)
     if inst is None:
         return PlainTextResponse("instance not found", status_code=404)
+    if pane != "shell":
+        # The agent TUI redraws in place, so its tmux capture holds only
+        # scroll-off fragments plus the current frame — incomplete, and laced
+        # with the TUI's chrome (input box, status rows). The provider
+        # transcript is the complete conversation; ALWAYS prefer it, falling
+        # through to the capture only when none exists (non-Claude providers,
+        # fresh sessions).
+        # By tmux session name, not just the worktree: sibling windows on the
+        # same directory share a transcript dir, and only the window's own
+        # thread marker says which conversation is THIS pane's.
+        text = _agent_transcript_text(
+            inst.GetWorktreePath(), tmux.to_mindflock_tmux_name(title)
+        )
+        if text:
+            return PlainTextResponse(text)
     base = (
         _shell_tmux_name(title)
         if pane == "shell"
@@ -6432,11 +6481,6 @@ def pane_history(title: str, pane: str = "agent") -> PlainTextResponse:
     )
     name = _live_session_name(base)
     if name is None:
-        if pane != "shell":
-            # Session gone but the provider transcript may still exist on disk.
-            text = _agent_transcript_text(inst.GetWorktreePath())
-            if text:
-                return PlainTextResponse(text)
         return PlainTextResponse("no live session", status_code=404)
     try:
         out = subprocess.run(
@@ -6453,20 +6497,6 @@ def pane_history(title: str, pane: str = "agent") -> PlainTextResponse:
         return PlainTextResponse(
             out.stderr.strip() or "capture failed", status_code=500
         )
-    if pane != "shell":
-        # Sessions whose TUI sits on tmux's alternate screen have empty
-        # history: the capture above only sees the visible frame. Prefer the
-        # provider's transcript file for those, when one exists.
-        hist = subprocess.run(
-            ["tmux", "display-message", "-p", "-t", name, "#{history_size}"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if hist.returncode == 0 and hist.stdout.strip() == "0":
-            text = _agent_transcript_text(inst.GetWorktreePath())
-            if text:
-                return PlainTextResponse(text)
     return PlainTextResponse(out.stdout.rstrip("\n") + "\n")
 
 

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22032,6 +22032,35 @@ function attachWheelScroll(host, term, getWs) {
     { capture: true, passive: true }
   );
 }
+function attachDragHistoryGesture(host, fire) {
+  const HOLD_MS = 220;
+  const MARGIN = 8;
+  const BOTTOM_ZONE = 18;
+  host.addEventListener("mousedown", (down) => {
+    if (down.button !== 0) return;
+    let timer;
+    const onMove = (ev) => {
+      const r = host.getBoundingClientRect();
+      const edge = ev.clientY < r.top - MARGIN ? "top" : ev.clientY > r.bottom - BOTTOM_ZONE ? "bottom" : null;
+      if (edge && timer === void 0) {
+        timer = setTimeout(() => {
+          cleanup();
+          fire(edge);
+        }, HOLD_MS);
+      } else if (!edge && timer !== void 0) {
+        clearTimeout(timer);
+        timer = void 0;
+      }
+    };
+    const cleanup = () => {
+      if (timer !== void 0) clearTimeout(timer);
+      window.removeEventListener("mousemove", onMove, true);
+      window.removeEventListener("mouseup", cleanup, true);
+    };
+    window.addEventListener("mousemove", onMove, true);
+    window.addEventListener("mouseup", cleanup, true);
+  });
+}
 function makeTerm(title, wsPath, interactive, absolutePath) {
   const container = document.createElement("div");
   container.className = "term-container";
@@ -22050,6 +22079,48 @@ function makeTerm(title, wsPath, interactive, absolutePath) {
   term.loadAddon(fit);
   term.open(container);
   attachCopyOnSelect(container, term, { session: title });
+  container.addEventListener("focusin", () => handle.resync());
+  attachDragHistoryGesture(container, (edge) => {
+    var _a2, _b2;
+    let ctx;
+    try {
+      const buf = term.buffer.active;
+      const rows = term.rows || 24;
+      const screen = [];
+      for (let r = 0; r < rows; r++)
+        screen.push(((_a2 = buf.getLine(buf.viewportY + r)) == null ? void 0 : _a2.translateToString(true)) ?? "");
+      const p = term.getSelectionPosition();
+      const side = edge === "bottom" ? p == null ? void 0 : p.start : p == null ? void 0 : p.end;
+      const row = side ? Math.max(0, Math.min(rows - 1, side.y - buf.viewportY)) : edge === "bottom" ? 0 : rows - 1;
+      ctx = { screen, rows, row, col: (side == null ? void 0 : side.x) ?? 0 };
+    } catch {
+    }
+    (_b2 = handle.onHistoryDrag) == null ? void 0 : _b2.call(handle, term.getSelection() || "", edge, ctx);
+  });
+  let topRowAt = 0;
+  let topRowTimer;
+  const emitTopRow = () => {
+    var _a2;
+    if (!handle.onTopRow) return;
+    try {
+      const buf = term.buffer.active;
+      handle.onTopRow(((_a2 = buf.getLine(buf.viewportY)) == null ? void 0 : _a2.translateToString(true)) ?? "");
+    } catch {
+    }
+  };
+  term.onRender(() => {
+    const now = performance.now();
+    clearTimeout(topRowTimer);
+    if (now - topRowAt > 150) {
+      topRowAt = now;
+      emitTopRow();
+    } else {
+      topRowTimer = setTimeout(() => {
+        topRowAt = performance.now();
+        emitTopRow();
+      }, 160);
+    }
+  });
   let ws = null;
   let sentSize = "";
   let closed = false;
@@ -22078,6 +22149,10 @@ function makeTerm(title, wsPath, interactive, absolutePath) {
         return true;
       }
       return false;
+    },
+    resync() {
+      sentSize = "";
+      handle.doFit();
     },
     doFit() {
       if (!container.clientWidth || !container.clientHeight || container.offsetParent === null)
@@ -22205,6 +22280,18 @@ function releaseTerms(title) {
   (_b2 = entry.shell) == null ? void 0 : _b2.dispose();
   registry.delete(title);
   notifyTermStates();
+}
+function resyncAll() {
+  var _a2, _b2;
+  for (const entry of registry.values()) {
+    (_a2 = entry.agent) == null ? void 0 : _a2.resync();
+    (_b2 = entry.shell) == null ? void 0 : _b2.resync();
+  }
+}
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) resyncAll();
+  });
 }
 function focusTerm(title, kind = "agent") {
   var _a2;
@@ -27398,6 +27485,397 @@ function SplitDiff({ content }) {
     ] }, i);
   }) });
 }
+function caretAt(x, y) {
+  const doc = document;
+  if (doc.caretRangeFromPoint) {
+    const r = doc.caretRangeFromPoint(x, y);
+    return r ? { node: r.startContainer, offset: r.startOffset } : null;
+  }
+  if (doc.caretPositionFromPoint) {
+    const p = doc.caretPositionFromPoint(x, y);
+    return p ? { node: p.offsetNode, offset: p.offset } : null;
+  }
+  return null;
+}
+function occurrences(text, needle) {
+  const out = [];
+  let i = text.indexOf(needle);
+  while (i >= 0 && out.length < 50) {
+    out.push(i);
+    i = text.indexOf(needle, i + 1);
+  }
+  return out;
+}
+function findAnchor(text, sel, edge, ctx, ghost) {
+  if (ctx) {
+    const tLines = text.split("\n");
+    const starts = [];
+    let off = 0;
+    for (const l of tLines) {
+      starts.push(off);
+      off += l.length + 1;
+    }
+    const usable = [];
+    ctx.screen.forEach((s, r) => {
+      const t = s.trim();
+      if (t.length >= 4 && (t.match(/[A-Za-z0-9]/g) || []).length >= 4)
+        usable.push([r, t]);
+    });
+    if (usable.length >= 2) {
+      const candidates = [...usable].sort((a, b) => b[1].length - a[1].length).slice(0, 8);
+      const liveTailStart = Math.max(0, tLines.length - ctx.rows - 2);
+      let bestJ = -1, bestScore = -1, bestBase = 0;
+      for (const base of candidates) {
+        const hits = [];
+        for (let j = tLines.length - 1; j >= 0 && hits.length < 50; j--)
+          if (tLines[j].includes(base[1])) hits.push(j);
+        for (const j of hits) {
+          let score = 0;
+          for (const [r, s] of usable) {
+            if (r === base[0]) continue;
+            const at = j + (r - base[0]);
+            for (let d = -3; d <= 3; d++) {
+              const tl = tLines[at + d];
+              if (tl && tl.includes(s)) {
+                score++;
+                break;
+              }
+            }
+          }
+          const beats = score > bestScore || score === bestScore && bestJ >= liveTailStart && j < liveTailStart;
+          if (beats) {
+            bestScore = score;
+            bestJ = j;
+            bestBase = base[0];
+          }
+        }
+      }
+      if (bestJ >= 0 && bestScore >= Math.min(2, usable.length - 1)) {
+        let line = Math.max(
+          0,
+          Math.min(tLines.length - 1, bestJ + (ctx.row - bestBase))
+        );
+        const rowText = (ctx.screen[ctx.row] || "").trim();
+        if (rowText.length >= 4 && (rowText.match(/[A-Za-z0-9]/g) || []).length >= 4) {
+          for (const d of [0, -1, 1, -2, 2, -3, 3]) {
+            const tl = tLines[line + d];
+            if (tl && tl.includes(rowText)) {
+              line += d;
+              break;
+            }
+          }
+        }
+        return {
+          anchor: starts[line] + Math.min(ctx.col, tLines[line].length),
+          matched: true,
+          frac: ctx.rows > 0 ? ctx.row / ctx.rows : void 0
+        };
+      }
+    }
+  }
+  if (sel) {
+    const exact = text.lastIndexOf(sel);
+    if (exact >= 0)
+      return { anchor: edge === "bottom" ? exact : exact + sel.length, matched: true };
+    const lines = sel.split("\n").map((l) => l.trim()).filter((l) => l.length >= 4);
+    if (edge === "top") lines.reverse();
+    for (let i = 0; i < lines.length; i++) {
+      const hits = occurrences(text, lines[i]);
+      if (!hits.length) continue;
+      let hit = hits[hits.length - 1];
+      const buddy = lines[i + 1];
+      if (hits.length > 1 && buddy) {
+        for (const h of hits) {
+          const near = edge === "bottom" ? text.slice(h, h + lines[i].length + buddy.length + 400) : text.slice(Math.max(0, h - buddy.length - 400), h + lines[i].length);
+          if (near.includes(buddy)) {
+            hit = h;
+            break;
+          }
+        }
+      }
+      return {
+        anchor: edge === "bottom" ? hit : hit + lines[i].length,
+        matched: true
+      };
+    }
+  }
+  if (ghost) {
+    const want = ghost.replace(/[…]+\s*$/, "").replace(/\s+/g, "");
+    if (want.length >= 12) {
+      const map = [];
+      let stripped = "";
+      for (let i = 0; i < text.length; i++) {
+        const c = text.charCodeAt(i);
+        if (c !== 32 && c !== 10 && c !== 13 && c !== 9) {
+          stripped += text[i];
+          map.push(i);
+        }
+      }
+      const j = stripped.lastIndexOf(want);
+      if (j >= 0) {
+        return {
+          anchor: map[Math.min(j + want.length - 1, map.length - 1)] + 1,
+          matched: true,
+          frac: 0.15
+        };
+      }
+    }
+  }
+  return { anchor: text.length, matched: false };
+}
+const histCache = /* @__PURE__ */ new Map();
+const HIST_CACHE_MAX = 8;
+function HistoryOverlay({
+  title,
+  pane,
+  dragSelection,
+  dragEdge,
+  dragCtx,
+  dragGhost,
+  initialPos,
+  onClose
+}) {
+  const [text, setText] = reactExports.useState(null);
+  const [error, setError] = reactExports.useState("");
+  const scrollRef = reactExports.useRef(null);
+  const pendingScroll = reactExports.useRef(
+    initialPos
+  );
+  const load2 = reactExports.useCallback(async () => {
+    const key = title + " " + pane;
+    let t;
+    try {
+      const r = await fetch(
+        `/api/instances/${encodeURIComponent(title)}/history?pane=${pane}`
+      );
+      if (!r.ok) throw new Error(await r.text() || "HTTP " + r.status);
+      t = await r.text();
+    } catch (e) {
+      setError(e.message || "history fetch failed");
+      return;
+    }
+    setError("");
+    histCache.delete(key);
+    histCache.set(key, t);
+    while (histCache.size > HIST_CACHE_MAX)
+      histCache.delete(histCache.keys().next().value);
+    const el = scrollRef.current;
+    if (pendingScroll.current == null) {
+      const atBottom = !el || el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+      pendingScroll.current = atBottom ? "bottom" : { fromTop: el.scrollTop };
+    }
+    setText(t);
+  }, [title, pane]);
+  reactExports.useEffect(() => {
+    pendingScroll.current = initialPos;
+    setText(histCache.get(title + " " + pane) ?? null);
+    load2();
+  }, [load2, title, pane]);
+  reactExports.useLayoutEffect(() => {
+    const el = scrollRef.current;
+    const want = pendingScroll.current;
+    if (!el || want == null || text == null) return;
+    pendingScroll.current = null;
+    el.scrollTop = want === "top" ? 0 : want === "bottom" ? el.scrollHeight : want.fromTop;
+  }, [text]);
+  reactExports.useEffect(() => {
+    const id = setInterval(() => {
+      var _a2;
+      if (pressAt.current) return;
+      const sel = (_a2 = window.getSelection) == null ? void 0 : _a2.call(window);
+      if (sel && !sel.isCollapsed && sel.toString().trim()) return;
+      load2();
+    }, 3e3);
+    return () => clearInterval(id);
+  }, [load2]);
+  const buttonDown = reactExports.useRef(dragSelection != null);
+  const suppressElementCopy = reactExports.useRef(false);
+  reactExports.useEffect(() => {
+    if (dragSelection == null) return;
+    const up = () => {
+      buttonDown.current = false;
+    };
+    window.addEventListener("mouseup", up, true);
+    return () => window.removeEventListener("mouseup", up, true);
+  }, [dragSelection]);
+  const contStarted = reactExports.useRef(false);
+  reactExports.useEffect(() => {
+    var _a2;
+    if (text == null || dragSelection == null || contStarted.current) return;
+    contStarted.current = true;
+    const el = scrollRef.current;
+    const node = (_a2 = el == null ? void 0 : el.querySelector("pre")) == null ? void 0 : _a2.firstChild;
+    if (!el || !node || node.nodeType !== Node.TEXT_NODE) return;
+    const { anchor, matched, frac } = findAnchor(
+      text,
+      dragSelection,
+      dragEdge,
+      dragCtx,
+      dragGhost
+    );
+    if (matched) {
+      try {
+        const r = document.createRange();
+        r.setStart(node, Math.min(anchor, text.length));
+        r.collapse(true);
+        const rr = r.getBoundingClientRect();
+        const er = el.getBoundingClientRect();
+        const park = frac ?? (dragEdge === "bottom" ? 0.3 : 0.7);
+        el.scrollTop += rr.top - (er.top + er.height * park);
+      } catch {
+      }
+    }
+    if (!buttonDown.current) return;
+    let live = true;
+    let raf = 0;
+    const rect0 = el.getBoundingClientRect();
+    let px = rect0.left + rect0.width / 2;
+    let py = dragEdge === "bottom" ? rect0.bottom + 24 : rect0.top - 24;
+    const extend = () => {
+      const r = el.getBoundingClientRect();
+      const c = caretAt(
+        Math.max(r.left + 4, Math.min(r.right - 4, px)),
+        Math.max(r.top + 4, Math.min(r.bottom - 4, py))
+      );
+      const sel = window.getSelection();
+      if (!c || !sel) return;
+      try {
+        sel.setBaseAndExtent(node, anchor, c.node, c.offset);
+      } catch {
+      }
+    };
+    const EDGE = 24;
+    const tick = () => {
+      if (!live) return;
+      const r = el.getBoundingClientRect();
+      const topZone = r.top + EDGE;
+      const bottomZone = r.bottom - EDGE;
+      if (py < topZone) el.scrollTop -= Math.min(64, 4 + (topZone - py) * 0.3);
+      else if (py > bottomZone) el.scrollTop += Math.min(64, 4 + (py - bottomZone) * 0.3);
+      extend();
+      raf = requestAnimationFrame(tick);
+    };
+    const onMove = (ev) => {
+      px = ev.clientX;
+      py = ev.clientY;
+    };
+    const stop = () => {
+      live = false;
+      cancelAnimationFrame(raf);
+      window.removeEventListener("mousemove", onMove, true);
+      window.removeEventListener("mouseup", finish, true);
+    };
+    const finish = () => {
+      stop();
+      suppressElementCopy.current = true;
+      setTimeout(() => {
+        var _a3;
+        const s = ((_a3 = window.getSelection()) == null ? void 0 : _a3.toString()) || "";
+        if (s.trim())
+          copyText(s).then((ok) => {
+            if (ok) toast("Copied " + s.length + " chars");
+          });
+        suppressElementCopy.current = false;
+      }, 0);
+    };
+    window.addEventListener("mousemove", onMove, true);
+    window.addEventListener("mouseup", finish, true);
+    raf = requestAnimationFrame(tick);
+    return stop;
+  }, [text, dragSelection, dragEdge, dragCtx, dragGhost]);
+  reactExports.useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+        e.preventDefault();
+        e.stopPropagation();
+        const el = scrollRef.current;
+        if (el) el.scrollTop = e.key === "ArrowUp" ? 0 : el.scrollHeight;
+      }
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+  const copyOnRelease = () => {
+    if (suppressElementCopy.current) return;
+    setTimeout(() => {
+      var _a2, _b2;
+      const sel = ((_b2 = (_a2 = window.getSelection) == null ? void 0 : _a2.call(window)) == null ? void 0 : _b2.toString()) || "";
+      if (!sel.trim()) return;
+      copyText(sel).then((ok) => {
+        if (ok) toast("Copied " + sel.length + " chars");
+      });
+    }, 0);
+  };
+  const pressAt = reactExports.useRef(null);
+  const onRootMouseDown = (e) => {
+    var _a2;
+    if (e.button !== 0) {
+      pressAt.current = null;
+      return;
+    }
+    const sel = (_a2 = window.getSelection) == null ? void 0 : _a2.call(window);
+    const hadSelection = !!(sel && !sel.isCollapsed && sel.toString().trim());
+    if (e.shiftKey && hadSelection && sel) {
+      e.preventDefault();
+      const c = caretAt(e.clientX, e.clientY);
+      if (c) {
+        try {
+          sel.extend(c.node, c.offset);
+        } catch {
+        }
+      }
+      pressAt.current = null;
+      return;
+    }
+    pressAt.current = {
+      x: e.clientX,
+      y: e.clientY,
+      hadSelection
+    };
+    sel == null ? void 0 : sel.removeAllRanges();
+  };
+  const onRootMouseUp = (e) => {
+    const p = pressAt.current;
+    pressAt.current = null;
+    if (!p || e.button !== 0) return;
+    if (Math.abs(e.clientX - p.x) > 4 || Math.abs(e.clientY - p.y) > 4) return;
+    if (p.hadSelection) return;
+    setTimeout(() => {
+      var _a2;
+      const sel = (_a2 = window.getSelection) == null ? void 0 : _a2.call(window);
+      if (sel && !sel.isCollapsed && sel.toString().trim()) return;
+      onClose();
+    }, 0);
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      className: "hist-overlay",
+      role: "region",
+      "aria-label": "Full pane history",
+      onMouseDown: onRootMouseDown,
+      onMouseUp: onRootMouseUp,
+      onDragStart: (e) => e.preventDefault(),
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "hist-bar", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "hist-title", children: [
+            "Full ",
+            pane === "shell" ? "terminal" : "agent",
+            " history"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "hist-hint", children: "drag to select · release to copy · Ctrl+↑/↓ top/bottom · click or Esc returns to live" })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hist-scroll", ref: scrollRef, onMouseUp: copyOnRelease, children: error ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hist-msg error", children: error }) : text === null ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hist-msg", children: "Loading history…" }) : text.trim() ? /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { children: text }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hist-msg", children: "No history yet." }) })
+      ]
+    }
+  );
+}
 const queueCache = /* @__PURE__ */ new Map();
 function qApi(title, path, opts) {
   return instApi(title, path, opts);
@@ -27739,6 +28217,7 @@ function Pane({
   const [booted, setBooted] = reactExports.useState(false);
   const [wsState, setWsState] = reactExports.useState("connecting");
   const [shellStarted, setShellStarted] = reactExports.useState(savedTab === "shell");
+  const [histPane, setHistPane] = reactExports.useState(null);
   const bodyRef = reactExports.useRef(null);
   const fitTimer = reactExports.useRef(void 0);
   const displayName = alias || title;
@@ -27747,6 +28226,15 @@ function Pane({
       if (!el || missing || loading) return;
       const handle = getTerm(title, kind);
       if (!el.contains(handle.container)) el.appendChild(handle.container);
+      handle.onHistoryDrag = (sel, edge, ctx) => setHistPane({ kind, dragSel: sel, edge, ctx, ghostSel: ghostRef.current });
+      if (kind === "agent") {
+        handle.onTopRow = (t) => {
+          const m = /^\s*[❯>]\s+(.+)$/.exec(t);
+          const g = m && m[1].trim() ? m[1].trim() : null;
+          ghostRef.current = g;
+          setGhost(g);
+        };
+      }
       if (kind === "agent") {
         handle.onState = (s) => setWsState(s);
         handle.onBoot = () => setBooted(true);
@@ -27770,6 +28258,53 @@ function Pane({
     obs.observe(bodyRef.current);
     return () => obs.disconnect();
   }, [fitSoon, missing, loading]);
+  const [pinOpen, setPinOpen] = reactExports.useState(false);
+  const [ghost, setGhost] = reactExports.useState(null);
+  const ghostRef = reactExports.useRef(null);
+  const ghostCore = (ghost || "").replace(/[…]+\s*$/, "").replace(/\s+/g, " ").trim();
+  const fullNorm = (inst.last_prompt_full || "").replace(/\s+/g, " ");
+  const ghostIsLatest = !ghost || !!fullNorm && fullNorm.includes(ghostCore.slice(0, 80));
+  const pinLine = ghost ?? inst.last_prompt;
+  const [lookup, setLookup] = reactExports.useState(null);
+  reactExports.useEffect(() => {
+    if (!pinOpen || ghostIsLatest || ghostCore.length < 8) return;
+    if ((lookup == null ? void 0 : lookup.q) === ghostCore) return;
+    let dead = false;
+    fetch(
+      `/api/instances/${encodeURIComponent(title)}/prompt?q=${encodeURIComponent(ghostCore)}`
+    ).then((r) => r.ok ? r.json() : null).then((j) => {
+      if (!dead && (j == null ? void 0 : j.text)) setLookup({ q: ghostCore, text: j.text });
+    }).catch(() => {
+    });
+    return () => {
+      dead = true;
+    };
+  }, [pinOpen, ghostIsLatest, ghostCore, title, lookup]);
+  const pinBody = ghostIsLatest ? inst.last_prompt_full || inst.last_prompt : (lookup == null ? void 0 : lookup.q) === ghostCore ? lookup.text : ghost;
+  const hasPin = !!pinLine;
+  const pinLen = (pinBody || "").length;
+  reactExports.useEffect(() => {
+    fitSoon();
+  }, [hasPin, pinOpen, pinLen, fitSoon]);
+  reactExports.useEffect(() => {
+    if (!focused || missing || loading || histPane) return;
+    const onKey = (e) => {
+      if (!(e.ctrlKey || e.metaKey) || e.altKey) return;
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      const a = document.activeElement;
+      const editing = a && (a.tagName === "INPUT" || a.tagName === "TEXTAREA" || a.tagName === "SELECT" || a.isContentEditable === true);
+      if (editing && !a.closest(".xterm")) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setHistPane({
+        kind: tab === "shell" ? "shell" : "agent",
+        dragSel: null,
+        pos: e.key === "ArrowUp" ? "top" : "bottom"
+      });
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [focused, missing, loading, histPane, tab]);
   const showTab = (t) => {
     setTab(t);
     setLastTab(title, t);
@@ -27999,6 +28534,37 @@ function Pane({
             {
               className: "act copyhist",
               type: "button",
+              title: "Browse the full history — scroll & select like a page (or drag a selection past the top of the terminal)",
+              onClick: (e) => {
+                e.stopPropagation();
+                setHistPane({ kind: tab === "shell" ? "shell" : "agent", dragSel: null });
+              },
+              children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "svg",
+                {
+                  width: "12",
+                  height: "12",
+                  viewBox: "0 0 24 24",
+                  fill: "none",
+                  stroke: "currentColor",
+                  strokeWidth: "2",
+                  strokeLinecap: "round",
+                  strokeLinejoin: "round",
+                  "aria-hidden": "true",
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: "M12 8v4l2 2" }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: "M3.05 11a9 9 0 1 1 .5 4" }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: "M3 22v-6h6" })
+                  ]
+                }
+              )
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              className: "act copyhist",
+              type: "button",
               title: "Copy this pane's whole history to the clipboard",
               onClick: (e) => {
                 e.stopPropagation();
@@ -28041,13 +28607,51 @@ function Pane({
           )
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pane-body", ref: bodyRef, children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pane-term agent-term" + (tab !== "agent" ? " hidden" : ""), ref: adopt("agent"), children: !booted && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "term-loading", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "spinner" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading session…" })
-          ] }) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pane-term agent-term" + (tab !== "agent" ? " hidden" : ""), ref: adopt("agent"), children: [
+            pinLine ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "prompt-pin" + (pinOpen ? " pin-open" : ""), children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  type: "button",
+                  className: "prompt-pin-mark",
+                  "aria-expanded": pinOpen,
+                  title: pinOpen ? "Collapse to one line" : "Show the whole prompt",
+                  onClick: (e) => {
+                    e.stopPropagation();
+                    setPinOpen((v) => !v);
+                  },
+                  children: "❯"
+                }
+              ),
+              pinOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "prompt-pin-body", children: pinBody }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "prompt-pin-text", children: pinLine }),
+              ghost ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "ghost-row-mask", "aria-hidden": "true" }) : null
+            ] }) : null,
+            !booted && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "term-loading", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "spinner" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading session…" })
+            ] })
+          ] }),
           shellStarted ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pane-term shell-term" + (tab !== "shell" ? " hidden" : ""), ref: adopt("shell") }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pane-term shell-term" + (tab !== "shell" ? " hidden" : "") }),
           caps2.git && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pane-diff" + (tab !== "diff" ? " hidden" : ""), children: /* @__PURE__ */ jsxRuntimeExports.jsx(DiffTab, { title, active: tab === "diff" }) }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pane-queue" + (tab !== "queue" ? " hidden" : ""), children: /* @__PURE__ */ jsxRuntimeExports.jsx(QueueTab, { title, active: tab === "queue" }) }),
+          histPane && /* @__PURE__ */ jsxRuntimeExports.jsx(
+            HistoryOverlay,
+            {
+              title,
+              pane: histPane.kind,
+              dragSelection: histPane.dragSel,
+              dragEdge: histPane.edge ?? "top",
+              dragCtx: histPane.ctx ?? null,
+              dragGhost: histPane.ghostSel ?? null,
+              initialPos: histPane.pos ?? "bottom",
+              onClose: () => {
+                const kind = histPane.kind;
+                setHistPane(null);
+                selectSession(title, { noKeyboard: true });
+                setTimeout(() => focusTerm(title, kind), 0);
+              }
+            }
+          ),
           reduceMotion && chip.cls === "s-running" && tab === "agent" && /* @__PURE__ */ jsxRuntimeExports.jsx(RunningCover, { paneRef }),
           (budget == null ? void 0 : budget.locked) && /* @__PURE__ */ jsxRuntimeExports.jsx(BudgetLock, { title, budget })
         ] })

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -4855,6 +4855,91 @@ p.set-hint {
   position: relative;
 }
 
+/* The agent pane is a column: the pinned prompt (when present) on top, the
+   terminal filling the rest. FitAddon measures .term-container, so the flex
+   sizing is what makes the terminal shrink to make room for the pin. */
+.pane-term.agent-term {
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-term.agent-term > .term-container {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Pinned prompt: first line of the session's latest user prompt. Bleeds to
+   the pane edges (negative margins swallow .pane-term's padding) so it reads
+   as a header, not content. */
+.prompt-pin {
+  flex: none;
+  position: relative; /* anchors .ghost-row-mask */
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin: -6px -8px 6px;
+  padding: 4px 10px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+}
+
+/* Covers the terminal's own pinned-prompt row (the TUI keeps drawing it in
+   the PTY, shared with mobile) while the bar above mirrors its text: the
+   6px pane gap plus one terminal row of terminal background. */
+.prompt-pin .ghost-row-mask {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 23px;
+  background: var(--term-bg, var(--bg));
+  pointer-events: none;
+  /* Above xterm's own layers (which form their own stacking contexts) but
+     below the boot loader (3) and pane overlays. */
+  z-index: 2;
+}
+
+.prompt-pin .prompt-pin-mark {
+  flex: none;
+  background: none;
+  border: none;
+  padding: 0 2px;
+  cursor: pointer;
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 11px;
+  line-height: inherit;
+  transition: transform 0.12s ease;
+}
+
+.prompt-pin.pin-open .prompt-pin-mark {
+  transform: rotate(90deg);
+}
+
+.prompt-pin .prompt-pin-text {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The whole prompt, in-flow (the terminal refits beneath it). Capped at a
+   few lines with its own scrollbar so a long prompt can't eat the pane. */
+.prompt-pin .prompt-pin-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-height: 110px;
+  overflow-y: auto;
+  color: var(--text);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  user-select: text;
+  cursor: text;
+}
+
 .pane-term .xterm {
   height: 100%;
 }

--- a/frontend/src/components/grid/HistoryOverlay.css
+++ b/frontend/src/components/grid/HistoryOverlay.css
@@ -1,0 +1,73 @@
+/* Full-history overlay (HistoryOverlay.tsx) — anchored to .pane-body, which
+   Pane.css already makes relative. z-index 4: above the reduce-motion cover
+   (2) and the boot loader (3), below the file-drop cue (5/6) and the budget
+   lock (6) — a spend stop must be able to paint over a history browse. */
+.hist-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  background: var(--term-bg, var(--bg));
+}
+
+.hist-bar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.hist-bar .hist-title {
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.hist-bar .hist-hint {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The page itself: native scrolling and selection are the whole feature.
+   overscroll-behavior keeps a fast wheel from spilling into the grid. */
+.hist-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 6px 10px;
+  cursor: text;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.hist-scroll pre {
+  margin: 0;
+  font-family: ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--term-fg, var(--text));
+  /* capture-pane -J joins wrapped lines back together; wrap them here like a
+     page would rather than growing a horizontal scrollbar. */
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.hist-msg {
+  padding: 18px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.hist-msg.error {
+  color: var(--red);
+}

--- a/frontend/src/components/grid/HistoryOverlay.tsx
+++ b/frontend/src/components/grid/HistoryOverlay.tsx
@@ -1,0 +1,580 @@
+/** Full-history overlay — browse a pane's whole tmux scrollback like a page.
+ *
+ * The live terminals mirror tmux: scrolled-back content is repainted in place
+ * (tmux copy-mode), so an xterm drag-selection can never extend past the top
+ * of the screen — the highlight is anchored to screen cells that tmux
+ * rewrites underneath it. This overlay is the answer: it fetches the pane's
+ * complete history (GET /api/instances/{title}/history, which falls back to
+ * the provider transcript for alt-screen TUIs) and renders it as native DOM
+ * text, so scrolling, drag-selecting past the viewport edge, and copying all
+ * behave exactly like a web page.
+ *
+ * Opened from the pane header's history button or by drag-selecting past the
+ * top edge of a live terminal (see attachDragHistoryGesture in
+ * lib/terminals). Esc or the × closes it. Copy mirrors the terminals' house
+ * rule: release the drag and the selection is already on the clipboard. */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { copyText } from "../../lib/clipboard";
+import type { DragScreenCtx } from "../../lib/terminals";
+import { toast } from "../../lib/toast";
+
+/** Caret under a viewport point, across the two DOM APIs. */
+function caretAt(x: number, y: number): { node: Node; offset: number } | null {
+  const doc = document as Document & {
+    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+  };
+  if (doc.caretRangeFromPoint) {
+    const r = doc.caretRangeFromPoint(x, y);
+    return r ? { node: r.startContainer, offset: r.startOffset } : null;
+  }
+  if (doc.caretPositionFromPoint) {
+    const p = doc.caretPositionFromPoint(x, y);
+    return p ? { node: p.offsetNode, offset: p.offset } : null;
+  }
+  return null;
+}
+
+function occurrences(text: string, needle: string): number[] {
+  const out: number[] = [];
+  let i = text.indexOf(needle);
+  while (i >= 0 && out.length < 50) {
+    out.push(i);
+    i = text.indexOf(needle, i + 1);
+  }
+  return out;
+}
+
+/** Locate the terminal's in-progress selection inside the captured history,
+ * returning the offset of the end the drag started from (bottom end for a
+ * top-edge drag, top end for a bottom-edge drag).
+ *
+ * The screen selection rarely matches the capture verbatim: xterm pads each
+ * row to the terminal width, the capture joins wrapped rows into one long
+ * line (capture-pane -J), and a drag past the bottom edge sweeps up the tmux
+ * status line, which is not pane content at all. So after trying the exact
+ * string, anchor on the first (bottom edge) / last (top edge) trimmed
+ * selection line that exists in the capture — a trimmed visual row is always
+ * a contiguous substring of its (possibly joined) captured line — using the
+ * neighbouring line to pick between duplicate hits. Falls back to the tail
+ * when nothing matches (alt-screen TUIs serve the provider transcript, whose
+ * text differs from the screen). */
+function findAnchor(
+  text: string,
+  sel: string,
+  edge: "top" | "bottom",
+  ctx: DragScreenCtx | null,
+  // The TUI's pinned-prompt row at gesture time ("❯ …"): the prompt that
+  // governs the visible section. The last-resort anchor — tool output on a
+  // TUI screen never reaches the transcript, but its prompt does.
+  ghost: string | null
+): { anchor: number; matched: boolean; frac?: number } {
+  // Best case: locate the whole visible screen block in the capture. It has
+  // far more signal than the selection alone, and knowing which captured
+  // line was which screen row lets the overlay open with the content parked
+  // exactly where the reader left it (same viewport fraction).
+  if (ctx) {
+    const tLines = text.split("\n");
+    const starts: number[] = [];
+    let off = 0;
+    for (const l of tLines) {
+      starts.push(off);
+      off += l.length + 1;
+    }
+    const usable: Array<[number, string]> = [];
+    ctx.screen.forEach((s, r) => {
+      const t = s.trim();
+      // Require real words, not just length: TUI chrome rows (╭───╮ borders,
+      // ─── separators) are long but can never match the capture/transcript,
+      // and they were crowding real text out of the candidate slots.
+      if (t.length >= 4 && (t.match(/[A-Za-z0-9]/g) || []).length >= 4)
+        usable.push([r, t]);
+    });
+    if (usable.length >= 2) {
+      // Base candidates: longest lines first (most distinctive), but try
+      // several — the longest screen line is often the tmux status bar,
+      // which is not pane content and has no hits at all.
+      const candidates = [...usable]
+        .sort((a, b) => b[1].length - a[1].length)
+        .slice(0, 8);
+      // The capture's last screen-worth of lines is the CURRENT frame. A
+      // scrolled-back TUI redraws OLD content there, so pure recency would
+      // anchor on that tail copy — a dead end for downward drags, with the
+      // TUI's bottom chrome right below it. On score ties, prefer a match
+      // that lies BEFORE the live frame; the tail copy only wins when it is
+      // the sole occurrence (a live, unscrolled screen).
+      const liveTailStart = Math.max(0, tLines.length - ctx.rows - 2);
+      let bestJ = -1,
+        bestScore = -1,
+        bestBase = 0;
+      for (const base of candidates) {
+        // Scan from the end (latest first) — re-run commands leave identical
+        // earlier copies in the history, and recency breaks those ties.
+        const hits: number[] = [];
+        for (let j = tLines.length - 1; j >= 0 && hits.length < 50; j--)
+          if (tLines[j].includes(base[1])) hits.push(j);
+        for (const j of hits) {
+          let score = 0;
+          for (const [r, s] of usable) {
+            if (r === base[0]) continue;
+            // ±3 lines of slack: capture-pane -J collapses wrapped rows (and
+            // a TUI's transcript fallback wraps/paces lines differently), so
+            // screen-row deltas only approximate captured-line deltas.
+            const at = j + (r - base[0]);
+            for (let d = -3; d <= 3; d++) {
+              const tl = tLines[at + d];
+              if (tl && tl.includes(s)) {
+                score++;
+                break;
+              }
+            }
+          }
+          const beats =
+            score > bestScore ||
+            (score === bestScore &&
+              bestJ >= liveTailStart &&
+              j < liveTailStart);
+          if (beats) {
+            bestScore = score;
+            bestJ = j;
+            bestBase = base[0];
+          }
+        }
+      }
+      if (bestJ >= 0 && bestScore >= Math.min(2, usable.length - 1)) {
+        let line = Math.max(
+          0,
+          Math.min(tLines.length - 1, bestJ + (ctx.row - bestBase))
+        );
+        // Row deltas drift by one per wrapped screen line between the base
+        // and the anchor (the capture joins wraps) — snap to the anchor
+        // row's own content nearby when it's distinctive enough.
+        const rowText = (ctx.screen[ctx.row] || "").trim();
+        if (rowText.length >= 4 && (rowText.match(/[A-Za-z0-9]/g) || []).length >= 4) {
+          for (const d of [0, -1, 1, -2, 2, -3, 3]) {
+            const tl = tLines[line + d];
+            if (tl && tl.includes(rowText)) {
+              line += d;
+              break;
+            }
+          }
+        }
+        return {
+          anchor: starts[line] + Math.min(ctx.col, tLines[line].length),
+          matched: true,
+          frac: ctx.rows > 0 ? ctx.row / ctx.rows : undefined,
+        };
+      }
+    }
+  }
+  if (sel) {
+    const exact = text.lastIndexOf(sel);
+    if (exact >= 0)
+      return { anchor: edge === "bottom" ? exact : exact + sel.length, matched: true };
+    const lines = sel
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length >= 4);
+    if (edge === "top") lines.reverse();
+    for (let i = 0; i < lines.length; i++) {
+      const hits = occurrences(text, lines[i]);
+      if (!hits.length) continue;
+      let hit = hits[hits.length - 1];
+      const buddy = lines[i + 1];
+      if (hits.length > 1 && buddy) {
+        for (const h of hits) {
+          const near =
+            edge === "bottom"
+              ? text.slice(h, h + lines[i].length + buddy.length + 400)
+              : text.slice(Math.max(0, h - buddy.length - 400), h + lines[i].length);
+          if (near.includes(buddy)) {
+            hit = h;
+            break;
+          }
+        }
+      }
+      return {
+        anchor: edge === "bottom" ? hit : hit + lines[i].length,
+        matched: true,
+      };
+    }
+  }
+  // Section fallback via the pinned prompt: anchor just past its end — the
+  // beginning of the section the reader was inside. Whitespace-stripped
+  // matching, since the row is width-wrapped and the transcript is not.
+  if (ghost) {
+    const want = ghost.replace(/[…]+\s*$/, "").replace(/\s+/g, "");
+    if (want.length >= 12) {
+      const map: number[] = [];
+      let stripped = "";
+      for (let i = 0; i < text.length; i++) {
+        const c = text.charCodeAt(i);
+        if (c !== 32 && c !== 10 && c !== 13 && c !== 9) {
+          stripped += text[i];
+          map.push(i);
+        }
+      }
+      const j = stripped.lastIndexOf(want);
+      if (j >= 0) {
+        return {
+          anchor: map[Math.min(j + want.length - 1, map.length - 1)] + 1,
+          matched: true,
+          frac: 0.15,
+        };
+      }
+    }
+  }
+  return { anchor: text.length, matched: false };
+}
+
+// Last-fetched history per pane, so a reopen renders instantly and the fresh
+// capture replaces it when it lands (stale-while-revalidate, like DiffTab).
+const histCache = new Map<string, string>();
+const HIST_CACHE_MAX = 8;
+
+export function HistoryOverlay({
+  title,
+  pane,
+  dragSelection,
+  dragEdge,
+  dragCtx,
+  dragGhost,
+  initialPos,
+  onClose,
+}: {
+  title: string;
+  pane: "agent" | "shell";
+  /** Non-null when opened by the drag-past-the-edge gesture, holding whatever
+   * the terminal had selected when the overlay took over: the same drag
+   * continues here — selection extends and the view auto-scrolls while the
+   * button stays down. Null when opened from the header button or wheel. */
+  dragSelection: string | null;
+  /** Which terminal edge the gesture crossed: "top" extends the selection
+   * upward from its end, "bottom" extends downward from its start. */
+  dragEdge: "top" | "bottom";
+  /** Visible-screen snapshot at gesture time (see DragScreenCtx) — lets the
+   * overlay open with the content parked where the reader left it. */
+  dragCtx: DragScreenCtx | null;
+  /** The TUI's pinned-prompt row at gesture time — anchor of last resort
+   * when the visible rows (tool output) aren't in the transcript. */
+  dragGhost: string | null;
+  /** Where the view opens: the tail by default, the very top for Ctrl+↑. */
+  initialPos: "top" | "bottom";
+  onClose: () => void;
+}) {
+  const [text, setText] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Scroll intent for the NEXT text commit: "bottom" follows the tail, "top"
+  // starts at the beginning (Ctrl+↑), {fromTop} keeps the reader's absolute
+  // position (a refresh landing while they browse — new output appends at
+  // the END, so distance-from-top is what holds their text still). Applied
+  // in the layout effect — scrollHeight is only correct after React commits
+  // the new text.
+  const pendingScroll = useRef<"top" | "bottom" | { fromTop: number } | null>(
+    initialPos
+  );
+
+  const load = useCallback(async () => {
+    const key = title + " " + pane;
+    let t: string;
+    try {
+      const r = await fetch(
+        `/api/instances/${encodeURIComponent(title)}/history?pane=${pane}`
+      );
+      if (!r.ok) throw new Error((await r.text()) || "HTTP " + r.status);
+      t = await r.text();
+    } catch (e) {
+      setError((e as Error).message || "history fetch failed");
+      return;
+    }
+    setError("");
+    histCache.delete(key);
+    histCache.set(key, t);
+    while (histCache.size > HIST_CACHE_MAX)
+      histCache.delete(histCache.keys().next().value!);
+    // Fresh capture replacing what's shown: follow the tail if the reader is
+    // there, otherwise hold their text still (fromTop). A still-pending
+    // initial intent ("top"/"bottom" not yet applied) wins.
+    const el = scrollRef.current;
+    if (pendingScroll.current == null) {
+      const atBottom =
+        !el || el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+      pendingScroll.current = atBottom ? "bottom" : { fromTop: el!.scrollTop };
+    }
+    setText(t);
+  }, [title, pane]);
+
+  useEffect(() => {
+    // Cached history renders instantly; the fetch below revalidates it.
+    pendingScroll.current = initialPos;
+    setText(histCache.get(title + " " + pane) ?? null);
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [load, title, pane]);
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    const want = pendingScroll.current;
+    if (!el || want == null || text == null) return;
+    pendingScroll.current = null;
+    el.scrollTop =
+      want === "top" ? 0 : want === "bottom" ? el.scrollHeight : want.fromTop;
+  }, [text]);
+
+  // Live tail: re-capture every few seconds while open, so the page never
+  // goes stale — scrolling to the bottom always reaches the present. Skipped
+  // while the reader is mid-press or has text selected (a refresh would
+  // shift the text under their highlight).
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (pressAt.current) return;
+      const sel = window.getSelection?.();
+      if (sel && !sel.isCollapsed && sel.toString().trim()) return;
+      load();
+    }, 3000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [load]);
+
+  // --- Mid-drag continuation --------------------------------------------
+  // Opened by the gesture, the button may still be down. Track it from mount
+  // (history takes a beat to fetch; a released button must not start a
+  // phantom drag), and suppress the scroller's own copy-on-release when the
+  // continuation's finish handler already copied.
+  const buttonDown = useRef(dragSelection != null);
+  const suppressElementCopy = useRef(false);
+  useEffect(() => {
+    if (dragSelection == null) return;
+    const up = () => {
+      buttonDown.current = false;
+    };
+    window.addEventListener("mouseup", up, true);
+    return () => window.removeEventListener("mouseup", up, true);
+  }, [dragSelection]);
+
+  const contStarted = useRef(false);
+  useEffect(() => {
+    if (text == null || dragSelection == null || contStarted.current) return;
+    contStarted.current = true;
+    const el = scrollRef.current;
+    const node = el?.querySelector("pre")?.firstChild;
+    if (!el || !node || node.nodeType !== Node.TEXT_NODE) return;
+    // Anchor where the terminal drag started: for a top-edge drag that is
+    // the bottom end of what was already selected, for a bottom-edge drag
+    // the top end. Falls back to the tail when nothing matched (alt-screen
+    // TUIs serve the provider transcript, whose text differs from the
+    // screen).
+    const { anchor, matched, frac } = findAnchor(
+      text,
+      dragSelection,
+      dragEdge,
+      dragCtx,
+      dragGhost
+    );
+    // Bring the anchor into view — with the terminal scrolled back, the
+    // selection lives mid-history and the default tail-follow would teleport
+    // the reader away from it. When the screen block was located, park the
+    // anchor at the same viewport fraction it had in the terminal, so the
+    // page reads as "didn't move"; otherwise leave room to grow in the drag
+    // direction. Runs even if the button was already released: the reader's
+    // place matters either way.
+    if (matched) {
+      try {
+        const r = document.createRange();
+        r.setStart(node, Math.min(anchor, text.length));
+        r.collapse(true);
+        const rr = r.getBoundingClientRect();
+        const er = el.getBoundingClientRect();
+        const park = frac ?? (dragEdge === "bottom" ? 0.3 : 0.7);
+        el.scrollTop += rr.top - (er.top + er.height * park);
+      } catch {
+        /* keep the tail position */
+      }
+    }
+    if (!buttonDown.current) return; // released before the history arrived
+    let live = true;
+    let raf = 0;
+    // Until the first real mousemove, assume the pointer sits just past the
+    // edge that fired, so scrolling starts at once.
+    const rect0 = el.getBoundingClientRect();
+    let px = rect0.left + rect0.width / 2;
+    let py = dragEdge === "bottom" ? rect0.bottom + 24 : rect0.top - 24;
+    const extend = () => {
+      const r = el.getBoundingClientRect();
+      const c = caretAt(
+        Math.max(r.left + 4, Math.min(r.right - 4, px)),
+        Math.max(r.top + 4, Math.min(r.bottom - 4, py))
+      );
+      const sel = window.getSelection();
+      if (!c || !sel) return;
+      try {
+        sel.setBaseAndExtent(node, anchor, c.node, c.offset);
+      } catch {
+        /* caret landed outside the text node tree */
+      }
+    };
+    // Browser-style edge autoscroll: scrolling starts while the pointer is
+    // still INSIDE the view but near its edge (EDGE px), speeding up the
+    // further past the threshold it goes — holding on the last visible line
+    // must keep scrolling, not require pushing outside the pane.
+    const EDGE = 24;
+    const tick = () => {
+      if (!live) return;
+      const r = el.getBoundingClientRect();
+      const topZone = r.top + EDGE;
+      const bottomZone = r.bottom - EDGE;
+      if (py < topZone) el.scrollTop -= Math.min(64, 4 + (topZone - py) * 0.3);
+      else if (py > bottomZone) el.scrollTop += Math.min(64, 4 + (py - bottomZone) * 0.3);
+      extend();
+      raf = requestAnimationFrame(tick);
+    };
+    const onMove = (ev: MouseEvent) => {
+      px = ev.clientX;
+      py = ev.clientY;
+    };
+    const stop = () => {
+      live = false;
+      cancelAnimationFrame(raf);
+      window.removeEventListener("mousemove", onMove, true);
+      window.removeEventListener("mouseup", finish, true);
+    };
+    const finish = () => {
+      stop();
+      suppressElementCopy.current = true;
+      setTimeout(() => {
+        const s = window.getSelection()?.toString() || "";
+        if (s.trim())
+          copyText(s).then((ok) => {
+            if (ok) toast("Copied " + s.length + " chars");
+          });
+        suppressElementCopy.current = false;
+      }, 0);
+    };
+    window.addEventListener("mousemove", onMove, true);
+    window.addEventListener("mouseup", finish, true);
+    raf = requestAnimationFrame(tick);
+    return stop;
+  }, [text, dragSelection, dragEdge, dragCtx, dragGhost]);
+
+  // Esc closes; Ctrl+↑ / Ctrl+↓ jump to the very top / bottom. Capture-phase
+  // so neither the focused xterm nor the global keymap sees the keystrokes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+        e.preventDefault();
+        e.stopPropagation();
+        const el = scrollRef.current;
+        if (el) el.scrollTop = e.key === "ArrowUp" ? 0 : el.scrollHeight;
+      }
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  // Same contract as the terminals: drag to select, release to copy.
+  const copyOnRelease = () => {
+    if (suppressElementCopy.current) return; // continuation already copied
+    setTimeout(() => {
+      const sel = window.getSelection?.()?.toString() || "";
+      if (!sel.trim()) return;
+      copyText(sel).then((ok) => {
+        if (ok) toast("Copied " + sel.length + " chars");
+      });
+    }, 0);
+  };
+
+  // Click semantics, matching what hands already expect from text: a click
+  // with text highlighted just deselects (you stay right where you are); a
+  // click with nothing highlighted returns to the live terminal. A drag is
+  // never a click (movement check), and the gesture's own release can't
+  // trigger this (its mousedown landed on the terminal, so no press start is
+  // recorded here).
+  const pressAt = useRef<{ x: number; y: number; hadSelection: boolean } | null>(null);
+  const onRootMouseDown = (e: React.MouseEvent) => {
+    if (e.button !== 0) {
+      pressAt.current = null;
+      return;
+    }
+    const sel = window.getSelection?.();
+    const hadSelection = !!(sel && !sel.isCollapsed && sel.toString().trim());
+    // Shift+click extends the selection from what's already highlighted to
+    // the click point (the release copies it, per the house rule). Done by
+    // hand: our collapse-on-press below would otherwise eat the browser's
+    // native extension.
+    if (e.shiftKey && hadSelection && sel) {
+      e.preventDefault();
+      const c = caretAt(e.clientX, e.clientY);
+      if (c) {
+        try {
+          sel.extend(c.node, c.offset);
+        } catch {
+          /* caret outside the text node tree */
+        }
+      }
+      pressAt.current = null; // never a "return" click
+      return;
+    }
+    pressAt.current = {
+      x: e.clientX,
+      y: e.clientY,
+      hadSelection,
+    };
+    // Pressing on already-selected text would start a native text
+    // drag-and-drop, silently keeping the OLD selection (and re-copying it on
+    // release). Collapse first so every new drag selects afresh — which is
+    // also the "click deselects" half of the contract above.
+    sel?.removeAllRanges();
+  };
+  const onRootMouseUp = (e: React.MouseEvent) => {
+    const p = pressAt.current;
+    pressAt.current = null;
+    if (!p || e.button !== 0) return;
+    if (Math.abs(e.clientX - p.x) > 4 || Math.abs(e.clientY - p.y) > 4) return;
+    if (p.hadSelection) return; // this click's job was deselecting
+    // After the browser settles: if the click somehow produced a selection
+    // (double-click word select settling late), it wasn't a "return" click.
+    setTimeout(() => {
+      const sel = window.getSelection?.();
+      if (sel && !sel.isCollapsed && sel.toString().trim()) return;
+      onClose();
+    }, 0);
+  };
+
+  return (
+    <div
+      className="hist-overlay"
+      role="region"
+      aria-label="Full pane history"
+      onMouseDown={onRootMouseDown}
+      onMouseUp={onRootMouseUp}
+      onDragStart={(e) => e.preventDefault()}
+    >
+      <div className="hist-bar">
+        <span className="hist-title">
+          Full {pane === "shell" ? "terminal" : "agent"} history
+        </span>
+        <span className="hist-hint">
+          drag to select · release to copy · Ctrl+↑/↓ top/bottom · click or Esc returns to live
+        </span>
+      </div>
+      <div className="hist-scroll" ref={scrollRef} onMouseUp={copyOnRelease}>
+        {error ? (
+          <div className="hist-msg error">{error}</div>
+        ) : text === null ? (
+          <div className="hist-msg">Loading history…</div>
+        ) : text.trim() ? (
+          <pre>{text}</pre>
+        ) : (
+          <div className="hist-msg">No history yet.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/grid/Pane.css
+++ b/frontend/src/components/grid/Pane.css
@@ -230,6 +230,91 @@
   position: relative;
 }
 
+/* The agent pane is a column: the pinned prompt (when present) on top, the
+   terminal filling the rest. FitAddon measures .term-container, so the flex
+   sizing is what makes the terminal shrink to make room for the pin. */
+.pane-term.agent-term {
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-term.agent-term > .term-container {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Pinned prompt: first line of the session's latest user prompt. Bleeds to
+   the pane edges (negative margins swallow .pane-term's padding) so it reads
+   as a header, not content. */
+.prompt-pin {
+  flex: none;
+  position: relative; /* anchors .ghost-row-mask */
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin: -6px -8px 6px;
+  padding: 4px 10px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+}
+
+/* Covers the terminal's own pinned-prompt row (the TUI keeps drawing it in
+   the PTY, shared with mobile) while the bar above mirrors its text: the
+   6px pane gap plus one terminal row of terminal background. */
+.prompt-pin .ghost-row-mask {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 23px;
+  background: var(--term-bg, var(--bg));
+  pointer-events: none;
+  /* Above xterm's own layers (which form their own stacking contexts) but
+     below the boot loader (3) and pane overlays. */
+  z-index: 2;
+}
+
+.prompt-pin .prompt-pin-mark {
+  flex: none;
+  background: none;
+  border: none;
+  padding: 0 2px;
+  cursor: pointer;
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 11px;
+  line-height: inherit;
+  transition: transform 0.12s ease;
+}
+
+.prompt-pin.pin-open .prompt-pin-mark {
+  transform: rotate(90deg);
+}
+
+.prompt-pin .prompt-pin-text {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The whole prompt, in-flow (the terminal refits beneath it). Capped at a
+   few lines with its own scrollbar so a long prompt can't eat the pane. */
+.prompt-pin .prompt-pin-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-height: 110px;
+  overflow-y: auto;
+  color: var(--text);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  user-select: text;
+  cursor: text;
+}
+
 .pane-term .xterm {
   height: 100%;
 }

--- a/frontend/src/components/grid/Pane.tsx
+++ b/frontend/src/components/grid/Pane.tsx
@@ -13,11 +13,18 @@ import { copyText } from "../../lib/clipboard";
 import { fmtUsd, displayBranch } from "../../lib/format";
 import { chipState, fastTrackStep, liveStep, nextStep } from "../../lib/stage";
 import { cleanupMissing, selectSession } from "../../lib/sessionActions";
-import { getTerm, peekTerm, type TermHandle } from "../../lib/terminals";
+import {
+  focusTerm,
+  getTerm,
+  peekTerm,
+  type DragScreenCtx,
+  type TermHandle,
+} from "../../lib/terminals";
 import { toast } from "../../lib/toast";
 import { dropSideFor, type DropSide } from "./layout";
 import type { DragCtx } from "./TerminalGrid";
 import { DiffTab } from "./DiffTab";
+import { HistoryOverlay } from "./HistoryOverlay";
 import { QueueTab } from "./QueueTab";
 import { SessionUsageChip } from "../usage/SessionUsageChip";
 
@@ -67,6 +74,22 @@ export function Pane({
   const [booted, setBooted] = useState(false);
   const [wsState, setWsState] = useState("connecting");
   const [shellStarted, setShellStarted] = useState(savedTab === "shell");
+  // Which pane's full-history overlay is open (null = closed). Opened by the
+  // header history button or Ctrl+↑/↓ (dragSel null), or by drag-selecting
+  // past a terminal edge — dragSel then carries the terminal's in-progress
+  // selection (and edge which end of it) so the overlay continues the same
+  // drag seamlessly. pos picks where the view opens (Ctrl+↑ starts at the
+  // very top).
+  const [histPane, setHistPane] = useState<{
+    kind: "agent" | "shell";
+    dragSel: string | null;
+    edge?: "top" | "bottom";
+    pos?: "top" | "bottom";
+    ctx?: DragScreenCtx;
+    /** The TUI's pinned-prompt row at gesture time — the anchor of last
+     * resort when the visible rows (tool output) aren't in the transcript. */
+    ghostSel?: string | null;
+  } | null>(null);
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const fitTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -78,6 +101,20 @@ export function Pane({
       if (!el || missing || loading) return;
       const handle = getTerm(title, kind);
       if (!el.contains(handle.container)) el.appendChild(handle.container);
+      handle.onHistoryDrag = (sel, edge, ctx) =>
+        setHistPane({ kind, dragSel: sel, edge, ctx, ghostSel: ghostRef.current });
+      if (kind === "agent") {
+        // The agent TUI pins its own contextual prompt row ("❯ …") at the top
+        // while scrolled back. Lift its text into the prompt bar (so the bar
+        // tracks what you're LOOKING at, not just the latest prompt) and let
+        // the render mask the duplicate row on desktop.
+        handle.onTopRow = (t) => {
+          const m = /^\s*[❯>]\s+(.+)$/.exec(t);
+          const g = m && m[1].trim() ? m[1].trim() : null;
+          ghostRef.current = g; // adopt()'s closures are stale — ref, not state
+          setGhost(g);
+        };
+      }
       if (kind === "agent") {
         handle.onState = (s) => setWsState(s);
         handle.onBoot = () => setBooted(true);
@@ -106,6 +143,89 @@ export function Pane({
     obs.observe(bodyRef.current);
     return () => obs.disconnect();
   }, [fitSoon, missing, loading]);
+
+  // Whether the pinned prompt shows its whole body. Collapsed to one line by
+  // default; ONLY the arrow toggles it — no hover magic.
+  const [pinOpen, setPinOpen] = useState(false);
+  // The agent TUI's own pinned-prompt row text, when its top row shows one
+  // (scrolled back in Claude Code). Non-null → the bar mirrors it and the
+  // duplicate row is masked. The ref mirrors the state for adopt()'s stale
+  // closures (the gesture handler reads it at fire time).
+  const [ghost, setGhost] = useState<string | null>(null);
+  const ghostRef = useRef<string | null>(null);
+
+  // What the bar shows: the TUI's contextual prompt while scrolled back (it
+  // tracks the section you're reading), the session's latest prompt at live.
+  const ghostCore = (ghost || "").replace(/[…]+\s*$/, "").replace(/\s+/g, " ").trim();
+  const fullNorm = (inst.last_prompt_full || "").replace(/\s+/g, " ");
+  const ghostIsLatest = !ghost || (!!fullNorm && fullNorm.includes(ghostCore.slice(0, 80)));
+  const pinLine = ghost ?? inst.last_prompt;
+
+  // Expanding an OLDER prompt (the ghost isn't the latest) needs its full
+  // body looked up server-side — only the latest prompt's body rides the
+  // snapshot. The ghost's own width-truncated text shows while it loads.
+  const [lookup, setLookup] = useState<{ q: string; text: string } | null>(null);
+  useEffect(() => {
+    if (!pinOpen || ghostIsLatest || ghostCore.length < 8) return;
+    if (lookup?.q === ghostCore) return;
+    let dead = false;
+    fetch(
+      `/api/instances/${encodeURIComponent(title)}/prompt?q=${encodeURIComponent(ghostCore)}`
+    )
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j: { text?: string | null } | null) => {
+        if (!dead && j?.text) setLookup({ q: ghostCore, text: j.text });
+      })
+      .catch(() => {});
+    return () => {
+      dead = true;
+    };
+  }, [pinOpen, ghostIsLatest, ghostCore, title, lookup]);
+
+  const pinBody = ghostIsLatest
+    ? inst.last_prompt_full || inst.last_prompt
+    : lookup?.q === ghostCore
+      ? lookup.text
+      : ghost;
+
+  // The pinned prompt is in-flow, so any change to its height — appearing,
+  // collapsing, or the prompt text itself changing — resizes the terminal
+  // without touching .pane-body, and the ResizeObserver above never fires.
+  const hasPin = !!pinLine;
+  const pinLen = (pinBody || "").length;
+  useEffect(() => {
+    fitSoon();
+  }, [hasPin, pinOpen, pinLen, fitSoon]);
+
+  // Ctrl+↑ / Ctrl+↓ on the focused pane opens the full-history view (at the
+  // top / bottom respectively). Once it's open its own handler owns these
+  // keys for in-view jumps, so this only fires from normal mode. Capture
+  // phase so it wins over xterm; real text fields keep their arrows (the
+  // terminal's hidden textarea is exempt — that IS the normal-mode case).
+  useEffect(() => {
+    if (!focused || missing || loading || histPane) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.ctrlKey || e.metaKey) || e.altKey) return;
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      const a = document.activeElement;
+      const editing =
+        a &&
+        (a.tagName === "INPUT" ||
+          a.tagName === "TEXTAREA" ||
+          a.tagName === "SELECT" ||
+          (a as HTMLElement).isContentEditable === true);
+      if (editing && !a.closest(".xterm")) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setHistPane({
+        kind: tab === "shell" ? "shell" : "agent",
+        dragSel: null,
+        pos: e.key === "ArrowUp" ? "top" : "bottom",
+      });
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [focused, missing, loading, histPane, tab]);
 
   const showTab = (t: Tab) => {
     setTab(t);
@@ -367,6 +487,31 @@ export function Pane({
         <button
           className="act copyhist"
           type="button"
+          title="Browse the full history — scroll & select like a page (or drag a selection past the top of the terminal)"
+          onClick={(e) => {
+            e.stopPropagation();
+            setHistPane({ kind: tab === "shell" ? "shell" : "agent", dragSel: null });
+          }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 8v4l2 2" />
+            <path d="M3.05 11a9 9 0 1 1 .5 4" />
+            <path d="M3 22v-6h6" />
+          </svg>
+        </button>
+        <button
+          className="act copyhist"
+          type="button"
           title="Copy this pane's whole history to the clipboard"
           onClick={(e) => {
             e.stopPropagation();
@@ -409,6 +554,38 @@ export function Pane({
       </div>
       <div className="pane-body" ref={bodyRef}>
         <div className={"pane-term agent-term" + (tab !== "agent" ? " hidden" : "")} ref={adopt("agent")}>
+          {/* Pinned prompt: what this session was last asked to do, always
+              visible while the output scrolls beneath it (the behavior the
+              mobile view's short screen gives for free). One line by default;
+              clicking the arrow — and only the arrow, no hover — expands the
+              whole prompt in-flow, capped at a few lines with its own
+              scrollbar. Rendered before the terminal container adopt()
+              appends, so it sits above the terminal in the flex column. */}
+          {pinLine ? (
+            <div className={"prompt-pin" + (pinOpen ? " pin-open" : "")}>
+              <button
+                type="button"
+                className="prompt-pin-mark"
+                aria-expanded={pinOpen}
+                title={pinOpen ? "Collapse to one line" : "Show the whole prompt"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setPinOpen((v) => !v);
+                }}
+              >
+                ❯
+              </button>
+              {pinOpen ? (
+                <div className="prompt-pin-body">{pinBody}</div>
+              ) : (
+                <span className="prompt-pin-text">{pinLine}</span>
+              )}
+              {/* While the TUI's own pinned row is being mirrored above, hide
+                  the duplicate: a strip of terminal background over the top
+                  row (desktop only by construction — mobile has no bar). */}
+              {ghost ? <div className="ghost-row-mask" aria-hidden="true" /> : null}
+            </div>
+          ) : null}
           {!booted && (
             <div className="term-loading">
               <div className="spinner" />
@@ -429,6 +606,25 @@ export function Pane({
         <div className={"pane-queue" + (tab !== "queue" ? " hidden" : "")}>
           <QueueTab title={title} active={tab === "queue"} />
         </div>
+        {histPane && (
+          <HistoryOverlay
+            title={title}
+            pane={histPane.kind}
+            dragSelection={histPane.dragSel}
+            dragEdge={histPane.edge ?? "top"}
+            dragCtx={histPane.ctx ?? null}
+            dragGhost={histPane.ghostSel ?? null}
+            initialPos={histPane.pos ?? "bottom"}
+            onClose={() => {
+              const kind = histPane.kind;
+              setHistPane(null);
+              // Hand the keyboard straight back to the terminal the overlay
+              // covered — closing should feel like returning, not leaving.
+              selectSession(title, { noKeyboard: true });
+              setTimeout(() => focusTerm(title, kind), 0);
+            }}
+          />
+        )}
         {reduceMotion && chip.cls === "s-running" && tab === "agent" && (
           <RunningCover paneRef={paneRef} />
         )}

--- a/frontend/src/lib/terminals.ts
+++ b/frontend/src/lib/terminals.ts
@@ -29,6 +29,14 @@ export interface TermHandle {
   /** Send raw data straight to the PTY (voice dictation etc.); false when
    * the socket isn't open. */
   send(data: string): boolean;
+  /** Re-assert this viewport's size to tmux even if unchanged on this
+   * connection. Sessions run `window-size latest`, so ANOTHER attached
+   * client (a second browser, a phone, a stale tab) can yank the window to
+   * its own size; the "only send on change" guard in doFit then leaves this
+   * pane drawing at the wrong width forever. Called when this client is the
+   * one being looked at (focus / tab visible), so the window follows the
+   * client you're using instead of the last one to attach. */
+  resync(): void;
   /** Live connection state:
    * "connecting" | "connected" | "disconnected" | "error" | "gone".
    * "connecting" is only the pre-first-open state; reconnects stay
@@ -41,6 +49,31 @@ export interface TermHandle {
    * terminal lifetime, so a pane that remounts (grid drag/reorder) must read
    * this to know the cover should already be hidden. */
   readonly booted: boolean;
+  /** Fired when a selection drag pushes past the top or bottom of the
+   * terminal — the "keep dragging and more content loads" webpage gesture.
+   * The pane answers by opening its full-history overlay (an xterm selection
+   * can't extend into tmux history: tmux repaints scrolled content in place,
+   * under the highlight's screen-cell anchors). Receives whatever the
+   * terminal had selected so far, which edge fired, and a snapshot of the
+   * visible screen (plus where the selection's anchor end sits in it), so
+   * the overlay can continue the same selection seamlessly — positioned so
+   * the content stays where the reader left it — while the button is still
+   * held. */
+  onHistoryDrag?: (selection: string, edge: "top" | "bottom", ctx?: DragScreenCtx) => void;
+  /** Fired (debounced) with the terminal's top visible row after each
+   * repaint. The pane watches it for the agent TUI's own pinned-prompt row
+   * ("❯ …" while scrolled back) so the desktop prompt bar can mirror that
+   * contextual text and mask the duplicate row. */
+  onTopRow?: (text: string) => void;
+}
+
+/** The visible screen at gesture time: its rows (right-trimmed), and the
+ * viewport row/column of the selection end the drag started from. */
+export interface DragScreenCtx {
+  screen: string[];
+  rows: number;
+  row: number;
+  col: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +364,56 @@ function attachWheelScroll(host: HTMLElement, term: Terminal, getWs: () => WebSo
   );
 }
 
+// Drag-past-the-edge → history gesture. A left-button drag that starts in
+// the terminal and holds past its top (or bottom) edge for a beat reads as
+// "keep scrolling, I want more than the screen holds" — the browser gesture
+// for extending a selection beyond the viewport. We can't honor it in xterm
+// (tmux repaints history in place, so the selection anchors point at
+// rewritten cells); instead it fires once per drag and the pane opens the
+// full-history overlay. The hold delay keeps an overshoot while selecting an
+// edge line from triggering it.
+function attachDragHistoryGesture(
+  host: HTMLElement,
+  fire: (edge: "top" | "bottom") => void
+) {
+  const HOLD_MS = 220;
+  const MARGIN = 8; // px past the top edge before the hold timer arms
+  // The bottom zone starts INSIDE the terminal: its last visible row is the
+  // tmux status bar, so a downward selection drag naturally comes to rest ON
+  // that row, never 8px past the container — requiring "outside only" made
+  // the downward gesture nearly impossible to hit in practice.
+  const BOTTOM_ZONE = 18;
+  host.addEventListener("mousedown", (down: MouseEvent) => {
+    if (down.button !== 0) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onMove = (ev: MouseEvent) => {
+      const r = host.getBoundingClientRect();
+      const edge: "top" | "bottom" | null =
+        ev.clientY < r.top - MARGIN
+          ? "top"
+          : ev.clientY > r.bottom - BOTTOM_ZONE
+            ? "bottom"
+            : null;
+      if (edge && timer === undefined) {
+        timer = setTimeout(() => {
+          cleanup();
+          fire(edge);
+        }, HOLD_MS);
+      } else if (!edge && timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    };
+    const cleanup = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      window.removeEventListener("mousemove", onMove, true);
+      window.removeEventListener("mouseup", cleanup, true);
+    };
+    window.addEventListener("mousemove", onMove, true);
+    window.addEventListener("mouseup", cleanup, true);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Terminal handle (port of mkTerm) + registry
 // ---------------------------------------------------------------------------
@@ -361,6 +444,61 @@ function makeTerm(
   term.loadAddon(fit);
   term.open(container);
   attachCopyOnSelect(container, term, { session: title });
+  // Clicking into a terminal makes this client the one in use — claim the
+  // tmux window size for it (see resync).
+  container.addEventListener("focusin", () => handle.resync());
+  attachDragHistoryGesture(container, (edge) => {
+    let ctx: DragScreenCtx | undefined;
+    try {
+      const buf = term.buffer.active;
+      const rows = term.rows || 24;
+      const screen: string[] = [];
+      for (let r = 0; r < rows; r++)
+        screen.push(buf.getLine(buf.viewportY + r)?.translateToString(true) ?? "");
+      // The anchor end of the selection — where the drag STARTED: its top
+      // end when dragging down (bottom edge), its bottom end dragging up.
+      const p = term.getSelectionPosition();
+      const side = edge === "bottom" ? p?.start : p?.end;
+      const row = side
+        ? Math.max(0, Math.min(rows - 1, side.y - buf.viewportY))
+        : edge === "bottom"
+          ? 0
+          : rows - 1;
+      ctx = { screen, rows, row, col: side?.x ?? 0 };
+    } catch {
+      /* buffer API moved: the overlay falls back to selection matching */
+    }
+    handle.onHistoryDrag?.(term.getSelection() || "", edge, ctx);
+  });
+  // Top-row watcher (see TermHandle.onTopRow). THROTTLED, not debounced: a
+  // streaming turn renders continuously, and a trailing debounce would never
+  // settle — the watcher then missed the TUI's pinned row for the whole
+  // stream. Leading edge fires immediately; the trailing timer catches the
+  // final state after a burst.
+  let topRowAt = 0;
+  let topRowTimer: ReturnType<typeof setTimeout> | undefined;
+  const emitTopRow = () => {
+    if (!handle.onTopRow) return;
+    try {
+      const buf = term.buffer.active;
+      handle.onTopRow(buf.getLine(buf.viewportY)?.translateToString(true) ?? "");
+    } catch {
+      /* buffer API moved */
+    }
+  };
+  term.onRender(() => {
+    const now = performance.now();
+    clearTimeout(topRowTimer);
+    if (now - topRowAt > 150) {
+      topRowAt = now;
+      emitTopRow();
+    } else {
+      topRowTimer = setTimeout(() => {
+        topRowAt = performance.now();
+        emitTopRow();
+      }, 160);
+    }
+  });
 
   let ws: WebSocket | null = null;
   let sentSize = "";
@@ -390,6 +528,10 @@ function makeTerm(
         return true;
       }
       return false;
+    },
+    resync() {
+      sentSize = "";
+      handle.doFit();
     },
     doFit() {
       // Skip while hidden/zero-sized — fitting then locks in a 1x1 grid.
@@ -555,6 +697,23 @@ export function fitAll() {
     entry.agent?.doFit();
     entry.shell?.doFit();
   }
+}
+
+/** Re-assert every live terminal's size (see TermHandle.resync). */
+export function resyncAll() {
+  for (const entry of registry.values()) {
+    entry.agent?.resync();
+    entry.shell?.resync();
+  }
+}
+
+// Coming back to this tab makes it the client in use: reclaim the tmux window
+// size for it. Only one tab is visible at a time, so this can't ping-pong the
+// way an unconditional periodic re-send would.
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) resyncAll();
+  });
 }
 
 /** Focus the logical terminal for a session (agent pane by default). */

--- a/tests/unit/test_claude_provider.py
+++ b/tests/unit/test_claude_provider.py
@@ -1506,3 +1506,84 @@ def test_last_turn_cache_put_evicts_when_full():
     _last_turn_cache_put("wd-overflow", {"checked": 0.0, "sig": None, "snippet": None})
     assert len(_claude_mod._LAST_TURN_CACHE) <= maxn // 2 + 1
     assert "wd-overflow" in _claude_mod._LAST_TURN_CACHE
+
+
+# --------------------------------------------------------------------------- #
+# Per-WINDOW transcript selection: sibling sessions sharing one directory all
+# write into the same projects/<cwd-slug>/ dir, so "newest .jsonl" is whoever
+# typed last. The window's thread marker names its own conversation.
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def two_windows(fake_home, tmp_path, monkeypatch):
+    """A workdir holding two conversations, one per window, with the SECOND
+    (``other``) written last so mtime alone would always pick it."""
+    import os
+
+    monkeypatch.setenv("MINDFLOCK_THREAD_MARKER_DIR", str(tmp_path / "threads"))
+    workdir = "/work/shared"
+    _write_transcript(
+        fake_home,
+        workdir,
+        [{"type": "user", "message": {"content": "mine: fix the parser"}}],
+        fname="aaaa-1111.jsonl",
+    )
+    _write_transcript(
+        fake_home,
+        workdir,
+        [{"type": "user", "message": {"content": "theirs: bump the deps"}}],
+        fname="bbbb-2222.jsonl",
+    )
+    proj = fake_home / ".claude" / "projects" / _encode(workdir)
+    os.utime(proj / "aaaa-1111.jsonl", (1000, 1000))  # older than its sibling
+    os.utime(proj / "bbbb-2222.jsonl", (2000, 2000))
+    thread_markers.record("mindflock_mine", "aaaa-1111")
+    thread_markers.record("mindflock_theirs", "bbbb-2222")
+    return workdir, proj
+
+
+def test_session_transcript_prefers_this_windows_thread_marker(two_windows):
+    workdir, proj = two_windows
+    # Path-keyed selection always lands on the sibling that wrote last...
+    assert _claude_mod._newest_transcript(workdir)[2] == str(proj / "bbbb-2222.jsonl")
+    # ...while each window gets its OWN conversation.
+    assert _claude_mod._session_transcript(workdir, "mindflock_mine")[2] == str(
+        proj / "aaaa-1111.jsonl"
+    )
+    assert _claude_mod._session_transcript(workdir, "mindflock_theirs")[2] == str(
+        proj / "bbbb-2222.jsonl"
+    )
+
+
+def test_session_transcript_falls_back_without_a_usable_marker(two_windows):
+    workdir, proj = two_windows
+    newest = str(proj / "bbbb-2222.jsonl")
+    # No session name, no marker for the name, and a marker naming a file that
+    # is gone all fall back to the newest transcript.
+    assert _claude_mod._session_transcript(workdir, "")[2] == newest
+    assert _claude_mod._session_transcript(workdir, "mindflock_hookless")[2] == newest
+    (proj / "aaaa-1111.jsonl").unlink()
+    assert _claude_mod._session_transcript(workdir, "mindflock_mine")[2] == newest
+
+
+def test_last_prompt_snippet_is_per_window_not_per_workdir(two_windows):
+    workdir, _ = two_windows
+    provider = ClaudeProvider()
+    # Both calls happen inside the cache TTL: the session name is part of the
+    # cache key, so the first window's answer can't be served to the second.
+    assert provider.last_prompt_snippet("mindflock_mine", workdir) == (
+        "mine: fix the parser"
+    )
+    assert provider.last_prompt_snippet("mindflock_theirs", workdir) == (
+        "theirs: bump the deps"
+    )
+    assert provider.last_prompt_full("mindflock_mine", workdir) == (
+        "mine: fix the parser"
+    )
+    assert provider.last_turn_snippet("mindflock_mine", workdir) == (
+        "mine: fix the parser"
+    )
+    assert provider.find_prompt_full("mindflock_mine", workdir, "mine: fix") == (
+        "mine: fix the parser"
+    )
+    # The other window's prompt is not reachable from this window.
+    assert provider.find_prompt_full("mindflock_mine", workdir, "theirs: bump") is None

--- a/tests/unit/test_server_routes.py
+++ b/tests/unit/test_server_routes.py
@@ -1409,13 +1409,19 @@ def test_pane_history_no_live_shell_session(registered, monkeypatch):
 def test_pane_history_falls_back_to_transcript(registered, monkeypatch):
     registered("ph-2", wt="/tmp/x")
     monkeypatch.setattr(server, "_live_session_name", lambda base: None)
+    seen = []
     monkeypatch.setattr(
-        server, "_agent_transcript_text", lambda wt: "recovered transcript"
+        server,
+        "_agent_transcript_text",
+        lambda wt, name="": (seen.append((wt, name)), "recovered transcript")[1],
     )
     # Agent pane, session gone -> the on-disk transcript is served instead of 404.
     r = client.get("/api/instances/ph-2/history")
     assert r.status_code == 200
     assert r.text == "recovered transcript"
+    # Looked up by THIS window's tmux session, not by the worktree alone —
+    # siblings sharing a directory each have their own conversation.
+    assert seen == [("/tmp/x", server.tmux.to_mindflock_tmux_name("ph-2"))]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_wave5_backend.py
+++ b/tests/unit/test_wave5_backend.py
@@ -607,7 +607,9 @@ def test_last_turn_snippet_mtime_guarded_cache(home, tmp_path):
     )
     assert prov.last_turn_snippet("s", wd) == "first"
     # Once the TTL lapses (simulated), the changed mtime/size triggers a re-read.
-    claude._LAST_TURN_CACHE[wd]["checked"] -= claude._LAST_TURN_TTL + 1
+    # The cache is keyed per WINDOW (workdir + tmux session name): siblings
+    # sharing a directory read different transcripts.
+    claude._LAST_TURN_CACHE[wd + "\x00s"]["checked"] -= claude._LAST_TURN_TTL + 1
     assert prov.last_turn_snippet("s", wd) == "second"
 
 


### PR DESCRIPTION
Two questions cost a scroll-hunt through a redrawing TUI: "what did I ask this
window to do?" and "what did it say ten minutes ago?" Both are answered from
the provider transcript now.

The pane header grows a pinned prompt line — the newest thing the human typed
into that session, one line, expandable to the whole body with the arrow.
While the agent is scrolled back, Claude Code pins its own contextual "❯ …"
row at the top; the bar mirrors THAT instead (so it tracks the section you are
reading, not just the latest turn) and masks the duplicate row. Expanding an
older prompt looks its body up through the new
GET /api/instances/{title}/prompt?q=<truncated line>, since only the latest
prompt's full text rides the session snapshot.

The full history becomes a real page (HistoryOverlay). The agent TUI redraws
in place, so its tmux capture is fragments plus the current frame, and an
xterm drag-selection can never extend past the top of the screen — the
highlight is anchored to cells tmux rewrites underneath it. So the agent pane's
/history now always prefers the provider transcript, and the overlay renders it
as native DOM text: scroll it, drag-select past the viewport edge, release to
copy (the terminals' house rule). Drag past a terminal's top or bottom edge and
the overlay takes the drag over mid-gesture, parking the anchor at the same
viewport fraction it had on screen so the content does not appear to move;
Ctrl+↑/↓ opens it at the very top/bottom.

Which transcript is THIS window's: several sessions can run in one directory
and they all write into the same projects/<cwd-slug>/ dir, so "newest .jsonl by
mtime" is whichever sibling typed last — the prompt bar on two windows over one
repo showed the same prompt, flipping as either one worked. The window's
activity hooks already record its Claude session id (thread_markers), and the
transcript is named after that id, so _session_transcript() opens it directly
and only falls back to newest-by-mtime when there is no marker (hookless
launches, other providers). The snippet cache is keyed per window for the same
reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)