### PR TITLE
Let the traffic screen find the token you already have

### DIFF
--- a/backend/web/addons/traffic.py
+++ b/backend/web/addons/traffic.py
@@ -40,19 +40,25 @@ _CACHE_TTL_S = 300.0
 
 
 async def _token() -> str:
-    """A GitHub token if one is configured, else ``""`` — never raises.
+    """A GitHub token if one is reachable, else ``""`` — never raises.
 
-    Best-effort and read-only: unlike the PR/issue integrations this addon
-    never needs write scope, so a missing token just means unauthenticated
-    GitHub calls (60/hr, plenty for a screen nobody polls in a loop).
+    The same chain the PR buttons use (config.toml → Settings → ``$GH_TOKEN``
+    → ``gh auth token``), because the ``gh auth token`` rung is where the token
+    usually IS: `gh auth login` is a normal thing to have done and pasting a
+    PAT into Settings is not. Resolving only the static layers left this screen
+    calling GitHub anonymously on a machine that was perfectly well
+    authenticated.
+
+    Anonymous is still a supported state — read-only public data needs no
+    scope, and stars/forks/downloads all answer without a token. Only the star
+    HISTORY does not: ``GET /repos/{repo}/stargazers`` is 401 "Requires
+    authentication" even for a public repo, so without this rung that one
+    section was permanently broken.
     """
     try:
-        from backend.config.secrets import resolve_secret_sync
+        from backend.web.core.github_pr import api_token
 
-        return resolve_secret_sync(
-            settings_getter=lambda s: s.github.token,
-            env_vars=("GH_TOKEN", "GITHUB_TOKEN"),
-        ).strip()
+        return (await api_token()).strip()
     except Exception:  # noqa: BLE001 — an unresolvable token is a normal state
         return ""
 

--- a/backend/web/core/github_pr.py
+++ b/backend/web/core/github_pr.py
@@ -127,12 +127,17 @@ def _github_config():
     )
 
 
-async def _token() -> str:
+async def api_token() -> str:
     """A usable GitHub API token, or ``""`` — never raises.
 
     ``resolve_token`` raises a long "no token available" message when every
     layer comes up empty; here that is a routine outcome (it just means the
     browser fallback is next), so it is folded into an empty string.
+
+    Public because it is the web layer's one answer to "what token do we call
+    GitHub with": config.toml → Settings → env → ``gh auth token``. Anything
+    else in ``backend/web`` that talks to api.github.com calls this rather than
+    growing its own copy of the chain.
     """
     from backend.ticket_ingestion.github_auth import resolve_token
 
@@ -310,7 +315,7 @@ async def create_pr(wt: str, base: str, head: str) -> PRResult:
     ref = repo_ref(wt)
     if ref is None:
         return PRResult(unavailable=True)
-    token = await _token()
+    token = await api_token()
     if not token:
         return PRResult(unavailable=True)
 
@@ -346,7 +351,7 @@ async def merge_pr(wt: str, number: int) -> PRResult:
     ref = repo_ref(wt)
     if ref is None:
         return PRResult(unavailable=True)
-    token = await _token()
+    token = await api_token()
     if not token:
         return PRResult(unavailable=True)
 
@@ -373,7 +378,7 @@ async def find_pr(wt: str, branch: str) -> Optional[dict]:
     ref = repo_ref(wt)
     if ref is None or not branch:
         return None
-    token = await _token()
+    token = await api_token()
     if not token:
         return None
 
@@ -417,7 +422,7 @@ async def pr_checks(wt: str, branch: str) -> str:
     ref = repo_ref(wt)
     if ref is None or not branch:
         return "unknown"
-    token = await _token()
+    token = await api_token()
     if not token:
         return "unknown"
 
@@ -496,7 +501,7 @@ async def pr_merge_state(wt: str, branch: str) -> Optional[dict]:
     ref = repo_ref(wt)
     if ref is None or not branch:
         return None
-    token = await _token()
+    token = await api_token()
     if not token:
         return None
 

--- a/tests/unit/test_server_routes.py
+++ b/tests/unit/test_server_routes.py
@@ -768,7 +768,7 @@ def _stub_rest(
         calls.append((method, path, params, body))
         return queued.pop(0) if queued else (0, "no stubbed response")
 
-    monkeypatch.setattr(github_pr, "_token", _token)
+    monkeypatch.setattr(github_pr, "api_token", _token)
     monkeypatch.setattr(github_pr, "origin_url", lambda wt: origin)
     monkeypatch.setattr(
         github_pr, "_commit_messages", lambda wt, base, head: list(commits)

--- a/tests/unit/test_traffic_addon.py
+++ b/tests/unit/test_traffic_addon.py
@@ -1,0 +1,174 @@
+"""Traffic addon (Settings → Site traffic, dev-shell only).
+
+Covers the two things that decide whether the screen shows numbers at all:
+
+* which token it calls GitHub with — the shared web-layer chain, whose last
+  rung (``gh auth token``) is where the token normally lives;
+* that one dead upstream costs you ONE section, not the whole payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.web.addons import traffic
+from backend.web.core import github_pr
+
+
+# --------------------------------------------------------------------------- #
+# Token resolution
+# --------------------------------------------------------------------------- #
+def test_token_comes_from_the_shared_web_github_chain(monkeypatch):
+    """Not the static-only resolver: this must reach the ``gh auth token`` rung.
+
+    Resolving only config.toml/Settings/env left the screen calling GitHub
+    anonymously on a machine authenticated through the gh CLI, which is the
+    normal setup — and anonymous cannot read stargazers at all.
+    """
+    seen = []
+
+    async def _api_token():
+        seen.append(True)
+        return "  ghp_from_the_cli  "
+
+    monkeypatch.setattr(github_pr, "api_token", _api_token)
+    assert asyncio.run(traffic._token()) == "ghp_from_the_cli"
+    assert seen == [True]
+
+
+def test_token_is_empty_when_nothing_is_configured(monkeypatch):
+    """No token is a supported state — public stars/forks/downloads need none."""
+
+    async def _api_token():
+        return ""
+
+    monkeypatch.setattr(github_pr, "api_token", _api_token)
+    assert asyncio.run(traffic._token()) == ""
+
+
+def test_token_swallows_a_broken_resolver(monkeypatch):
+    """A dashboard must never 500 because the token chain raised."""
+
+    async def _api_token():
+        raise RuntimeError("gh exploded")
+
+    monkeypatch.setattr(github_pr, "api_token", _api_token)
+    assert asyncio.run(traffic._token()) == ""
+
+
+# --------------------------------------------------------------------------- #
+# Payload assembly
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def stub_http(monkeypatch):
+    """Route ``_get_json`` by URL fragment; unmatched URLs are a hard failure."""
+
+    def install(routes: dict):
+        async def _get_json(url, *, token="", accept=""):
+            for frag, resp in routes.items():
+                if frag in url:
+                    return resp
+            raise AssertionError("unstubbed URL: " + url)
+
+        monkeypatch.setattr(traffic, "_get_json", _get_json)
+
+    return install
+
+
+_REPO_OK = (200, {"stargazers_count": 12, "forks_count": 3, "open_issues_count": 1})
+_RELEASES_OK = (
+    200,
+    [
+        {
+            "tag_name": "v0.1.15",
+            "assets": [{"name": "MindFlock.dmg", "download_count": 7}],
+        }
+    ],
+)
+_CLICKS_OK = (200, {"series": [{"day": "2026-08-10", "slug": "mac", "clicks": 3}]})
+
+
+def test_star_history_401_degrades_only_that_section(monkeypatch, stub_http):
+    """The exact anonymous-GitHub failure: stargazers 401s, the rest answers.
+
+    ``GET /repos/{repo}/stargazers`` requires authentication even for a public
+    repo, so an unauthenticated dashboard loses the growth curve — and must
+    keep the stars, forks, downloads and clicks it already has.
+    """
+    stub_http(
+        {
+            "/stargazers": (401, {"message": "Requires authentication"}),
+            "/releases": _RELEASES_OK,
+            "/repos/MindFlock/MindFlock": _REPO_OK,
+            "/go/_stats": _CLICKS_OK,
+        }
+    )
+
+    async def _no_token():
+        return ""
+
+    monkeypatch.setattr(traffic, "_token", _no_token)
+    payload = asyncio.run(traffic.TrafficAddon()._payload(days=7, refresh=True))
+
+    assert payload["repo"]["stars"] == 12
+    assert payload["downloads_total"] == 7
+    assert payload["clicks"]["totals_by_slug"] == {"mac": 3}
+    assert payload["star_history"] == []
+    assert "401" in payload["errors"]["github"]
+    assert payload["errors"]["clicks"] is None
+
+
+def test_star_history_is_cumulative_by_day(stub_http, monkeypatch):
+    """Each stargazer is one +1 event; the curve is their running total."""
+    stub_http(
+        {
+            "/stargazers": (
+                200,
+                [
+                    {"starred_at": "2026-08-08T10:00:00Z"},
+                    {"starred_at": "2026-08-10T11:00:00Z"},
+                    {"starred_at": "2026-08-10T12:00:00Z"},
+                ],
+            ),
+            "/releases": _RELEASES_OK,
+            "/repos/MindFlock/MindFlock": _REPO_OK,
+            "/go/_stats": _CLICKS_OK,
+        }
+    )
+
+    async def _token():
+        return "ghp_x"
+
+    monkeypatch.setattr(traffic, "_token", _token)
+    payload = asyncio.run(traffic.TrafficAddon()._payload(days=7, refresh=True))
+
+    assert payload["star_history"] == [
+        {"day": "2026-08-08", "stars": 1},
+        {"day": "2026-08-10", "stars": 3},
+    ]
+    assert payload["errors"]["github"] is None
+
+
+def test_unreachable_click_worker_leaves_github_intact(stub_http, monkeypatch):
+    """The two sections share nothing; a Worker hiccup must not hide stars."""
+    stub_http(
+        {
+            "/stargazers": (200, []),
+            "/releases": _RELEASES_OK,
+            "/repos/MindFlock/MindFlock": _REPO_OK,
+            "/go/_stats": (0, "Cannot connect to host mindflock.ai"),
+        }
+    )
+
+    async def _token():
+        return "ghp_x"
+
+    monkeypatch.setattr(traffic, "_token", _token)
+    payload = asyncio.run(traffic.TrafficAddon()._payload(days=7, refresh=True))
+
+    assert payload["repo"]["stars"] == 12
+    assert payload["errors"]["github"] is None
+    assert "mindflock.ai" in payload["errors"]["clicks"]
+    assert payload["clicks"]["series"] == []


### PR DESCRIPTION
Site traffic drew stars, forks and downloads but never the star-history curve:
"GitHub star history lookup failed (401): Requires authentication". The other
three calls answer anonymously; GET /repos/{repo}/stargazers does not, even for
a public repo — it is the only endpoint here that GitHub gates, and the growth
curve is reconstructed from the per-star timestamps only it returns.

The addon was resolving its token with resolve_secret_sync, which walks
config.toml -> Settings -> $GH_TOKEN and stops. It never asked `gh auth token`,
which is where the token actually is on a normal machine: `gh auth login` is a
thing people have done, pasting a PAT into a Settings field is not. So a
perfectly well authenticated laptop called GitHub anonymously and lost the one
section that needs auth.

It now uses the same chain as the PR buttons, which already had this right.
That resolver was github_pr._token; it is api_token now, since "the token the
web layer calls GitHub with" is exactly the sort of thing a sibling module
should reuse instead of growing a fourth copy of the ladder (there are already
two spellings of the `gh auth token` subprocess in ticket_ingestion).

Anonymous stays a supported state — no token still yields stars, forks,
downloads and clicks, with the history section degrading on its own. The addon
arrived untested, so this also covers the token rungs, the 401 degradation, the
cumulative-by-day curve, and a dead click Worker not taking GitHub down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)