### PR TITLE
Name the traffic-token fix in the 0.1.15 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   other's work. Each window now reads the conversation its own activity hooks
   recorded for it.
 
+- **Site traffic finds the GitHub token you already have.** It resolved only a
+  pasted token or `$GH_TOKEN`, never `gh auth token`, so a machine authenticated
+  the ordinary way (`gh auth login`) called GitHub anonymously — and the star
+  history is the one section GitHub refuses to serve anonymously, 401 even for a
+  public repo. It now uses the same resolution chain as the PR buttons.
+
 ## [0.1.14] - 2026-08-07
 
 ### Fixed


### PR DESCRIPTION
The v0.1.15 tag is being re-cut onto current main (all nine assets had 0 downloads), so the release ships the traffic-token fix — its changelog entry should say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)