### PR TITLE
Arm the drag-up history gesture where the hand actually stops

### DIFF
--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22032,16 +22032,19 @@ function attachWheelScroll(host, term, getWs) {
     { capture: true, passive: true }
   );
 }
+const DRAG_EDGE_ZONE = 18;
+function dragEdgeAt(y, r, zone = DRAG_EDGE_ZONE) {
+  if (y < r.top + zone) return "top";
+  if (y > r.bottom - zone) return "bottom";
+  return null;
+}
 function attachDragHistoryGesture(host, fire) {
   const HOLD_MS = 220;
-  const MARGIN = 8;
-  const BOTTOM_ZONE = 18;
   host.addEventListener("mousedown", (down) => {
     if (down.button !== 0) return;
     let timer;
     const onMove = (ev) => {
-      const r = host.getBoundingClientRect();
-      const edge = ev.clientY < r.top - MARGIN ? "top" : ev.clientY > r.bottom - BOTTOM_ZONE ? "bottom" : null;
+      const edge = dragEdgeAt(ev.clientY, host.getBoundingClientRect());
       if (edge && timer === void 0) {
         timer = setTimeout(() => {
           cleanup();

--- a/frontend/src/__tests__/dragHistoryGesture.test.ts
+++ b/frontend/src/__tests__/dragHistoryGesture.test.ts
@@ -1,0 +1,65 @@
+/** Where the drag-past-the-edge → full-history gesture arms.
+ *
+ * This geometry is the whole gesture: xterm cannot extend a selection past the
+ * top of the terminal (tmux repaints history underneath the highlight), so
+ * dragging out of the edge is what hands the drag to the history overlay. If
+ * the zone doesn't match the motion a hand actually makes, the feature may as
+ * well not exist — which is exactly what happened while the top zone sat
+ * OUTSIDE the element.
+ *
+ * The DOM half (hold timer, one-shot per drag, release cancels) lives in
+ * attachDragHistoryGesture; the suite runs in the "node" environment on
+ * purpose, so what is pinned here is the decision, not the wiring.
+ */
+
+import { describe, it, expect } from "vitest";
+import { dragEdgeAt, DRAG_EDGE_ZONE } from "../lib/terminals";
+
+/** A terminal occupying y = 100..400 on screen. */
+const term = { top: 100, bottom: 400 };
+
+describe("dragEdgeAt", () => {
+  it("arms 'top' while the pointer is still INSIDE the terminal", () => {
+    // The regression: a drag up stops where the selection stops — on the top
+    // row — and used to need another 8px into the pane header to count. Nobody
+    // does that, and nothing tells them to.
+    expect(dragEdgeAt(101, term)).toBe("top");
+    expect(dragEdgeAt(110, term)).toBe("top");
+  });
+
+  it("still arms 'top' once the pointer leaves the element", () => {
+    expect(dragEdgeAt(99, term)).toBe("top");
+    expect(dragEdgeAt(40, term)).toBe("top");
+    expect(dragEdgeAt(-50, term)).toBe("top");
+  });
+
+  it("arms 'bottom' on the tmux status row and below it", () => {
+    expect(dragEdgeAt(399, term)).toBe("bottom");
+    expect(dragEdgeAt(390, term)).toBe("bottom");
+    expect(dragEdgeAt(460, term)).toBe("bottom");
+  });
+
+  it("stays null through the middle, so ordinary selection is untouched", () => {
+    expect(dragEdgeAt(200, term)).toBeNull();
+    expect(dragEdgeAt(250, term)).toBeNull();
+    // Just inside each zone boundary.
+    expect(dragEdgeAt(100 + DRAG_EDGE_ZONE, term)).toBeNull();
+    expect(dragEdgeAt(400 - DRAG_EDGE_ZONE, term)).toBeNull();
+  });
+
+  it("treats the two edges symmetrically", () => {
+    const depth = 5;
+    expect(dragEdgeAt(term.top + depth, term)).toBe("top");
+    expect(dragEdgeAt(term.bottom - depth, term)).toBe("bottom");
+  });
+
+  it("resolves a pane shorter than two zones to one edge, not both", () => {
+    // A squeezed pane (nine-up grid) has overlapping zones. Every point still
+    // gets exactly one answer — the overlap goes to "top", and the rows below
+    // it are "bottom" — so the gesture can't flicker between the two.
+    const tiny = { top: 100, bottom: 120 };
+    expect(dragEdgeAt(105, tiny)).toBe("top"); // in both zones -> top wins
+    expect(dragEdgeAt(117, tiny)).toBe("top");
+    expect(dragEdgeAt(119, tiny)).toBe("bottom"); // past the top zone
+  });
+});

--- a/frontend/src/lib/terminals.ts
+++ b/frontend/src/lib/terminals.ts
@@ -372,28 +372,41 @@ function attachWheelScroll(host: HTMLElement, term: Terminal, getWs: () => WebSo
 // rewritten cells); instead it fires once per drag and the pane opens the
 // full-history overlay. The hold delay keeps an overshoot while selecting an
 // edge line from triggering it.
-function attachDragHistoryGesture(
+/** How far INSIDE each edge the gesture arms. Both zones reach inward, and
+ * for the same reason: a drag that runs out of screen comes to rest ON the
+ * edge row, not past the container. Downward that row is the tmux status bar;
+ * upward it is the top line, where the selection visibly stops growing —
+ * exactly the moment the reader is asking for more than the screen holds.
+ * Requiring the pointer to LEAVE the element made both gestures nearly
+ * impossible to hit; the top one, the one people actually reach for, was
+ * unreachable in practice, since nothing tells you to keep dragging up into
+ * the pane header. The hold delay is what keeps an ordinary overshoot from
+ * firing it. */
+export const DRAG_EDGE_ZONE = 18;
+
+/** Which edge zone a pointer at ``y`` is in, or null for the middle. Pure, so
+ * the geometry that decides whether the gesture is reachable at all can be
+ * tested without a DOM. */
+export function dragEdgeAt(
+  y: number,
+  r: { top: number; bottom: number },
+  zone: number = DRAG_EDGE_ZONE
+): "top" | "bottom" | null {
+  if (y < r.top + zone) return "top";
+  if (y > r.bottom - zone) return "bottom";
+  return null;
+}
+
+export function attachDragHistoryGesture(
   host: HTMLElement,
   fire: (edge: "top" | "bottom") => void
 ) {
   const HOLD_MS = 220;
-  const MARGIN = 8; // px past the top edge before the hold timer arms
-  // The bottom zone starts INSIDE the terminal: its last visible row is the
-  // tmux status bar, so a downward selection drag naturally comes to rest ON
-  // that row, never 8px past the container — requiring "outside only" made
-  // the downward gesture nearly impossible to hit in practice.
-  const BOTTOM_ZONE = 18;
   host.addEventListener("mousedown", (down: MouseEvent) => {
     if (down.button !== 0) return;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const onMove = (ev: MouseEvent) => {
-      const r = host.getBoundingClientRect();
-      const edge: "top" | "bottom" | null =
-        ev.clientY < r.top - MARGIN
-          ? "top"
-          : ev.clientY > r.bottom - BOTTOM_ZONE
-            ? "bottom"
-            : null;
+      const edge = dragEdgeAt(ev.clientY, host.getBoundingClientRect());
       if (edge && timer === undefined) {
         timer = setTimeout(() => {
           cleanup();


### PR DESCRIPTION
Dragging up to select more than a screenful did nothing. The gesture that
hands the drag to the history page armed only once the pointer was 8px OUTSIDE
the terminal's top edge — but a drag up ends where the selection stops
growing, ON the top row, and nothing suggests you should keep dragging into
the pane header. So the motion people make never armed it, and the feature was
unreachable in the direction it exists for.

The bottom edge already knew this: its zone starts 18px INSIDE the element,
with a comment saying that requiring 'outside only' made the downward gesture
nearly impossible to hit. That reasoning was never carried up to the top. Both
edges are symmetric now, and the 220ms hold is what still separates 'I want
more history' from an ordinary overshoot while selecting an edge line.

The geometry is split out as dragEdgeAt() so it can be tested: the suite runs
in vitest's node environment, so pinning the decision is possible where
pinning the DOM wiring is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)