### PR TITLE
Count a prompt typed mid-turn as a prompt

### DIFF
--- a/backend/providers/claude.py
+++ b/backend/providers/claude.py
@@ -871,11 +871,37 @@ def _snippet_from_text(text: str, limit: int = 120) -> Optional[str]:
     return None
 
 
+#: Transcript entry types that carry something the HUMAN said. A prompt typed
+#: while a turn is still running is filed as ``{"type": "queue-operation",
+#: "operation": "enqueue", "content": "..."}`` and NEVER becomes a "user"
+#: entry — not even once it is consumed. Readers that only knew about "user"
+#: therefore lost every queued prompt: the pinned line went stale, expanding
+#: it found nothing to expand, and the history page skipped the message
+#: entirely.
+_USER_ENTRY_TYPES = ("user", "queue-operation")
+
+
+def _is_role(obj, role: str) -> bool:
+    """Whether a transcript entry belongs to ``role``, counting a queued
+    prompt as the human speaking (see :data:`_USER_ENTRY_TYPES`)."""
+    if not isinstance(obj, dict):
+        return False
+    t = obj.get("type")
+    return t == role or (role == "user" and t in _USER_ENTRY_TYPES)
+
+
 def _entry_text(obj) -> Optional[str]:
     """The human-readable body of one transcript entry, or None to skip it
     (meta entries, tool_use/tool_result-only turns, non-conversation lines)."""
     if not isinstance(obj, dict):
         return None
+    if obj.get("type") == "queue-operation":
+        # "enqueue" is the prompt being typed; "remove" is the same text
+        # coming back off the queue, which would double every queued message.
+        if obj.get("operation") != "enqueue":
+            return None
+        content = obj.get("content")
+        return content if isinstance(content, str) and content.strip() else None
     if obj.get("type") not in ("user", "assistant"):
         return None
     if obj.get("isMeta"):
@@ -984,9 +1010,7 @@ def _snippet_from_transcript(
                 obj = json.loads(line)
             except ValueError:
                 continue
-            if role is not None and (
-                not isinstance(obj, dict) or obj.get("type") != role
-            ):
+            if role is not None and not _is_role(obj, role):
                 continue
             if role is not None and obj.get("toolUseResult") is not None:
                 continue  # tool output the transcript files under "user"
@@ -1074,7 +1098,7 @@ def _claude_find_prompt_full(
                 obj = json.loads(line)
             except ValueError:
                 continue
-            if not isinstance(obj, dict) or obj.get("type") != "user":
+            if not _is_role(obj, "user"):
                 continue
             if obj.get("toolUseResult") is not None:
                 continue

--- a/backend/web/core/session_stats.py
+++ b/backend/web/core/session_stats.py
@@ -184,7 +184,19 @@ def _agent_transcript_text(workdir: str, session_name: str = ""):
                     obj = json.loads(line)
                 except ValueError:
                     continue
-                if obj.get("isMeta") or obj.get("type") not in ("user", "assistant"):
+                if obj.get("isMeta"):
+                    continue
+                if obj.get("type") == "queue-operation":
+                    # A prompt typed while the turn was still running. It is
+                    # never re-filed as a "user" entry, so skipping it drops
+                    # the message from the conversation for good.
+                    if obj.get("operation") != "enqueue":
+                        continue
+                    queued = obj.get("content")
+                    if isinstance(queued, str) and queued.strip():
+                        parts.append("## User\n" + queued)
+                    continue
+                if obj.get("type") not in ("user", "assistant"):
                     continue
                 content = (obj.get("message") or {}).get("content")
                 texts = []

--- a/tests/unit/test_claude_provider.py
+++ b/tests/unit/test_claude_provider.py
@@ -1587,3 +1587,91 @@ def test_last_prompt_snippet_is_per_window_not_per_workdir(two_windows):
     )
     # The other window's prompt is not reachable from this window.
     assert provider.find_prompt_full("mindflock_mine", workdir, "theirs: bump") is None
+
+
+# --------------------------------------------------------------------------- #
+# Queued prompts: a message typed while the turn is still running is filed as
+# {"type": "queue-operation", "operation": "enqueue", "content": ...} and is
+# NEVER re-filed as a "user" entry, so a reader that only knows "user" loses it
+# permanently.
+# --------------------------------------------------------------------------- #
+def _enqueued(text: str) -> dict:
+    return {"type": "queue-operation", "operation": "enqueue", "content": text}
+
+
+def test_last_prompt_sees_a_prompt_typed_mid_turn(fake_home):
+    workdir = "/work/queued"
+    _write_transcript(
+        fake_home,
+        workdir,
+        [
+            {"type": "user", "message": {"content": "the first thing I asked"}},
+            {"type": "assistant", "message": {"content": "working on it"}},
+            _enqueued("actually also make the menu bigger"),
+        ],
+    )
+    provider = ClaudeProvider()
+    assert provider.last_prompt_snippet("s", workdir) == (
+        "actually also make the menu bigger"
+    )
+    assert provider.last_prompt_full("s", workdir) == (
+        "actually also make the menu bigger"
+    )
+
+
+def test_find_prompt_full_expands_a_queued_prompt(fake_home):
+    """The pinned line is width-truncated by the TUI; expanding it looks the
+    body up by prefix. Queued prompts used to return null here, so clicking
+    the arrow re-showed the same truncated text."""
+    workdir = "/work/queued2"
+    long_prompt = (
+        "I also think i want the new menu to be much larger so i dont have to "
+        "scroll. Also make the more options and launch flags open by default"
+    )
+    _write_transcript(fake_home, workdir, [_enqueued(long_prompt)])
+    provider = ClaudeProvider()
+    got = provider.find_prompt_full(
+        "s", workdir, "I also think i want the new menu to be much larger…"
+    )
+    assert got == long_prompt
+
+
+def test_queue_removals_are_not_second_copies_of_the_prompt(fake_home):
+    """Each queued message is enqueued and later removed with the SAME text;
+    only the enqueue is the human speaking."""
+    workdir = "/work/queued3"
+    _write_transcript(
+        fake_home,
+        workdir,
+        [
+            _enqueued("do the thing"),
+            {
+                "type": "queue-operation",
+                "operation": "remove",
+                "content": "do the thing",
+            },
+            {"type": "assistant", "message": {"content": "done"}},
+        ],
+    )
+    from backend.providers.claude import _entry_text
+
+    assert _entry_text(_enqueued("do the thing")) == "do the thing"
+    assert (
+        _entry_text(
+            {
+                "type": "queue-operation",
+                "operation": "remove",
+                "content": "do the thing",
+            }
+        )
+        is None
+    )
+    # The newest human prompt is still the enqueue, not the assistant reply.
+    assert ClaudeProvider().last_prompt_snippet("s", workdir) == "do the thing"
+
+
+def test_empty_queue_content_is_not_a_prompt(fake_home):
+    from backend.providers.claude import _entry_text
+
+    assert _entry_text(_enqueued("   ")) is None
+    assert _entry_text({"type": "queue-operation", "operation": "enqueue"}) is None

--- a/tests/unit/test_session_stats.py
+++ b/tests/unit/test_session_stats.py
@@ -93,6 +93,43 @@ def test_transcript_text_renders_user_and_assistant(tmp_path, monkeypatch):
     assert "meta noise" not in text  # isMeta lines are dropped
 
 
+def test_transcript_text_keeps_a_prompt_typed_mid_turn(tmp_path, monkeypatch):
+    """Queued prompts are filed as queue-operation and never re-filed as
+    "user", so dropping them loses the message from the history page for
+    good — and those are exactly the follow-ups sent while the agent works."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    workdir = str(tmp_path / "wt")
+    _write_transcript(
+        str(tmp_path),
+        workdir,
+        [
+            {"type": "user", "message": {"content": "start the work"}},
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "content": "and also fix the menu",
+            },
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "on it"}]},
+            },
+            # The same text coming back off the queue must not print twice.
+            {
+                "type": "queue-operation",
+                "operation": "remove",
+                "content": "and also fix the menu",
+            },
+        ],
+    )
+    text = st._agent_transcript_text(workdir)
+    assert text is not None
+    assert "## User\nstart the work" in text
+    assert "## User\nand also fix the menu" in text
+    assert text.count("and also fix the menu") == 1
+    assert "## Claude\non it" in text
+
+
 # --------------------------------------------------------------------------- #
 # _session_tokens — cache keying + invalidation
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Type a follow-up while the agent is still working and Claude Code files it as
{"type": "queue-operation", "operation": "enqueue", "content": ...}. It is
never re-filed as a "user" entry, not even once consumed — so every reader
here, all of which matched on type == "user", lost the message permanently.

Three visible symptoms, one cause. The pinned line showed an older prompt
while the TUI showed the queued one. Expanding it did nothing: the bar falls
back to the TUI's own width-truncated row when the snapshot's full body does
not match, and the lookup that should have supplied the real body searched
only "user" entries and returned null — so the arrow re-rendered the same
truncated text. And the history page skipped those messages outright, which is
the worst of the three: follow-ups sent while the agent works are exactly the
ones you go back to read.

Queued prompts now count as the human speaking, in the snippet scan, the
prefix lookup and the rendered history. Only "enqueue" does — each queued
message is later removed with the same text, and counting both would print
every follow-up twice.

Signed-off-by: emandel2630 <emandel2630@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)