### PR TITLE
Open the New Session folds, and size the card to hold them

### DIFF
--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29693,7 +29693,8 @@ function NewSessionDialog() {
   const [inPlace, setInPlace] = reactExports.useState(true);
   const [initRepo, setInitRepo] = reactExports.useState(false);
   const [error, setError] = reactExports.useState("");
-  const [advancedOpen, setAdvancedOpen] = reactExports.useState(false);
+  const [advancedOpen, setAdvancedOpen] = reactExports.useState(true);
+  const [launchOpen, setLaunchOpen] = reactExports.useState(true);
   const [templates, setTemplates] = reactExports.useState([]);
   const [activeTemplate, setActiveTemplate] = reactExports.useState("");
   const [provisioningAvailable, setProvisioningAvailable] = reactExports.useState(false);
@@ -30253,9 +30254,12 @@ function NewSessionDialog() {
                   id: "new-launch-advanced",
                   className: "nf-advanced",
                   ref: launchRef,
+                  open: launchOpen,
                   onToggle: (e) => {
                     var _a2;
-                    if (e.target.open)
+                    const open2 = e.target.open;
+                    setLaunchOpen(open2);
+                    if (open2)
                       (_a2 = launchRef.current) == null ? void 0 : _a2.scrollIntoView({ behavior: "smooth", block: "end" });
                   },
                   children: [

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -5928,13 +5928,15 @@ p.set-hint {
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 20px 22px;
-  /* One narrow column, quick-launch first: Name + Prompt up top, Folder+Agent
-     in a compact row, git/workspace options folded behind <details>. The card
-     holds a FIXED height so opening a fold scrolls the revealed fields inside
-     .nf-body rather than growing/re-centering the dialog; clamps to the
-     viewport on short windows. */
-  width: min(540px, 94vw);
-  height: min(90vh, 480px);
+  /* One column, quick-launch first: Name + Prompt up top, Folder+Agent in a
+     compact row, then the git/workspace and launch-flag folds — which now
+     stand OPEN by default, so the card is sized to hold the whole form at
+     once instead of making you scroll for the fields you came to change. The
+     height is still FIXED (not content-driven) so toggling a fold scrolls
+     inside .nf-body rather than growing/re-centering the dialog, and both
+     axes clamp to the viewport on small windows. */
+  width: min(760px, 94vw);
+  height: min(92vh, 900px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/dialogs/NewSessionDialog.css
+++ b/frontend/src/components/dialogs/NewSessionDialog.css
@@ -26,13 +26,15 @@
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 20px 22px;
-  /* One narrow column, quick-launch first: Name + Prompt up top, Folder+Agent
-     in a compact row, git/workspace options folded behind <details>. The card
-     holds a FIXED height so opening a fold scrolls the revealed fields inside
-     .nf-body rather than growing/re-centering the dialog; clamps to the
-     viewport on short windows. */
-  width: min(540px, 94vw);
-  height: min(90vh, 480px);
+  /* One column, quick-launch first: Name + Prompt up top, Folder+Agent in a
+     compact row, then the git/workspace and launch-flag folds — which now
+     stand OPEN by default, so the card is sized to hold the whole form at
+     once instead of making you scroll for the fields you came to change. The
+     height is still FIXED (not content-driven) so toggling a fold scrolls
+     inside .nf-body rather than growing/re-centering the dialog, and both
+     axes clamp to the viewport on small windows. */
+  width: min(760px, 94vw);
+  height: min(92vh, 900px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -207,7 +207,12 @@ export function NewSessionDialog() {
   const [inPlace, setInPlace] = useState(true);
   const [initRepo, setInitRepo] = useState(false);
   const [error, setError] = useState("");
-  const [advancedOpen, setAdvancedOpen] = useState(false);
+  // Both folds start OPEN: the card is tall enough to hold them, and hiding
+  // the git/workspace choices behind a click made people launch with the
+  // wrong strategy rather than discover it. Closing one is still remembered
+  // for the life of the dialog.
+  const [advancedOpen, setAdvancedOpen] = useState(true);
+  const [launchOpen, setLaunchOpen] = useState(true);
   const [templates, setTemplates] = useState<Template[]>([]);
   const [activeTemplate, setActiveTemplate] = useState("");
   const [provisioningAvailable, setProvisioningAvailable] = useState(false);
@@ -859,11 +864,16 @@ export function NewSessionDialog() {
             id="new-launch-advanced"
             className="nf-advanced"
             ref={launchRef}
+            open={launchOpen}
             onToggle={(e) => {
+              const open = (e.target as HTMLDetailsElement).open;
+              setLaunchOpen(open);
               // The fold is the last thing in the scroll region, so its revealed
               // fields open below the fold line — scroll them into view so it's
-              // obvious the click did something and where to look.
-              if ((e.target as HTMLDetailsElement).open)
+              // obvious the click did something and where to look. Only on a
+              // real click: open-by-default fires no toggle, and scrolling the
+              // body on arrival would bury the Name field.
+              if (open)
                 launchRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
             }}
           >

--- a/tests/unit/test_frontend_ux.py
+++ b/tests/unit/test_frontend_ux.py
@@ -134,7 +134,9 @@ def test_new_dialog_folds_git_workspace_options():
     js = client.get("/app.js").text
     assert '"new-in-place"' in js  # work-in-place toggle
     assert '"new-init-repo"' in js  # git init lives here
-    # The fold defaults closed; templates re-open it when they rely on it.
+    # Both folds now stand OPEN by default (the card is sized to hold the whole
+    # form): hiding the workspace strategy behind a click had people launching
+    # with the wrong one rather than finding it.
     assert "nf-advanced" in js
 
 


### PR DESCRIPTION
The card was pinned to 540x480 with git/workspace options and launch flags
folded away, so the fields you open the dialog to change were two clicks and a
scroll from view — and hiding the workspace strategy behind a fold had people
launching with the wrong one rather than discovering it.

Both folds now start open, and the card is 760x900 (still clamped to 94vw /
92vh) so the whole form fits without scrolling on an ordinary screen. The
height stays FIXED rather than content-driven, which is what keeps toggling a
fold from growing and re-centering the dialog under the pointer; .nf-body
still scrolls internally on a short window.

Closing a fold is remembered for the life of the dialog — the launch fold was
uncontrolled, so it needed its own state to be openable by default without
snapping shut on the next render.

Signed-off-by: emandel2630 <emandel2630@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)