### PR TITLE
Trim the New Session card, and hold each folder row to one line

### DIFF
--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29694,7 +29694,7 @@ function NewSessionDialog() {
   const [initRepo, setInitRepo] = reactExports.useState(false);
   const [error, setError] = reactExports.useState("");
   const [advancedOpen, setAdvancedOpen] = reactExports.useState(true);
-  const [launchOpen, setLaunchOpen] = reactExports.useState(true);
+  const [launchOpen, setLaunchOpen] = reactExports.useState(false);
   const [templates, setTemplates] = reactExports.useState([]);
   const [activeTemplate, setActiveTemplate] = reactExports.useState("");
   const [provisioningAvailable, setProvisioningAvailable] = reactExports.useState(false);

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -5929,14 +5929,16 @@ p.set-hint {
   border-radius: 12px;
   padding: 20px 22px;
   /* One column, quick-launch first: Name + Prompt up top, Folder+Agent in a
-     compact row, then the git/workspace and launch-flag folds — which now
-     stand OPEN by default, so the card is sized to hold the whole form at
-     once instead of making you scroll for the fields you came to change. The
-     height is still FIXED (not content-driven) so toggling a fold scrolls
-     inside .nf-body rather than growing/re-centering the dialog, and both
-     axes clamp to the viewport on small windows. */
-  width: min(760px, 94vw);
-  height: min(92vh, 900px);
+     compact row, then the git/workspace fold (open by default — those are the
+     settings people come here to change) and the launch-flag fold (closed;
+     extra CLI flags are a rarity). Sized to hold exactly that without
+     scrolling, and no larger: a modal that fills the screen to show a form
+     half its size is its own kind of wrong. The height stays FIXED (not
+     content-driven) so toggling a fold scrolls inside .nf-body rather than
+     growing and re-centering the dialog under the pointer; both axes clamp to
+     the viewport on small windows. */
+  width: min(620px, 94vw);
+  height: min(88vh, 680px);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -6015,7 +6017,7 @@ p.set-hint {
   }
 }
 
-/* "More options" fold — git & workspace settings, collapsed by default. */
+/* "More options" fold — git & workspace settings, open by default. */
 .nf-advanced {
   border-top: 1px solid var(--border);
   padding-top: 10px;
@@ -6263,13 +6265,27 @@ p.set-hint {
   cursor: help;
 }
 
+/* Exactly one row per source, however many folders came back. Recent and
+   Nearby routinely return a dozen, and wrapping let a single source eat three
+   or four lines — pushing the fields below it off the card and making the
+   whole dialog taller than the form needs. The overflow scrolls sideways
+   instead, so nothing is lost. */
 .nf-suggest .nt-list {
   flex: 1 1 auto;
   min-width: 0;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  /* Room for the thin scrollbar so it can't sit on top of the chips. */
+  padding-bottom: 3px;
 }
 
-/* Long project names would otherwise stretch one chip across the whole row. */
+/* Long project names would otherwise stretch one chip across the whole row;
+   flex: none keeps them from being squeezed to nothing in the no-wrap row
+   (the chip's own ellipsis handles the truncation). */
 .nf-suggest .nt-chip {
+  flex: none;
   max-width: 190px;
 }
 

--- a/frontend/src/components/dialogs/NewSessionDialog.css
+++ b/frontend/src/components/dialogs/NewSessionDialog.css
@@ -27,14 +27,16 @@
   border-radius: 12px;
   padding: 20px 22px;
   /* One column, quick-launch first: Name + Prompt up top, Folder+Agent in a
-     compact row, then the git/workspace and launch-flag folds — which now
-     stand OPEN by default, so the card is sized to hold the whole form at
-     once instead of making you scroll for the fields you came to change. The
-     height is still FIXED (not content-driven) so toggling a fold scrolls
-     inside .nf-body rather than growing/re-centering the dialog, and both
-     axes clamp to the viewport on small windows. */
-  width: min(760px, 94vw);
-  height: min(92vh, 900px);
+     compact row, then the git/workspace fold (open by default — those are the
+     settings people come here to change) and the launch-flag fold (closed;
+     extra CLI flags are a rarity). Sized to hold exactly that without
+     scrolling, and no larger: a modal that fills the screen to show a form
+     half its size is its own kind of wrong. The height stays FIXED (not
+     content-driven) so toggling a fold scrolls inside .nf-body rather than
+     growing and re-centering the dialog under the pointer; both axes clamp to
+     the viewport on small windows. */
+  width: min(620px, 94vw);
+  height: min(88vh, 680px);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -113,7 +115,7 @@
   }
 }
 
-/* "More options" fold — git & workspace settings, collapsed by default. */
+/* "More options" fold — git & workspace settings, open by default. */
 .nf-advanced {
   border-top: 1px solid var(--border);
   padding-top: 10px;
@@ -361,13 +363,27 @@
   cursor: help;
 }
 
+/* Exactly one row per source, however many folders came back. Recent and
+   Nearby routinely return a dozen, and wrapping let a single source eat three
+   or four lines — pushing the fields below it off the card and making the
+   whole dialog taller than the form needs. The overflow scrolls sideways
+   instead, so nothing is lost. */
 .nf-suggest .nt-list {
   flex: 1 1 auto;
   min-width: 0;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  /* Room for the thin scrollbar so it can't sit on top of the chips. */
+  padding-bottom: 3px;
 }
 
-/* Long project names would otherwise stretch one chip across the whole row. */
+/* Long project names would otherwise stretch one chip across the whole row;
+   flex: none keeps them from being squeezed to nothing in the no-wrap row
+   (the chip's own ellipsis handles the truncation). */
 .nf-suggest .nt-chip {
+  flex: none;
   max-width: 190px;
 }
 

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -207,12 +207,14 @@ export function NewSessionDialog() {
   const [inPlace, setInPlace] = useState(true);
   const [initRepo, setInitRepo] = useState(false);
   const [error, setError] = useState("");
-  // Both folds start OPEN: the card is tall enough to hold them, and hiding
-  // the git/workspace choices behind a click made people launch with the
-  // wrong strategy rather than discover it. Closing one is still remembered
-  // for the life of the dialog.
+  // "More options" starts OPEN — hiding the git/workspace choices behind a
+  // click had people launch with the wrong strategy rather than discover it,
+  // and those are the settings this dialog exists to set. Launch flags stay
+  // CLOSED: extra CLI flags are a per-session rarity, and the card is sized
+  // for the form without them. Either fold's state is remembered for the life
+  // of the dialog.
   const [advancedOpen, setAdvancedOpen] = useState(true);
-  const [launchOpen, setLaunchOpen] = useState(true);
+  const [launchOpen, setLaunchOpen] = useState(false);
   const [templates, setTemplates] = useState<Template[]>([]);
   const [activeTemplate, setActiveTemplate] = useState("");
   const [provisioningAvailable, setProvisioningAvailable] = useState(false);

--- a/tests/unit/test_frontend_ux.py
+++ b/tests/unit/test_frontend_ux.py
@@ -134,9 +134,9 @@ def test_new_dialog_folds_git_workspace_options():
     js = client.get("/app.js").text
     assert '"new-in-place"' in js  # work-in-place toggle
     assert '"new-init-repo"' in js  # git init lives here
-    # Both folds now stand OPEN by default (the card is sized to hold the whole
-    # form): hiding the workspace strategy behind a click had people launching
-    # with the wrong one rather than finding it.
+    # "More options" stands OPEN by default — hiding the workspace strategy
+    # behind a click had people launching with the wrong one rather than
+    # finding it. The launch-flags fold below it stays closed.
     assert "nf-advanced" in js
 
 


### PR DESCRIPTION
Three corrections to the last pass. The card was oversized: 760x900 to show a
form that needs neither, so a modal meant to get out of the way filled the
screen. It is 620x680 now — bigger than the 540x480 that made you scroll,
sized to what is actually open.

Which is: More options open (git and workspace are the settings this dialog
exists to set), launch flags closed (extra CLI flags are a per-session
rarity, and they were the taller of the two folds).

And the folder suggestions hold one row per source. Recent and Nearby
routinely return a dozen folders, and a wrapping chip list let a single source
run to three or four lines — pushing the rest of the form off the card and
driving the height it needed. They scroll sideways instead, so nothing is
lost; the chips keep flex: none so the no-wrap row can't squeeze them to
nothing.

Signed-off-by: emandel2630 <emandel2630@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)