### PR TITLE
Whole chips only, and actually keep More options open

### DIFF
--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29631,6 +29631,26 @@ const SUGGEST_SOURCES = [
   { key: "nearby", label: "Nearby", hint: "repos and folders sitting under your home directory" }
 ];
 const CHECK_DEBOUNCE_MS = 400;
+function FitRow({ children }) {
+  const ref = reactExports.useRef(null);
+  reactExports.useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const fit = () => {
+      const kids = Array.from(el.children);
+      for (const k of kids) k.classList.remove("nt-clipped");
+      const limit = el.clientWidth;
+      for (const k of kids) {
+        if (k.offsetLeft + k.offsetWidth > limit + 0.5) k.classList.add("nt-clipped");
+      }
+    };
+    fit();
+    const ro = new ResizeObserver(fit);
+    ro.observe(el);
+    return () => ro.disconnect();
+  });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "nt-list", ref, children });
+}
 function leafName(path) {
   return path.replace(/[/\\]+$/, "").split(/[/\\]/).pop() || path;
 }
@@ -29719,7 +29739,8 @@ function NewSessionDialog() {
     setProvision(false);
     setInPlace(true);
     setInitRepo(false);
-    setAdvancedOpen(false);
+    setAdvancedOpen(true);
+    setLaunchOpen(false);
     folderDo({ t: "reopen" });
     setActiveTemplate("");
     setPresetValue("");
@@ -30071,7 +30092,7 @@ function NewSessionDialog() {
                 ] }),
                 suggestRows.map((g) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "nf-suggest-row", children: [
                   /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "nf-suggest-label", title: g.hint, children: g.label }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "nt-list", children: g.items.map((s) => {
+                  /* @__PURE__ */ jsxRuntimeExports.jsx(FitRow, { children: g.items.map((s) => {
                     const active = folderPath === s.path;
                     return /* @__PURE__ */ jsxRuntimeExports.jsx(
                       "button",

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -6270,15 +6270,23 @@ p.set-hint {
    or four lines — pushing the fields below it off the card and making the
    whole dialog taller than the form needs.
 
-   What doesn't fit is simply clipped: no wrap, and no scrollbar either. A
-   horizontal scrollbar under a row of three chips is louder than the chips,
-   and these are a shortcut, not an index — the list arrives ranked, so the
-   folder you want is at the left, and Browse… is right there for the rest. */
+   What doesn't fit is dropped: no wrap, and no scrollbar either. A horizontal
+   scrollbar under a row of three chips is louder than the chips, and these are
+   a shortcut, not an index — the list arrives ranked, so the folder you want is
+   at the left, and Browse… is right there for the rest. Whole chips only: the
+   overflow below is just the backstop for the frame before FitRow (see the
+   TSX) has measured, since clipping a pill down the middle looks like a bug. */
 .nf-suggest .nt-list {
   flex: 1 1 auto;
   min-width: 0;
   flex-wrap: nowrap;
   overflow: hidden;
+}
+
+/* Measured out of the row by FitRow — display:none, not visibility, so the
+   chip gives its space back to the ones that did fit. */
+.nf-suggest .nt-chip.nt-clipped {
+  display: none;
 }
 
 /* Long project names would otherwise stretch one chip across the whole row;

--- a/frontend/src/components/dialogs/NewSessionDialog.css
+++ b/frontend/src/components/dialogs/NewSessionDialog.css
@@ -368,15 +368,23 @@
    or four lines — pushing the fields below it off the card and making the
    whole dialog taller than the form needs.
 
-   What doesn't fit is simply clipped: no wrap, and no scrollbar either. A
-   horizontal scrollbar under a row of three chips is louder than the chips,
-   and these are a shortcut, not an index — the list arrives ranked, so the
-   folder you want is at the left, and Browse… is right there for the rest. */
+   What doesn't fit is dropped: no wrap, and no scrollbar either. A horizontal
+   scrollbar under a row of three chips is louder than the chips, and these are
+   a shortcut, not an index — the list arrives ranked, so the folder you want is
+   at the left, and Browse… is right there for the rest. Whole chips only: the
+   overflow below is just the backstop for the frame before FitRow (see the
+   TSX) has measured, since clipping a pill down the middle looks like a bug. */
 .nf-suggest .nt-list {
   flex: 1 1 auto;
   min-width: 0;
   flex-wrap: nowrap;
   overflow: hidden;
+}
+
+/* Measured out of the row by FitRow — display:none, not visibility, so the
+   chip gives its space back to the ones that did fit. */
+.nf-suggest .nt-chip.nt-clipped {
+  display: none;
 }
 
 /* Long project names would otherwise stretch one chip across the whole row;

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -3,7 +3,14 @@
  * templates strip, prompt presets, provisioning fold, and per-session launch
  * flags live behind progressive disclosure. */
 
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import type { Config, Instance } from "../../api/types";
 import { api } from "../../api/client";
 import { refreshInstances, refreshConfig, queryClient } from "../../state/queries";
@@ -64,6 +71,47 @@ const SUGGEST_SOURCES: Array<{ key: string; label: string; hint: string }> = [
  * is. The endpoint answers 200-with-exists:false for half-typed paths, so a
  * per-keystroke call would be harmless but pointless traffic. */
 const CHECK_DEBOUNCE_MS = 400;
+
+/** A no-wrap chip row that hides whatever doesn't fit, whole chips only.
+ *
+ * The row is one line by design (see NewSessionDialog.css), and `overflow:
+ * hidden` alone cuts the last pill down the middle — a chopped-off folder name
+ * reads as a rendering fault, not as "there are more". Only measurement can
+ * tell a chip that fits from one that doesn't, so after layout each child is
+ * checked against the container's right edge and the ones past it are hidden
+ * outright. Hiding a later child never moves an earlier one in a no-wrap row,
+ * so this settles in a single pass; a ResizeObserver redoes it when the dialog
+ * is resized.
+ */
+function FitRow({ children }: { children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const fit = () => {
+      const kids = Array.from(el.children) as HTMLElement[];
+      // Unhide first: the row may have grown, and a chip hidden at the old
+      // width has no geometry to measure at the new one.
+      for (const k of kids) k.classList.remove("nt-clipped");
+      const limit = el.clientWidth;
+      for (const k of kids) {
+        // Half a pixel of slack: sub-pixel layout would otherwise drop a chip
+        // that lands exactly on the edge.
+        if (k.offsetLeft + k.offsetWidth > limit + 0.5) k.classList.add("nt-clipped");
+      }
+    };
+    fit();
+    const ro = new ResizeObserver(fit);
+    ro.observe(el);
+    return () => ro.disconnect();
+  });
+  return (
+    <div className="nt-list" ref={ref}>
+      {children}
+    </div>
+  );
+}
+
 
 /** Last path segment, for naming the folder the confirm row would use. Keeps
  * both separators so a Windows path doesn't come back as the whole string. */
@@ -249,7 +297,11 @@ export function NewSessionDialog() {
     setProvision(false);
     setInPlace(true);
     setInitRepo(false);
-    setAdvancedOpen(false);
+    // Matches the initial state, and has to be set here too: this reset runs
+    // on EVERY open, so a useState default alone left the fold shut from the
+    // second open onward.
+    setAdvancedOpen(true);
+    setLaunchOpen(false);
     folderDo({ t: "reopen" });
     setActiveTemplate("");
     setPresetValue("");
@@ -683,7 +735,7 @@ export function NewSessionDialog() {
                   <span className="nf-suggest-label" title={g.hint}>
                     {g.label}
                   </span>
-                  <div className="nt-list">
+                  <FitRow>
                     {g.items.map((s) => {
                       const active = folderPath === s.path;
                       return (
@@ -702,7 +754,7 @@ export function NewSessionDialog() {
                         </button>
                       );
                     })}
-                  </div>
+                  </FitRow>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
Two corrections.

The folder rows dropped what didn't fit by clipping, which cut the last pill
down the middle — a chopped-off folder name reads as a rendering fault rather
than as "there are more". CSS can't tell a chip that fits from one that
doesn't, so FitRow measures: after layout, any child past the container's
right edge is hidden outright. Hiding a later child never moves an earlier one
in a no-wrap row, so it settles in one pass, and a ResizeObserver redoes it
when the dialog is resized. The overflow rule stays as the backstop for the
frame before the measurement runs.

And More options was still opening shut. Making its useState default true was
not enough: the reset effect that runs on EVERY open set it back to false, so
only the first open of a session would have honoured it — and that one is
preceded by the same reset. It is set in both places now, with the launch fold
explicitly reset closed beside it, so every open starts the same way.

Signed-off-by: emandel2630 <emandel2630@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)