### PR TITLE
Measure the folder chips against the row, not the window

### DIFF
--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29631,6 +29631,9 @@ const SUGGEST_SOURCES = [
   { key: "nearby", label: "Nearby", hint: "repos and folders sitting under your home directory" }
 ];
 const CHECK_DEBOUNCE_MS = 400;
+function fitsWithin(childRight, rowRight) {
+  return childRight <= rowRight + 0.5;
+}
 function FitRow({ children }) {
   const ref = reactExports.useRef(null);
   reactExports.useLayoutEffect(() => {
@@ -29639,9 +29642,12 @@ function FitRow({ children }) {
     const fit = () => {
       const kids = Array.from(el.children);
       for (const k of kids) k.classList.remove("nt-clipped");
-      const limit = el.clientWidth;
+      const right = el.getBoundingClientRect().right;
+      if (!(right > 0)) return;
       for (const k of kids) {
-        if (k.offsetLeft + k.offsetWidth > limit + 0.5) k.classList.add("nt-clipped");
+        if (!fitsWithin(k.getBoundingClientRect().right, right)) {
+          k.classList.add("nt-clipped");
+        }
       }
     };
     fit();

--- a/frontend/src/__tests__/fitRow.test.ts
+++ b/frontend/src/__tests__/fitRow.test.ts
@@ -1,0 +1,53 @@
+/** The folder-row fit test.
+ *
+ * The suggestion rows are one line with no scrollbar, so chips past the edge
+ * are hidden rather than clipped mid-pill. The comparison is one line of
+ * arithmetic and still managed to be wrong in the way that matters: the first
+ * version measured children with offsetLeft, which is relative to
+ * offsetParent — and the offsetParent here is .modal (position: fixed), so
+ * every chip's offset included the dialog's distance from the window edge and
+ * compared as overflowing. Recent and Nearby rendered completely empty.
+ *
+ * Hence the shape of these: the two edges are only comparable when they come
+ * from the same origin, and the cases below are written in viewport
+ * coordinates (a dialog that does NOT start at x=0) so that mistake cannot
+ * pass again.
+ */
+
+import { describe, it, expect } from "vitest";
+import { fitsWithin } from "../components/dialogs/NewSessionDialog";
+
+describe("fitsWithin", () => {
+  // A row inside a dialog that starts 300px into the window and ends at 900.
+  const rowRight = 900;
+
+  it("keeps a chip that ends inside the row", () => {
+    expect(fitsWithin(420, rowRight)).toBe(true);
+    expect(fitsWithin(899, rowRight)).toBe(true);
+  });
+
+  it("drops a chip that ends past the row", () => {
+    expect(fitsWithin(901, rowRight)).toBe(false);
+    expect(fitsWithin(1400, rowRight)).toBe(false);
+  });
+
+  it("keeps a chip landing exactly on the edge, and a hair past it", () => {
+    // Sub-pixel layout routinely reports a fitting child a fraction over.
+    expect(fitsWithin(900, rowRight)).toBe(true);
+    expect(fitsWithin(900.4, rowRight)).toBe(true);
+    expect(fitsWithin(900.6, rowRight)).toBe(false);
+  });
+
+  it("keeps chips whose coordinates are offset far from the origin", () => {
+    // The regression, with the geometry it actually had: a 620px dialog
+    // centred in a ~1500px window, so the row runs x = 516…1016 and its first
+    // chip ends at 616. Measured against the row's right EDGE it plainly
+    // fits; measured against the row's WIDTH (500) — which is what comparing
+    // an offsetParent-relative offset to clientWidth amounts to — it reads as
+    // overflow, and so did every chip after it.
+    const rowRightEdge = 1016;
+    const rowWidth = 500;
+    expect(fitsWithin(616, rowRightEdge)).toBe(true);
+    expect(fitsWithin(616, rowWidth)).toBe(false); // the old, wrong comparison
+  });
+});

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -72,6 +72,15 @@ const SUGGEST_SOURCES: Array<{ key: string; label: string; hint: string }> = [
  * per-keystroke call would be harmless but pointless traffic. */
 const CHECK_DEBOUNCE_MS = 400;
 
+/** Whether a child ending at ``childRight`` fits inside a row ending at
+ * ``rowRight``. Both edges must come from the SAME coordinate space — mixing
+ * an offsetParent-relative offset with a container width is what emptied the
+ * folder rows once already. Half a pixel of slack, since sub-pixel layout
+ * routinely puts a fitting child a hair past the edge. */
+export function fitsWithin(childRight: number, rowRight: number): boolean {
+  return childRight <= rowRight + 0.5;
+}
+
 /** A no-wrap chip row that hides whatever doesn't fit, whole chips only.
  *
  * The row is one line by design (see NewSessionDialog.css), and `overflow:
@@ -93,11 +102,19 @@ function FitRow({ children }: { children: React.ReactNode }) {
       // Unhide first: the row may have grown, and a chip hidden at the old
       // width has no geometry to measure at the new one.
       for (const k of kids) k.classList.remove("nt-clipped");
-      const limit = el.clientWidth;
+      // Viewport coordinates for BOTH sides. offsetLeft looked like the
+      // obvious measure and is a trap here: it is relative to offsetParent,
+      // which for these chips is .modal (position: fixed), so each chip's
+      // offset carried the whole dialog's distance from the window edge and
+      // every one of them compared as overflowing — the rows rendered empty.
+      const right = el.getBoundingClientRect().right;
+      if (!(right > 0)) return; // not laid out yet; hide nothing
       for (const k of kids) {
         // Half a pixel of slack: sub-pixel layout would otherwise drop a chip
         // that lands exactly on the edge.
-        if (k.offsetLeft + k.offsetWidth > limit + 0.5) k.classList.add("nt-clipped");
+        if (!fitsWithin(k.getBoundingClientRect().right, right)) {
+          k.classList.add("nt-clipped");
+        }
       }
     };
     fit();


### PR DESCRIPTION
The rows came back empty. offsetLeft looked like the obvious way to ask where
a chip sits, and it is relative to offsetParent — which for these chips is
.modal, the position: fixed backdrop. So every chip's offset carried the whole
dialog's distance from the window edge (~516px for a centred card) and was
compared against the row's WIDTH (~500px): the very first chip read as
overflow, and so did all the rest.

Both edges now come from getBoundingClientRect, so they share an origin, and
the comparison is split out as fitsWithin() with the case that failed written
down in viewport coordinates. A zero-width row (not laid out yet) hides
nothing rather than everything — the failure mode should be a clipped chip,
never an empty row.

Signed-off-by: emandel2630 <emandel2630@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)