### PR TITLE
Give the New Session card the last inch, and say blank is fine

### DIFF
--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -30176,7 +30176,7 @@ function NewSessionDialog() {
                     rows: 2,
                     autoComplete: "off",
                     spellCheck: false,
-                    placeholder: "What should the agent do first?",
+                    placeholder: "What should the agent do first? Leave blank if you don’t want to kick anything off just yet.",
                     value: prompt,
                     onChange: (e) => setPrompt(e.target.value)
                   }

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -5933,12 +5933,14 @@ p.set-hint {
      settings people come here to change) and the launch-flag fold (closed;
      extra CLI flags are a rarity). Sized to hold exactly that without
      scrolling, and no larger: a modal that fills the screen to show a form
-     half its size is its own kind of wrong. The height stays FIXED (not
+     half its size is its own kind of wrong. The 92vh share carries as much weight
+     as the pixel cap: on a short window it was the viewport clamp, not the
+     680px, that brought the scroll shadows back. The height stays FIXED (not
      content-driven) so toggling a fold scrolls inside .nf-body rather than
      growing and re-centering the dialog under the pointer; both axes clamp to
      the viewport on small windows. */
-  width: min(620px, 94vw);
-  height: min(88vh, 680px);
+  width: min(660px, 94vw);
+  height: min(92vh, 760px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/dialogs/NewSessionDialog.css
+++ b/frontend/src/components/dialogs/NewSessionDialog.css
@@ -31,12 +31,14 @@
      settings people come here to change) and the launch-flag fold (closed;
      extra CLI flags are a rarity). Sized to hold exactly that without
      scrolling, and no larger: a modal that fills the screen to show a form
-     half its size is its own kind of wrong. The height stays FIXED (not
+     half its size is its own kind of wrong. The 92vh share carries as much weight
+     as the pixel cap: on a short window it was the viewport clamp, not the
+     680px, that brought the scroll shadows back. The height stays FIXED (not
      content-driven) so toggling a fold scrolls inside .nf-body rather than
      growing and re-centering the dialog under the pointer; both axes clamp to
      the viewport on small windows. */
-  width: min(620px, 94vw);
-  height: min(88vh, 680px);
+  width: min(660px, 94vw);
+  height: min(92vh, 760px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -848,7 +848,7 @@ export function NewSessionDialog() {
               rows={2}
               autoComplete="off"
               spellCheck={false}
-              placeholder="What should the agent do first?"
+              placeholder="What should the agent do first? Leave blank if you don’t want to kick anything off just yet."
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
             />


### PR DESCRIPTION
Two small things. The card is 660x760 (from 620x680), which is the bit of room
the form needed to stop showing its scroll shadows on arrival — and the 92vh
share matters as much as the pixel cap, since on a short window the viewport
clamp was what brought them back.

And the prompt placeholder now says so: 'What should the agent do first? Leave
blank if you don't want to kick anything off just yet.' The label already read
'optional', which answers whether the field CAN be empty but not what leaving
it empty does — you get a session sitting at its prompt, which is the normal
way to start one you mean to drive by hand.

Signed-off-by: emandel2630 <emandel2630@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)