### PR TITLE
Fold the prompt away, name the folds plainly, and go back not up

### DIFF
--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -29721,6 +29721,7 @@ function NewSessionDialog() {
   const [error, setError] = reactExports.useState("");
   const [advancedOpen, setAdvancedOpen] = reactExports.useState(true);
   const [launchOpen, setLaunchOpen] = reactExports.useState(false);
+  const [promptOpen, setPromptOpen] = reactExports.useState(false);
   const [templates, setTemplates] = reactExports.useState([]);
   const [activeTemplate, setActiveTemplate] = reactExports.useState("");
   const [provisioningAvailable, setProvisioningAvailable] = reactExports.useState(false);
@@ -29732,6 +29733,7 @@ function NewSessionDialog() {
   const launchDefaults = reactExports.useRef({});
   const titleRef = reactExports.useRef(null);
   const launchRef = reactExports.useRef(null);
+  const promptRef = reactExports.useRef(null);
   const rootRef = reactExports.useRef(null);
   const [folder, folderDo] = reactExports.useReducer(folderReducer, FOLDER_INIT);
   const repoPath = folder.path;
@@ -29747,6 +29749,7 @@ function NewSessionDialog() {
     setInitRepo(false);
     setAdvancedOpen(true);
     setLaunchOpen(false);
+    setPromptOpen(false);
     folderDo({ t: "reopen" });
     setActiveTemplate("");
     setPresetValue("");
@@ -29852,6 +29855,7 @@ function NewSessionDialog() {
     setInPlace(!!t.in_place);
     setInitRepo(!!t.init_repo);
     setAdvancedOpen(!!(t.provisioned || t.init_repo || !t.in_place));
+    if (t.prompt) setPromptOpen(true);
     setActiveTemplate(t.name);
     if (!title.trim()) setTitle(t.name || "");
     (_a2 = titleRef.current) == null ? void 0 : _a2.focus();
@@ -30082,7 +30086,7 @@ function NewSessionDialog() {
                   {
                     type: "button",
                     className: "linklike",
-                    title: "Ticks “Create a git repo in this folder” under More options",
+                    title: "Ticks “Create a git repo in this folder” under Git & workspace",
                     onClick: armInitRepo,
                     children: "Create one"
                   }
@@ -30125,63 +30129,6 @@ function NewSessionDialog() {
                   onPick: (p) => folderDo({ t: "browse-commit", path: p })
                 }
               ),
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
-                  "Prompt",
-                  " ",
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "muted", children: "— optional; sent to the agent at launch · Ctrl+Enter creates" })
-                ] }),
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "preset-row", children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsxs(
-                    "select",
-                    {
-                      id: "new-preset",
-                      title: "Prompt presets — pick one to fill the prompt below (editable after)",
-                      value: presetValue,
-                      onChange: (e) => {
-                        setPresetValue(e.target.value);
-                        const p = findPreset(e.target.value);
-                        if (p) setPrompt(p.prompt);
-                      },
-                      children: [
-                        /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "", children: "Preset…" }),
-                        BUILTIN_PRESETS.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("optgroup", { label: "Built-in", children: BUILTIN_PRESETS.map((p) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "b:" + p.name, title: p.prompt, children: p.name }, "b:" + p.name)) }),
-                        savedPresets.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("optgroup", { label: "Saved", children: savedPresets.map((p) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "u:" + p.name, title: p.prompt, children: p.name }, "u:" + p.name)) })
-                      ]
-                    }
-                  ),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "preset-save", title: "Save current prompt as preset…", onClick: savePreset, children: "Save…" }),
-                  presetValue.startsWith("u:") && /* @__PURE__ */ jsxRuntimeExports.jsx(
-                    "button",
-                    {
-                      type: "button",
-                      id: "preset-del",
-                      title: "Delete the selected saved preset",
-                      onClick: () => {
-                        const p = findPreset(presetValue);
-                        if (!p) return;
-                        const list = loadUserPresets().filter((q) => q.name !== p.name);
-                        saveUserPresets(list);
-                        setSavedPresets(list);
-                        setPresetValue("");
-                      },
-                      children: "✕"
-                    }
-                  )
-                ] }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(
-                  "textarea",
-                  {
-                    id: "new-prompt",
-                    rows: 2,
-                    autoComplete: "off",
-                    spellCheck: false,
-                    placeholder: "What should the agent do first? Leave blank if you don’t want to kick anything off just yet.",
-                    value: prompt,
-                    onChange: (e) => setPrompt(e.target.value)
-                  }
-                )
-              ] }),
               /* @__PURE__ */ jsxRuntimeExports.jsxs(
                 "details",
                 {
@@ -30191,10 +30138,7 @@ function NewSessionDialog() {
                   open: advancedOpen,
                   onToggle: (e) => setAdvancedOpen(e.target.open),
                   children: [
-                    /* @__PURE__ */ jsxRuntimeExports.jsxs("summary", { children: [
-                      "More options ",
-                      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "muted", children: "— git & workspace" })
-                    ] }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { children: "Git & workspace" }),
                     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "nf-advanced-body", children: [
                       /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "check", children: [
                         /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -30272,6 +30216,80 @@ function NewSessionDialog() {
                         ] })
                       ] })
                     ] })
+                  ]
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "details",
+                {
+                  id: "new-prompt-fold",
+                  className: "nf-advanced",
+                  ref: promptRef,
+                  open: promptOpen,
+                  onToggle: (e) => {
+                    var _a2;
+                    const open2 = e.target.open;
+                    setPromptOpen(open2);
+                    if (open2)
+                      (_a2 = promptRef.current) == null ? void 0 : _a2.scrollIntoView({ behavior: "smooth", block: "end" });
+                  },
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsxs("summary", { children: [
+                      "Prompt ",
+                      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "muted", children: "— sent to the agent at launch" })
+                    ] }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "nf-advanced-body", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { children: [
+                      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "preset-row", children: [
+                        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                          "select",
+                          {
+                            id: "new-preset",
+                            title: "Prompt presets — pick one to fill the prompt below (editable after)",
+                            value: presetValue,
+                            onChange: (e) => {
+                              setPresetValue(e.target.value);
+                              const p = findPreset(e.target.value);
+                              if (p) setPrompt(p.prompt);
+                            },
+                            children: [
+                              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "", children: "Preset…" }),
+                              BUILTIN_PRESETS.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("optgroup", { label: "Built-in", children: BUILTIN_PRESETS.map((p) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "b:" + p.name, title: p.prompt, children: p.name }, "b:" + p.name)) }),
+                              savedPresets.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("optgroup", { label: "Saved", children: savedPresets.map((p) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "u:" + p.name, title: p.prompt, children: p.name }, "u:" + p.name)) })
+                            ]
+                          }
+                        ),
+                        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", id: "preset-save", title: "Save current prompt as preset…", onClick: savePreset, children: "Save…" }),
+                        presetValue.startsWith("u:") && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                          "button",
+                          {
+                            type: "button",
+                            id: "preset-del",
+                            title: "Delete the selected saved preset",
+                            onClick: () => {
+                              const p = findPreset(presetValue);
+                              if (!p) return;
+                              const list = loadUserPresets().filter((q) => q.name !== p.name);
+                              saveUserPresets(list);
+                              setSavedPresets(list);
+                              setPresetValue("");
+                            },
+                            children: "✕"
+                          }
+                        )
+                      ] }),
+                      /* @__PURE__ */ jsxRuntimeExports.jsx(
+                        "textarea",
+                        {
+                          id: "new-prompt",
+                          rows: 2,
+                          autoComplete: "off",
+                          spellCheck: false,
+                          placeholder: "What should the agent do first? Leave blank if you don’t want to kick anything off just yet.",
+                          value: prompt,
+                          onChange: (e) => setPrompt(e.target.value)
+                        }
+                      )
+                    ] }) })
                   ]
                 }
               ),
@@ -30393,9 +30411,10 @@ function FolderBrowser({
           type: "button",
           id: "rb-up",
           title: "Parent folder",
+          "aria-label": "Parent folder",
           disabled: !(data == null ? void 0 : data.parent),
           onClick: () => (data == null ? void 0 : data.parent) && load2(data.parent),
-          children: "↑"
+          children: "←"
         }
       ),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "rb-cwd", className: "rb-cwd", title: (data == null ? void 0 : data.path) || "", children: (data == null ? void 0 : data.path) || "" }),

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -5929,18 +5929,19 @@ p.set-hint {
   border-radius: 12px;
   padding: 20px 22px;
   /* One column, quick-launch first: Name + Prompt up top, Folder+Agent in a
-     compact row, then the git/workspace fold (open by default — those are the
-     settings people come here to change) and the launch-flag fold (closed;
-     extra CLI flags are a rarity). Sized to hold exactly that without
+     compact row, then three folds: git/workspace (open by default — those are
+     the settings people come here to change), the prompt, and launch flags
+     (both closed; most sessions start with neither). Sized to hold exactly that without
      scrolling, and no larger: a modal that fills the screen to show a form
-     half its size is its own kind of wrong. The 92vh share carries as much weight
-     as the pixel cap: on a short window it was the viewport clamp, not the
-     680px, that brought the scroll shadows back. The height stays FIXED (not
-     content-driven) so toggling a fold scrolls inside .nf-body rather than
+     half its size is its own kind of wrong, and one that reaches the top bar
+     has stopped reading as a card at all. The vh share carries as much weight as
+     the pixel cap: too low and the scroll shadows return on a short window,
+     too high and the card runs into the chrome above it. The height stays FIXED
+     (not content-driven) so toggling a fold scrolls inside .nf-body rather than
      growing and re-centering the dialog under the pointer; both axes clamp to
      the viewport on small windows. */
   width: min(660px, 94vw);
-  height: min(92vh, 760px);
+  height: min(86vh, 620px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/dialogs/NewSessionDialog.css
+++ b/frontend/src/components/dialogs/NewSessionDialog.css
@@ -27,18 +27,19 @@
   border-radius: 12px;
   padding: 20px 22px;
   /* One column, quick-launch first: Name + Prompt up top, Folder+Agent in a
-     compact row, then the git/workspace fold (open by default — those are the
-     settings people come here to change) and the launch-flag fold (closed;
-     extra CLI flags are a rarity). Sized to hold exactly that without
+     compact row, then three folds: git/workspace (open by default — those are
+     the settings people come here to change), the prompt, and launch flags
+     (both closed; most sessions start with neither). Sized to hold exactly that without
      scrolling, and no larger: a modal that fills the screen to show a form
-     half its size is its own kind of wrong. The 92vh share carries as much weight
-     as the pixel cap: on a short window it was the viewport clamp, not the
-     680px, that brought the scroll shadows back. The height stays FIXED (not
-     content-driven) so toggling a fold scrolls inside .nf-body rather than
+     half its size is its own kind of wrong, and one that reaches the top bar
+     has stopped reading as a card at all. The vh share carries as much weight as
+     the pixel cap: too low and the scroll shadows return on a short window,
+     too high and the card runs into the chrome above it. The height stays FIXED
+     (not content-driven) so toggling a fold scrolls inside .nf-body rather than
      growing and re-centering the dialog under the pointer; both axes clamp to
      the viewport on small windows. */
   width: min(660px, 94vw);
-  height: min(92vh, 760px);
+  height: min(86vh, 620px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/dialogs/NewSessionDialog.tsx
+++ b/frontend/src/components/dialogs/NewSessionDialog.tsx
@@ -272,14 +272,20 @@ export function NewSessionDialog() {
   const [inPlace, setInPlace] = useState(true);
   const [initRepo, setInitRepo] = useState(false);
   const [error, setError] = useState("");
-  // "More options" starts OPEN — hiding the git/workspace choices behind a
-  // click had people launch with the wrong strategy rather than discover it,
-  // and those are the settings this dialog exists to set. Launch flags stay
+  // "Git & workspace" starts OPEN — hiding those choices behind a click had
+  // people launch with the wrong strategy rather than discover it, and they
+  // are the settings this dialog exists to set. Launch flags stay
   // CLOSED: extra CLI flags are a per-session rarity, and the card is sized
   // for the form without them. Either fold's state is remembered for the life
   // of the dialog.
   const [advancedOpen, setAdvancedOpen] = useState(true);
   const [launchOpen, setLaunchOpen] = useState(false);
+  // The prompt is a fold too, and a closed one: a session started with no
+  // prompt is the common case (you drive it by hand from the terminal), and
+  // the textarea plus its preset row was the tallest block on the card. It
+  // sits BELOW the git/workspace options, where the things you set before
+  // launching are grouped.
+  const [promptOpen, setPromptOpen] = useState(false);
   const [templates, setTemplates] = useState<Template[]>([]);
   const [activeTemplate, setActiveTemplate] = useState("");
   const [provisioningAvailable, setProvisioningAvailable] = useState(false);
@@ -293,6 +299,7 @@ export function NewSessionDialog() {
   const launchDefaults = useRef<Record<string, string>>({});
   const titleRef = useRef<HTMLInputElement | null>(null);
   const launchRef = useRef<HTMLDetailsElement | null>(null);
+  const promptRef = useRef<HTMLDetailsElement | null>(null);
   // The modal's own element, so the opening focus can tell "nothing in here has
   // the caret yet" from "the user is already typing in one of these fields".
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -319,6 +326,7 @@ export function NewSessionDialog() {
     // second open onward.
     setAdvancedOpen(true);
     setLaunchOpen(false);
+    setPromptOpen(false);
     folderDo({ t: "reopen" });
     setActiveTemplate("");
     setPresetValue("");
@@ -472,6 +480,9 @@ export function NewSessionDialog() {
     setInPlace(!!t.in_place);
     setInitRepo(!!t.init_repo);
     setAdvancedOpen(!!(t.provisioned || t.init_repo || !t.in_place));
+    // A template that brings a prompt has just written into a fold that
+    // defaults shut; leaving it shut hides the text it filled in.
+    if (t.prompt) setPromptOpen(true);
     setActiveTemplate(t.name);
     if (!title.trim()) setTitle(t.name || "");
     titleRef.current?.focus();
@@ -728,7 +739,7 @@ export function NewSessionDialog() {
                   <button
                     type="button"
                     className="linklike"
-                    title="Ticks “Create a git repo in this folder” under More options"
+                    title="Ticks “Create a git repo in this folder” under Git & workspace"
                     onClick={armInitRepo}
                   >
                     Create one
@@ -786,74 +797,6 @@ export function NewSessionDialog() {
             />
           )}
 
-          <label>
-            <span>
-              Prompt{" "}
-              <span className="muted">— optional; sent to the agent at launch · Ctrl+Enter creates</span>
-            </span>
-            <span className="preset-row">
-              <select
-                id="new-preset"
-                title="Prompt presets — pick one to fill the prompt below (editable after)"
-                value={presetValue}
-                onChange={(e) => {
-                  setPresetValue(e.target.value);
-                  const p = findPreset(e.target.value);
-                  if (p) setPrompt(p.prompt);
-                }}
-              >
-                <option value="">Preset…</option>
-                {BUILTIN_PRESETS.length > 0 && (
-                  <optgroup label="Built-in">
-                    {BUILTIN_PRESETS.map((p) => (
-                      <option key={"b:" + p.name} value={"b:" + p.name} title={p.prompt}>
-                        {p.name}
-                      </option>
-                    ))}
-                  </optgroup>
-                )}
-                {savedPresets.length > 0 && (
-                  <optgroup label="Saved">
-                    {savedPresets.map((p) => (
-                      <option key={"u:" + p.name} value={"u:" + p.name} title={p.prompt}>
-                        {p.name}
-                      </option>
-                    ))}
-                  </optgroup>
-                )}
-              </select>
-              <button type="button" id="preset-save" title="Save current prompt as preset…" onClick={savePreset}>
-                Save…
-              </button>
-              {presetValue.startsWith("u:") && (
-                <button
-                  type="button"
-                  id="preset-del"
-                  title="Delete the selected saved preset"
-                  onClick={() => {
-                    const p = findPreset(presetValue);
-                    if (!p) return;
-                    const list = loadUserPresets().filter((q) => q.name !== p.name);
-                    saveUserPresets(list);
-                    setSavedPresets(list);
-                    setPresetValue("");
-                  }}
-                >
-                  ✕
-                </button>
-              )}
-            </span>
-            <textarea
-              id="new-prompt"
-              rows={2}
-              autoComplete="off"
-              spellCheck={false}
-              placeholder="What should the agent do first? Leave blank if you don’t want to kick anything off just yet."
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-            />
-          </label>
-
           <details
             id="new-advanced"
             className="nf-advanced"
@@ -862,7 +805,7 @@ export function NewSessionDialog() {
             onToggle={(e) => setAdvancedOpen((e.target as HTMLDetailsElement).open)}
           >
             <summary>
-              More options <span className="muted">— git &amp; workspace</span>
+              Git &amp; workspace
             </summary>
             <div className="nf-advanced-body">
               <label className="check">
@@ -928,6 +871,88 @@ export function NewSessionDialog() {
                   </p>
                 </div>
               )}
+            </div>
+          </details>
+
+          <details
+            id="new-prompt-fold"
+            className="nf-advanced"
+            ref={promptRef}
+            open={promptOpen}
+            onToggle={(e) => {
+              const open = (e.target as HTMLDetailsElement).open;
+              setPromptOpen(open);
+              if (open)
+                promptRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+            }}
+          >
+            <summary>
+              Prompt <span className="muted">— sent to the agent at launch</span>
+            </summary>
+            <div className="nf-advanced-body">
+              <label>
+                <span className="preset-row">
+                  <select
+                    id="new-preset"
+                    title="Prompt presets — pick one to fill the prompt below (editable after)"
+                    value={presetValue}
+                    onChange={(e) => {
+                      setPresetValue(e.target.value);
+                      const p = findPreset(e.target.value);
+                      if (p) setPrompt(p.prompt);
+                    }}
+                  >
+                    <option value="">Preset…</option>
+                    {BUILTIN_PRESETS.length > 0 && (
+                      <optgroup label="Built-in">
+                        {BUILTIN_PRESETS.map((p) => (
+                          <option key={"b:" + p.name} value={"b:" + p.name} title={p.prompt}>
+                            {p.name}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+                    {savedPresets.length > 0 && (
+                      <optgroup label="Saved">
+                        {savedPresets.map((p) => (
+                          <option key={"u:" + p.name} value={"u:" + p.name} title={p.prompt}>
+                            {p.name}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+                  </select>
+                  <button type="button" id="preset-save" title="Save current prompt as preset…" onClick={savePreset}>
+                    Save…
+                  </button>
+                  {presetValue.startsWith("u:") && (
+                    <button
+                      type="button"
+                      id="preset-del"
+                      title="Delete the selected saved preset"
+                      onClick={() => {
+                        const p = findPreset(presetValue);
+                        if (!p) return;
+                        const list = loadUserPresets().filter((q) => q.name !== p.name);
+                        saveUserPresets(list);
+                        setSavedPresets(list);
+                        setPresetValue("");
+                      }}
+                    >
+                      ✕
+                    </button>
+                  )}
+                </span>
+                <textarea
+                  id="new-prompt"
+                  rows={2}
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="What should the agent do first? Leave blank if you don’t want to kick anything off just yet."
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                />
+              </label>
             </div>
           </details>
 
@@ -1098,14 +1123,18 @@ function FolderBrowser({
   return (
     <div id="repo-browser">
       <div className="rb-head">
+        {/* ← rather than ↑: every file browser people already use — Finder,
+            Explorer, a web page — spells "out of here" as back, and the row
+            list reads as a place you stepped into, not a level you climbed. */}
         <button
           type="button"
           id="rb-up"
           title="Parent folder"
+          aria-label="Parent folder"
           disabled={!data?.parent}
           onClick={() => data?.parent && load(data.parent)}
         >
-          ↑
+          ←
         </button>
         <span id="rb-cwd" className="rb-cwd" title={data?.path || ""}>
           {data?.path || ""}

--- a/tests/unit/test_frontend_settings_revamp.py
+++ b/tests/unit/test_frontend_settings_revamp.py
@@ -373,8 +373,11 @@ def test_new_session_ctrl_enter_submits_at_dialog_level():
     # The prompt textarea carries no onKeyDown, so a plain Enter still newlines.
     prompt = js.split('id: "new-prompt"', 1)[1][:400]
     assert "onKeyDown" not in prompt
-    # The hint advertises the shortcut.
-    assert "Ctrl+Enter creates" in js
+    # The shortcut is deliberately NOT advertised in the dialog any more — the
+    # prompt summary was carrying a hint for a key nobody needed told about,
+    # and the label is worth more as a name than as a cheat sheet. It still
+    # works; that is what everything above this line pins.
+    assert "Ctrl+Enter creates" not in js
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_frontend_ux.py
+++ b/tests/unit/test_frontend_ux.py
@@ -127,16 +127,15 @@ def test_app_js_has_no_maximize_ui():
 # --------------------------------------------------------------------------- #
 def test_new_dialog_folds_git_workspace_options():
     html = client.get("/").text
-    # Git/workspace options live behind a "More options" fold — the defaults
-    # suit the common case, and fillFromTemplate() auto-opens the fold when a
-    # template turns any of them on. Name/folder/prompt stay up top, unfolded.
+    # Git/workspace options live behind a "Git & workspace" fold, and
+    # fillFromTemplate() opens it when a template turns any of them on.
     assert 'id: "new-advanced"' in client.get("/app.js").text
     js = client.get("/app.js").text
     assert '"new-in-place"' in js  # work-in-place toggle
     assert '"new-init-repo"' in js  # git init lives here
-    # "More options" stands OPEN by default — hiding the workspace strategy
+    # "Git & workspace" stands OPEN by default — hiding the workspace strategy
     # behind a click had people launching with the wrong one rather than
-    # finding it. The launch-flags fold below it stays closed.
+    # finding it. The prompt and launch-flags folds below it stay closed.
     assert "nf-advanced" in js
 
 


### PR DESCRIPTION
The New Session card, from the top: Name, Folder + Agent, then three folds —
Git & workspace open, Prompt and Launch flags shut.

The prompt moved below the git/workspace options and became a fold of its own,
closed. A session started with no prompt is the ordinary case (you drive it
from the terminal), and the textarea plus its preset row was the tallest block
on the card; the things you set BEFORE launching now read as one group. A
template carrying a prompt opens the fold, since otherwise it writes text into
a section you cannot see.

That freed enough room to bring the card down to 660x620 from 660x760 — it was
reaching the top bar, and a modal that touches the chrome has stopped reading
as a card.

Naming: the fold is "Git & workspace", not "More options — git & workspace"
(a label that says what is inside beats one that says there is more of it),
and the prompt summary no longer advertises "optional" or "Ctrl+Enter
creates" — the shortcut still works, it just isn't sold in the label.

And the folder browser's parent button is ← rather than ↑. Finder, Explorer
and the browser all spell "out of here" as back, and the row list reads as a
place you stepped into, not a level you climbed.

Signed-off-by: emandel2630 <emandel2630@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)