### PR TITLE
Release 0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the tab counts are already filled in. Skipped when no ticketing source is
   connected, and paused while the window is hidden.
 
+### Fixed
+
+- **"PR merged or closed" stopped crying wolf.** Both PR notifications — the
+  browser/ntfy alert and the in-app toast — were inferred from the stage pill
+  leaving or re-entering the `pr` rung. But the stage ladder drops to `agent` the
+  moment the working tree goes dirty, before it has even looked the PR up, so an
+  agent iterating on review feedback walked `pr → agent → committed → pushed → pr`
+  on every single edit. Each lap announced that the pull request had been merged
+  or closed, then that it had opened again, for a PR that never moved.
+
+  A new `session.pr_state_changed` event carries the PR's own state instead, and
+  both channels key off that, so each transition is announced once when it really
+  happens. A lookup that fails — no `gh`, a rate limit, a network blip — is never
+  read as a close; a first sighting seeds silently, so a restart cannot
+  re-announce an already-merged PR; and switching branches re-seeds rather than
+  reporting the previous branch's PR as closed.
+
+### Changed
+
+- **Expanding a pinned prompt no longer shoves the terminal.** The full prompt
+  used to open in flow, which shrank the terminal container, refit xterm and
+  resized the real tmux pane — so reading what a session was asked to do reflowed
+  the output you were reading it against, and cost a PTY resize on every toggle.
+  It now draws over the terminal instead, anchored on the bar itself so the first
+  line lands exactly where the collapsed summary was, with no blank row and no
+  duplicated line. The bar stays one line tall in both states, so the terminal
+  never moves.
+
 ## [0.1.16] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17] - 2026-08-11
+
 ### Added
 
 - **✨ writes the commit message.** The commit dialog has a button that reads the
@@ -1260,7 +1262,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.16...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.17...HEAD
+[0.1.17]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.17
 [0.1.16]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.16
 [0.1.15]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.15
 [0.1.14]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.14

--- a/backend/web/addons/notify.py
+++ b/backend/web/addons/notify.py
@@ -64,15 +64,20 @@ NOTIFY_RULES: List[dict] = [
         "tags": ["question"],
     },
     {
-        # There is no dedicated "merged" event: an open PR sets stage "pr", and
-        # merging/closing it moves the stage off "pr" (usually to "pushed").
+        # Keyed on the PR lookup's own state, NOT on the stage leaving "pr".
+        # The stage ladder drops off "pr" whenever the tree goes dirty or a
+        # commit runs (agent_state._session_stage returns "agent"/"precommit"
+        # before it ever consults the PR), so the old `stage_changed old="pr"`
+        # rule fired "PR merged or closed" on every edit of a PR that was open
+        # the whole time — then fired again as the session climbed back to "pr".
+        # `old: "OPEN"` covers both real endings (MERGED and CLOSED).
         "id": "pr_closed",
         "label": "A pull request is merged or closed",
-        "event": "session.stage_changed",
-        "old": "pr",
+        "event": "session.pr_state_changed",
+        "old": "OPEN",
         "new": None,
         "title": "{session}: PR merged or closed",
-        "body": "The pull request left the open-review stage.",
+        "body": "The pull request is no longer open.",
         "default_enabled": True,
         "priority": 3,
         "tags": ["white_check_mark"],

--- a/backend/web/core/agent_state.py
+++ b/backend/web/core/agent_state.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import threading
 import time
 from typing import Dict, Optional
 
@@ -28,6 +29,7 @@ from backend import session
 from backend.providers.usage_limits import is_limit_screen
 from backend.session import tmux
 from backend.session.storage import Loading
+from backend.web.core import events as _events
 from backend.web.core.terminal import _exit_marker_path
 
 
@@ -136,6 +138,54 @@ _THREAD_RECORD_AT: dict = {}
 # user is actually on, not a previous task's leftovers. Dict ops are
 # GIL-atomic and every drift step is idempotent, so no lock is needed.
 _LAST_BRANCH: Dict[str, str] = {}
+
+# Last PR state observed per session title, as ``(branch, state)`` — the memory
+# behind ``session.pr_state_changed``. Kept separate from the stage ladder on
+# purpose: ``_session_stage`` drops off the "pr" rung whenever the tree goes
+# dirty, a commit runs, or pre-commit blocks one, so "the stage left pr" is NOT
+# "the PR closed". Consumers that inferred it that way announced a merge (and
+# then a re-open) on every edit/commit/push cycle of a PR that never moved.
+_LAST_PR_STATE: Dict[str, tuple] = {}
+_LAST_PR_STATE_LOCK = threading.Lock()
+
+
+def _track_pr_state(title: str, branch: str, info) -> None:
+    """Emit ``session.pr_state_changed`` when ``branch``'s PR really moved.
+
+    ``info`` is :func:`server._pr_info`'s answer — ``{"url", "state"}`` or None.
+    A missing/None ``info`` is never a transition: it means the lookup did not
+    happen (no commits beyond base, or the stage returned early), the branch has
+    no PR, or the lookup FAILED — and ``_pr_info`` cannot distinguish the last
+    two past its sticky window. Treating that as "closed" is exactly the false
+    alarm this event exists to remove, so it is dropped instead.
+
+    First sighting seeds silently (a restart must not re-announce a PR that was
+    already merged), and so does a branch change (a different branch is a
+    different PR, not a transition of this one). Never raises: a notification
+    must never break the stage probe.
+    """
+    state = str((info or {}).get("state") or "").upper()
+    if not title or not branch or not state:
+        return
+    with _LAST_PR_STATE_LOCK:
+        prev = _LAST_PR_STATE.get(title)
+        _LAST_PR_STATE[title] = (branch, state)
+        if prev is None or prev[0] != branch or prev[1] == state:
+            return
+        old = prev[1]
+    # Outside the lock: emit runs subscribers (the notify addon pushes to ntfy)
+    # on this thread, and the poll must not serialize behind them.
+    try:
+        _events.BUS.emit(
+            "session.pr_state_changed",
+            session=title,
+            old=old,
+            new=state,
+            data={"url": (info or {}).get("url") or ""},
+        )
+    except Exception:  # noqa: BLE001 — an event never breaks the stage probe
+        pass
+
 
 # Foreground commands that mean "no agent is running in this pane" — the CLI
 # exited (or its launcher dropped to a shell), so the pane can't be 'working'.
@@ -1280,6 +1330,12 @@ def _session_stage(inst) -> dict:
         # miss the real PR and wedge the chip on "pushed". `beyond` still keys
         # off the fork-point ("is there work to push"), not where the PR goes.
         info = srv._pr_info(wt, branch) if beyond > 0 else None
+        # Announce a REAL PR-state transition from the lookup itself, here where
+        # the answer is in hand and BEFORE the dirty-tree branch below returns
+        # the stage to "agent". Subscribers used to infer "merged or closed"
+        # from the stage leaving "pr", which that very return makes it do on
+        # every edit — see _track_pr_state.
+        _track_pr_state(getattr(inst, "Title", "") or "", branch, info)
         # Surface the PR's URL so the chip can link to it whatever its state
         # (open / merged / closed) — a PR-review session has one from the start.
         if info and info.get("url"):

--- a/backend/web/core/events.py
+++ b/backend/web/core/events.py
@@ -57,6 +57,16 @@ EVENT_NAMES = (
     # "loop": bool}).
     "session.prompt_sent",
     "session.queue_changed",
+    # A session's pull request genuinely changed state: ``old``/``new`` are the
+    # GitHub states ("" | OPEN | MERGED | CLOSED), data: {"url": str}. This is
+    # NOT derivable from ``session.stage_changed``: the stage ladder drops off
+    # "pr" whenever the tree goes dirty or a commit runs (see
+    # ``agent_state._session_stage``), so a PR that stayed open the whole time
+    # used to look like it had closed and re-opened on every edit/commit/push
+    # cycle — firing "PR merged or closed" and then "PR open" over and over.
+    # Emitted only when the PR lookup itself reports a different state, so it
+    # fires once per real transition.
+    "session.pr_state_changed",
     # Usage limits (roadmap D): the provider's window reopened for a session
     # that had run out — emitted once per reopening, by the drain-loop watcher
     # that also nudges such a session to carry on (data: {"resumed": bool}).

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -24491,19 +24491,29 @@ function EventToasts() {
         if (env.new) patchInstance(env.session, { stage: String(env.new) });
         if (isReplay(env)) return;
         const title = env.session;
-        if (env.new === "pr") {
-          notifyOnce(title, "pr", "PR open for " + title, {
-            onClick: () => {
-              const inst = instByTitle(title);
-              if (inst == null ? void 0 : inst.pr_url) window.open(inst.pr_url, "_blank");
-              else selectSession(title);
-            }
-          });
-        } else if (env.new === "interrupt") {
+        if (env.new === "interrupt") {
           notifyOnce(title, "interrupt", "pre-commit failed on " + title, {
             onClick: () => selectSession(title)
           });
-        } else if (env.old === "pr") {
+        }
+      })
+    );
+    unsubs.push(
+      ev.subscribe("session.pr_state_changed", (env) => {
+        var _a3;
+        if (isReplay(env)) return;
+        const title = env.session;
+        const url = String(((_a3 = env.data) == null ? void 0 : _a3.url) || "");
+        if (env.new === "OPEN") {
+          notifyOnce(title, "pr", "PR open for " + title, {
+            onClick: () => {
+              const inst = instByTitle(title);
+              const href = (inst == null ? void 0 : inst.pr_url) || url;
+              if (href) window.open(href, "_blank");
+              else selectSession(title);
+            }
+          });
+        } else if (env.old === "OPEN") {
           notifyOnce(title, "merged", title + ": PR merged or closed ✓", {
             onClick: () => selectSession(title)
           });
@@ -28301,10 +28311,9 @@ function Pane({
   }, [pinOpen, ghostIsLatest, ghostCore, title, lookup]);
   const pinBody = ghostIsLatest ? inst.last_prompt_full || inst.last_prompt : (lookup == null ? void 0 : lookup.q) === ghostCore ? lookup.text : ghost;
   const hasPin = !!pinLine;
-  const pinLen = (pinBody || "").length;
   reactExports.useEffect(() => {
     fitSoon();
-  }, [hasPin, pinOpen, pinLen, fitSoon]);
+  }, [hasPin, fitSoon]);
   reactExports.useEffect(() => {
     if (!focused || missing || loading || histPane) return;
     const onKey = (e) => {
@@ -28642,7 +28651,8 @@ function Pane({
                   children: "❯"
                 }
               ),
-              pinOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "prompt-pin-body", children: pinBody }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "prompt-pin-text", children: pinLine }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "prompt-pin-text", children: pinLine }),
+              pinOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "prompt-pin-body", children: pinBody }) : null,
               ghost ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "ghost-row-mask", "aria-hidden": "true" }) : null
             ] }) : null,
             !booted && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "term-loading", children: [

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -4906,10 +4906,14 @@ p.set-hint {
 
 /* Pinned prompt: first line of the session's latest user prompt. Bleeds to
    the pane edges (negative margins swallow .pane-term's padding) so it reads
-   as a header, not content. */
+   as a header, not content.
+
+   The BAR is always exactly one line tall — open or closed. That is load
+   bearing: it is the only part of the pin that is in flow, so expanding a
+   prompt cannot change the terminal's height (see .prompt-pin-body). */
 .prompt-pin {
   flex: none;
-  position: relative; /* anchors .ghost-row-mask */
+  position: relative; /* anchors .ghost-row-mask and .prompt-pin-body */
   display: flex;
   align-items: baseline;
   gap: 6px;
@@ -4961,19 +4965,66 @@ p.set-hint {
   text-overflow: ellipsis;
 }
 
-/* The whole prompt, in-flow (the terminal refits beneath it). Capped at a
-   few lines with its own scrollbar so a long prompt can't eat the pane. */
+/* Open: the panel covers this line, so hide it — but with visibility, NOT
+   display. A hidden element still occupies its line, which is what keeps the
+   bar one line tall and the terminal from moving. Removing it from flow would
+   collapse the bar to the arrow's height and reintroduce exactly the shift this
+   whole arrangement exists to avoid. (Hiding it also keeps the covered copy out
+   of drag-selection, which an opaque panel alone would not.) */
+.prompt-pin.pin-open .prompt-pin-text {
+  visibility: hidden;
+}
+
+/* Open, the pin becomes its own stacking context so the panel and the arrow
+   ride together at ONE depth against the pane's other layers: over the
+   terminal, the ghost-row mask and the boot loader (3) — an explicitly opened
+   prompt should be readable — but under file-drop (5) and the budget lock (6),
+   which are modal and must always win. Inside it the z-indexes below are local,
+   so they can be ordered freely without touching that ranking. */
+.prompt-pin.pin-open {
+  z-index: 4;
+}
+
+/* The whole prompt, as an OVERLAY over the bar — deliberately NOT in flow. In
+   flow it grew the pin, which shrank .term-container, which refit xterm and
+   resized the real tmux pane: reading a prompt reflowed the output you were
+   reading it against, and cost a PTY resize on every toggle. Out of flow, the
+   bar stays one line and the terminal never moves.
+
+   top: 0 (not 100%) so the panel replaces the bar rather than hanging beneath
+   it — its first line lands exactly where the collapsed summary was, with no
+   blank row left behind. Capped with its own scrollbar so a long prompt can't
+   blanket the pane. */
 .prompt-pin .prompt-pin-body {
-  flex: 1 1 auto;
-  min-width: 0;
-  max-height: 110px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 4; /* local (see .prompt-pin.pin-open): over the ghost-row mask */
+  max-height: 140px;
   overflow-y: auto;
+  padding: 4px 10px 8px;
+  /* First line only, clearing the arrow the panel is drawn over — so the text
+     starts on the same column it occupied collapsed, and later lines use the
+     full width. Tracks the arrow's box (2px padding + glyph + the bar's 6px
+     flex gap), which is fixed at this font-size. */
+  text-indent: 17px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
   color: var(--text);
   line-height: 1.45;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   user-select: text;
   cursor: text;
+}
+
+/* ...and the arrow stays above the panel it is drawn over, so the prompt can
+   still be collapsed from exactly where it was opened. */
+.prompt-pin.pin-open .prompt-pin-mark {
+  position: relative;
+  z-index: 5; /* local — see .prompt-pin.pin-open */
 }
 
 .pane-term .xterm {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/frontend/src/components/EventToasts.tsx
+++ b/frontend/src/components/EventToasts.tsx
@@ -270,21 +270,33 @@ export function EventToasts() {
         if (env.new) patchInstance(env.session, { stage: String(env.new) as Instance["stage"] });
         if (isReplay(env)) return; // toast-only subscriber — skip stale history
         const title = env.session;
-        if (env.new === "pr") {
-          notifyOnce(title, "pr", "PR open for " + title, {
-            onClick: () => {
-              const inst = instByTitle(title);
-              if (inst?.pr_url) window.open(inst.pr_url, "_blank");
-              else selectSession(title);
-            },
-          });
-        } else if (env.new === "interrupt") {
+        if (env.new === "interrupt") {
           notifyOnce(title, "interrupt", "pre-commit failed on " + title, {
             onClick: () => selectSession(title),
           });
-        } else if (env.old === "pr") {
-          // F4: the server never emits "merged" — a merged/closed PR moves the
-          // stage OFF "pr" (same detection as the notify addon).
+        }
+        // Both PR toasts moved to session.pr_state_changed below. The stage
+        // ladder leaves and re-enters "pr" on every edit/commit/push cycle of a
+        // PR that never moved, and notifyOnce only dedupes for 30s — so keying
+        // them here re-toasted "PR merged or closed" and then "PR open" for the
+        // rest of a review session.
+      })
+    );
+    unsubs.push(
+      ev.subscribe("session.pr_state_changed", (env) => {
+        if (isReplay(env)) return;
+        const title = env.session;
+        const url = String((env.data as { url?: string } | undefined)?.url || "");
+        if (env.new === "OPEN") {
+          notifyOnce(title, "pr", "PR open for " + title, {
+            onClick: () => {
+              const inst = instByTitle(title);
+              const href = inst?.pr_url || url;
+              if (href) window.open(href, "_blank");
+              else selectSession(title);
+            },
+          });
+        } else if (env.old === "OPEN") {
           notifyOnce(title, "merged", title + ": PR merged or closed ✓", {
             onClick: () => selectSession(title),
           });

--- a/frontend/src/components/grid/Pane.css
+++ b/frontend/src/components/grid/Pane.css
@@ -256,10 +256,14 @@
 
 /* Pinned prompt: first line of the session's latest user prompt. Bleeds to
    the pane edges (negative margins swallow .pane-term's padding) so it reads
-   as a header, not content. */
+   as a header, not content.
+
+   The BAR is always exactly one line tall — open or closed. That is load
+   bearing: it is the only part of the pin that is in flow, so expanding a
+   prompt cannot change the terminal's height (see .prompt-pin-body). */
 .prompt-pin {
   flex: none;
-  position: relative; /* anchors .ghost-row-mask */
+  position: relative; /* anchors .ghost-row-mask and .prompt-pin-body */
   display: flex;
   align-items: baseline;
   gap: 6px;
@@ -311,19 +315,66 @@
   text-overflow: ellipsis;
 }
 
-/* The whole prompt, in-flow (the terminal refits beneath it). Capped at a
-   few lines with its own scrollbar so a long prompt can't eat the pane. */
+/* Open: the panel covers this line, so hide it — but with visibility, NOT
+   display. A hidden element still occupies its line, which is what keeps the
+   bar one line tall and the terminal from moving. Removing it from flow would
+   collapse the bar to the arrow's height and reintroduce exactly the shift this
+   whole arrangement exists to avoid. (Hiding it also keeps the covered copy out
+   of drag-selection, which an opaque panel alone would not.) */
+.prompt-pin.pin-open .prompt-pin-text {
+  visibility: hidden;
+}
+
+/* Open, the pin becomes its own stacking context so the panel and the arrow
+   ride together at ONE depth against the pane's other layers: over the
+   terminal, the ghost-row mask and the boot loader (3) — an explicitly opened
+   prompt should be readable — but under file-drop (5) and the budget lock (6),
+   which are modal and must always win. Inside it the z-indexes below are local,
+   so they can be ordered freely without touching that ranking. */
+.prompt-pin.pin-open {
+  z-index: 4;
+}
+
+/* The whole prompt, as an OVERLAY over the bar — deliberately NOT in flow. In
+   flow it grew the pin, which shrank .term-container, which refit xterm and
+   resized the real tmux pane: reading a prompt reflowed the output you were
+   reading it against, and cost a PTY resize on every toggle. Out of flow, the
+   bar stays one line and the terminal never moves.
+
+   top: 0 (not 100%) so the panel replaces the bar rather than hanging beneath
+   it — its first line lands exactly where the collapsed summary was, with no
+   blank row left behind. Capped with its own scrollbar so a long prompt can't
+   blanket the pane. */
 .prompt-pin .prompt-pin-body {
-  flex: 1 1 auto;
-  min-width: 0;
-  max-height: 110px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 4; /* local (see .prompt-pin.pin-open): over the ghost-row mask */
+  max-height: 140px;
   overflow-y: auto;
+  padding: 4px 10px 8px;
+  /* First line only, clearing the arrow the panel is drawn over — so the text
+     starts on the same column it occupied collapsed, and later lines use the
+     full width. Tracks the arrow's box (2px padding + glyph + the bar's 6px
+     flex gap), which is fixed at this font-size. */
+  text-indent: 17px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
   color: var(--text);
   line-height: 1.45;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   user-select: text;
   cursor: text;
+}
+
+/* ...and the arrow stays above the panel it is drawn over, so the prompt can
+   still be collapsed from exactly where it was opened. */
+.prompt-pin.pin-open .prompt-pin-mark {
+  position: relative;
+  z-index: 5; /* local — see .prompt-pin.pin-open */
 }
 
 .pane-term .xterm {

--- a/frontend/src/components/grid/Pane.tsx
+++ b/frontend/src/components/grid/Pane.tsx
@@ -188,14 +188,17 @@ export function Pane({
       ? lookup.text
       : ghost;
 
-  // The pinned prompt is in-flow, so any change to its height — appearing,
-  // collapsing, or the prompt text itself changing — resizes the terminal
-  // without touching .pane-body, and the ResizeObserver above never fires.
+  // Only the pin's APPEARING or disappearing changes the terminal's height, and
+  // it does so without touching .pane-body, so the ResizeObserver above never
+  // fires for it. Expanding is not in this list on purpose: the body is an
+  // overlay, so opening a prompt costs no refit and no tmux resize (which the
+  // backend's activity classifier would have to rebaseline anyway). The bar's
+  // own text is ellipsized to one line, so changing it can't change the height
+  // either.
   const hasPin = !!pinLine;
-  const pinLen = (pinBody || "").length;
   useEffect(() => {
     fitSoon();
-  }, [hasPin, pinOpen, pinLen, fitSoon]);
+  }, [hasPin, fitSoon]);
 
   // Ctrl+↑ / Ctrl+↓ on the focused pane opens the full-history view (at the
   // top / bottom respectively). Once it's open its own handler owns these
@@ -557,9 +560,10 @@ export function Pane({
           {/* Pinned prompt: what this session was last asked to do, always
               visible while the output scrolls beneath it (the behavior the
               mobile view's short screen gives for free). One line by default;
-              clicking the arrow — and only the arrow, no hover — expands the
-              whole prompt in-flow, capped at a few lines with its own
-              scrollbar. Rendered before the terminal container adopt()
+              clicking the arrow — and only the arrow, no hover — drops the
+              whole prompt OVER the terminal, capped at a few lines with its own
+              scrollbar. Over, not in flow: expanding must not shove the output
+              you are reading. Rendered before the terminal container adopt()
               appends, so it sits above the terminal in the flex column. */}
           {pinLine ? (
             <div className={"prompt-pin" + (pinOpen ? " pin-open" : "")}>
@@ -575,11 +579,14 @@ export function Pane({
               >
                 ❯
               </button>
-              {pinOpen ? (
-                <div className="prompt-pin-body">{pinBody}</div>
-              ) : (
-                <span className="prompt-pin-text">{pinLine}</span>
-              )}
+              {/* The one-line summary is always RENDERED, even when open — it
+                  is what holds the bar at exactly one line, so expanding never
+                  resizes the terminal. Open, the body is drawn OVER the bar and
+                  Pane.css hides this copy with visibility while it keeps
+                  occupying that line — so there is no duplicated first line and
+                  no blank row, and the terminal still never moves. */}
+              <span className="prompt-pin-text">{pinLine}</span>
+              {pinOpen ? <div className="prompt-pin-body">{pinBody}</div> : null}
               {/* While the TUI's own pinned row is being mirrored above, hide
                   the duplicate: a strip of terminal background over the top
                   row (desktop only by construction — mobile has no bar). */}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.16"
+version = "0.1.17"
 description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -96,6 +96,7 @@ def test_event_names_vocabulary_is_complete():
         "session.status_changed",
         "session.activity_changed",
         "session.stage_changed",
+        "session.pr_state_changed",
         "session.budget_exceeded",
         "session.prompt_sent",
         "session.queue_changed",

--- a/tests/unit/test_frontend_wave2.py
+++ b/tests/unit/test_frontend_wave2.py
@@ -140,9 +140,13 @@ def test_app_js_wave3_wiring():
     js = client.get("/app.js").text
     # F3: toast published on the public extension API
     assert ".toast = toast" in js
-    # F4: merged-PR detection keys off leaving the "pr" stage; the dead
-    # new==="merged" listener branch is gone (the server never emits it).
-    assert 'env.old === "pr"' in js
+    # F4: merged-PR detection keys off the PR's OWN state, via
+    # session.pr_state_changed. It must NOT key off the stage leaving "pr" —
+    # the stage ladder does that on every edit under an open PR, which toasted
+    # "merged or closed" (then "PR open" again) for a PR that never moved.
+    assert 'ev.subscribe("session.pr_state_changed"' in js
+    assert 'env.old === "OPEN"' in js
+    assert 'env.old === "pr"' not in js
     assert 'env.new === "merged"' not in js
     # F5 retired: neither the managed-repo label nor the foreign-repo ⇄ chip remain.
     assert "repo_root" not in js

--- a/tests/unit/test_frontend_wave5.py
+++ b/tests/unit/test_frontend_wave5.py
@@ -95,10 +95,13 @@ def test_app_js_toast_subscribers_skip_replays():
     assert 'typeof ev.isReplay === "function"' in js
     # Clarify toast/badge arming gated; state repaint (forceActivity) is not.
     assert 'env.new === "clarify" && !isReplay(env)' in js
-    # Stage (PR / interrupt / merged) and budget subscribers bail on replays.
-    assert js.count("if (isReplay(env)) return;") >= 2
+    # Stage (interrupt), PR-state (open / merged) and budget subscribers all
+    # bail on replays.
+    assert js.count("if (isReplay(env)) return;") >= 3
     stage = js[js.index('ev.subscribe("session.stage_changed"') :]
-    assert stage.index("isReplay(env)") < stage.index('env.new === "pr"')
+    assert stage.index("isReplay(env)") < stage.index('env.new === "interrupt"')
+    pr = js[js.index('ev.subscribe("session.pr_state_changed"') :]
+    assert pr.index("isReplay(env)") < pr.index('env.new === "OPEN"')
     budget = js[js.index('ev.subscribe("session.budget_exceeded"') :]
     assert budget.index("isReplay(env)") < budget.index("exceeded its budget")
 

--- a/tests/unit/test_ntfy.py
+++ b/tests/unit/test_ntfy.py
@@ -626,17 +626,31 @@ def test_dispatch_ignores_unrelated_events(pushes):
     S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
     addon = _addon()
     addon._on_event({**_clarify(), "event": "session.created", "new": None})
-    # stage_changed off "pr" matches pr_closed; onto "pr" must not.
+    # The stage ladder leaves "pr" on every edit and climbs back on every push.
+    # NEITHER direction is a PR closing, and pr_closed no longer keys off it.
     addon._on_event(
         {**_clarify(), "event": "session.stage_changed", "old": "pushed", "new": "pr"}
+    )
+    addon._on_event(
+        {**_clarify(), "event": "session.stage_changed", "old": "pr", "new": "agent"}
+    )
+    # A PR opening is not a PR closing either.
+    addon._on_event(
+        {**_clarify(), "event": "session.pr_state_changed", "old": "", "new": "OPEN"}
     )
     assert pushes == []
 
 
-def test_pr_closed_matches_leaving_the_pr_stage(pushes):
+@pytest.mark.parametrize("ending", ["MERGED", "CLOSED"])
+def test_pr_closed_matches_a_real_pr_ending(pushes, ending):
     S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
     _addon()._on_event(
-        {**_clarify(), "event": "session.stage_changed", "old": "pr", "new": "pushed"}
+        {
+            **_clarify(),
+            "event": "session.pr_state_changed",
+            "old": "OPEN",
+            "new": ending,
+        }
     )
     (push,) = pushes
     assert push["title"] == "alpha: PR merged or closed"

--- a/tests/unit/test_pr_state_events.py
+++ b/tests/unit/test_pr_state_events.py
@@ -1,0 +1,248 @@
+"""``session.pr_state_changed`` fires once per REAL pull-request transition.
+
+The regression this locks down: "PR merged or closed" and "PR open" used to be
+inferred from the stage pill leaving / re-entering the ``pr`` rung. But
+``_session_stage`` returns ``agent`` the moment the tree is dirty — before it
+even looks at the PR — so an agent iterating on review feedback walked
+``pr -> agent -> committed -> pushed -> pr`` on every single edit, and the user
+got "PR merged or closed ✓" followed by "PR open for X", over and over, for a
+pull request that never moved.
+
+The event now comes from the PR lookup's own state, so a PR that stays open is
+silent no matter what the working tree does.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.session.storage import Status
+from backend.web import server
+from backend.web.addons import notify
+from backend.web.core import agent_state
+from backend.web.core import events as events_mod
+
+
+# --------------------------------------------------------------------------- #
+# helpers (same shapes as test_stage_branch_drift.py)
+# --------------------------------------------------------------------------- #
+def _git(*args: str, cwd: str) -> str:
+    cp = subprocess.run(
+        ["git", "-C", cwd, "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        capture_output=True,
+        text=True,
+    )
+    assert cp.returncode == 0, cp.stderr + cp.stdout
+    return cp.stdout.strip()
+
+
+def _repo_with_feature_commit(path: Path) -> Path:
+    """A repo on ``feat`` with one commit beyond ``main`` — so the stage probe
+    has something to push and actually performs the PR lookup."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+    exclude = path / ".git" / "info" / "exclude"
+    exclude.parent.mkdir(parents=True, exist_ok=True)
+    exclude.write_text(".mindflock_*\n")
+    (path / "a.txt").write_text("one\n")
+    _git("add", "-A", cwd=str(path))
+    _git("commit", "-q", "-m", "init", cwd=str(path))
+    _git("checkout", "-q", "-b", "feat", cwd=str(path))
+    (path / "b.txt").write_text("two\n")
+    _git("add", "-A", cwd=str(path))
+    _git("commit", "-q", "-m", "work", cwd=str(path))
+    return path
+
+
+class _FakeInst:
+    Program = "bash"
+    Path = ""
+    InPlace = False
+
+    def __init__(self, wt: str, *, branch: str = "feat", title: str = "t"):
+        self.Title = title
+        self.Branch = branch
+        self.BaseBranch = "main"
+        self.Status = Status.Running
+        self._wt = wt
+
+    def Started(self):  # noqa: N802
+        return True
+
+    def GetWorktreePath(self):  # noqa: N802
+        return self._wt
+
+
+@pytest.fixture
+def bus_events():
+    """Every envelope emitted during the test, in order."""
+    seen: list = []
+    unsubscribe = events_mod.BUS.subscribe(seen.append)
+    yield seen
+    unsubscribe()
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches(monkeypatch):
+    caches = (
+        server._BASE_BRANCH_CACHE,
+        server._DIFF_STAT_CACHE,
+        server._PR_CACHE,
+        server._ORIGIN_SHA_CACHE,
+        server._PROBE_CACHE,
+        agent_state._LAST_BRANCH,
+        agent_state._LAST_PR_STATE,
+    )
+    for cache in caches:
+        cache.clear()
+    monkeypatch.setattr(server, "_failed_precommit_step", lambda title: "hook")
+    yield
+    for cache in caches:
+        cache.clear()
+
+
+def _pr_states(envelopes):
+    return [
+        (e["old"], e["new"])
+        for e in envelopes
+        if e["event"] == "session.pr_state_changed"
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# The regression: a working tree churning under an OPEN PR is silent
+# --------------------------------------------------------------------------- #
+def test_dirty_tree_under_open_pr_emits_nothing(tmp_path, monkeypatch, bus_events):
+    wt = _repo_with_feature_commit(tmp_path / "r")
+    inst = _FakeInst(str(wt))
+    monkeypatch.setattr(
+        server, "_pr_info", lambda *a, **k: {"url": "u", "state": "OPEN"}
+    )
+
+    # Poll once with a clean tree: first sighting only SEEDS (a restart must not
+    # re-announce a PR that was already open).
+    server._session_stage(inst)
+    assert _pr_states(bus_events) == []
+
+    # The agent edits a file -> the stage ladder drops to "agent"...
+    (wt / "a.txt").write_text("edited\n")
+    server._PROBE_CACHE.clear()
+    assert server._session_stage(inst)["stage"] == "agent"
+
+    # ...and the agent commits, walking the stage back up toward "pr".
+    _git("add", "-A", cwd=str(wt))
+    _git("commit", "-q", "-m", "fix review", cwd=str(wt))
+    server._PROBE_CACHE.clear()
+    server._session_stage(inst)
+
+    # The PR was OPEN the whole time, so nothing was announced.
+    assert _pr_states(bus_events) == []
+
+
+# --------------------------------------------------------------------------- #
+# Real transitions still fire — exactly once
+# --------------------------------------------------------------------------- #
+def test_merge_emits_once(tmp_path, monkeypatch, bus_events):
+    wt = _repo_with_feature_commit(tmp_path / "r")
+    inst = _FakeInst(str(wt))
+    state = {"state": "OPEN"}
+    monkeypatch.setattr(
+        server, "_pr_info", lambda *a, **k: {"url": "u", "state": state["state"]}
+    )
+
+    server._session_stage(inst)  # seed OPEN
+    state["state"] = "MERGED"
+    server._PROBE_CACHE.clear()
+    server._session_stage(inst)
+    assert _pr_states(bus_events) == [("OPEN", "MERGED")]
+
+    # Polling again on the same (merged) PR must not re-announce it.
+    server._PROBE_CACHE.clear()
+    server._session_stage(inst)
+    assert _pr_states(bus_events) == [("OPEN", "MERGED")]
+
+
+def test_pr_appearing_emits_open(tmp_path, monkeypatch, bus_events):
+    wt = _repo_with_feature_commit(tmp_path / "r")
+    inst = _FakeInst(str(wt))
+    info = {"value": None}
+    monkeypatch.setattr(server, "_pr_info", lambda *a, **k: info["value"])
+
+    server._session_stage(inst)  # no PR yet
+    info["value"] = {"url": "u", "state": "OPEN"}
+    server._PR_CACHE.clear()
+    server._PROBE_CACHE.clear()
+    server._session_stage(inst)
+    # First OPEN observation seeds rather than emitting: there is no prior state
+    # to have transitioned FROM, and re-announcing on every server restart is
+    # the noise this whole change exists to remove.
+    assert _pr_states(bus_events) == []
+
+
+# --------------------------------------------------------------------------- #
+# A missing answer is never a close
+# --------------------------------------------------------------------------- #
+def test_failed_lookup_does_not_fake_a_close(tmp_path, monkeypatch, bus_events):
+    wt = _repo_with_feature_commit(tmp_path / "r")
+    inst = _FakeInst(str(wt))
+    info = {"value": {"url": "u", "state": "OPEN"}}
+    monkeypatch.setattr(server, "_pr_info", lambda *a, **k: info["value"])
+
+    server._session_stage(inst)  # seed OPEN
+    info["value"] = None  # rate limit / no gh / network blip
+    server._PROBE_CACHE.clear()
+    server._session_stage(inst)
+
+    assert _pr_states(bus_events) == []
+    # ...and the remembered state is untouched, so the real merge still fires.
+    info["value"] = {"url": "u", "state": "CLOSED"}
+    server._PROBE_CACHE.clear()
+    server._session_stage(inst)
+    assert _pr_states(bus_events) == [("OPEN", "CLOSED")]
+
+
+def test_branch_switch_reseeds_instead_of_emitting(tmp_path, monkeypatch, bus_events):
+    wt = _repo_with_feature_commit(tmp_path / "r")
+    inst = _FakeInst(str(wt))
+    monkeypatch.setattr(
+        server, "_pr_info", lambda *a, **k: {"url": "u", "state": "OPEN"}
+    )
+    server._session_stage(inst)  # seed OPEN on "feat"
+
+    # Same session, second branch, whose PR lookup reports MERGED. That is a
+    # DIFFERENT pull request — not this one closing.
+    _git("checkout", "-q", "-b", "feat2", cwd=str(wt))
+    monkeypatch.setattr(
+        server, "_pr_info", lambda *a, **k: {"url": "u2", "state": "MERGED"}
+    )
+    server._PROBE_CACHE.clear()
+    server._session_stage(inst)
+
+    assert _pr_states(bus_events) == []
+    assert agent_state._LAST_PR_STATE[inst.Title] == ("feat2", "MERGED")
+
+
+# --------------------------------------------------------------------------- #
+# The notify rule follows the new event, and no longer the stage
+# --------------------------------------------------------------------------- #
+def test_notify_rule_keys_off_pr_state_not_stage():
+    rule = next(r for r in notify.NOTIFY_RULES if r["id"] == "pr_closed")
+    assert rule["event"] == "session.pr_state_changed"
+
+    # The transition that used to cause the false alarm no longer matches...
+    assert not notify._matches(
+        rule, {"event": "session.stage_changed", "old": "pr", "new": "agent"}
+    )
+    # ...while both genuine endings do.
+    for ending in ("MERGED", "CLOSED"):
+        assert notify._matches(
+            rule,
+            {"event": "session.pr_state_changed", "old": "OPEN", "new": ending},
+        )
+    # A PR opening is not a closing.
+    assert not notify._matches(
+        rule, {"event": "session.pr_state_changed", "old": "", "new": "OPEN"}
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Ships two fixes on top of the commit-message feature already sitting on `main`.

## Announce PR state from the PR, not from the stage pill

Both PR notifications — the browser/ntfy rule and the in-app toast — were inferred from `session.stage_changed` leaving or re-entering the `pr` rung. `_session_stage` returns `agent` as soon as the tree is dirty, *before* it consults the PR at all, so an agent working through review feedback walked `pr → agent → committed → pushed → pr` on every edit. Each lap fired "PR merged or closed" and then "PR open" for a pull request that never moved; the 5s/30s dedupe windows are far shorter than an edit/commit/push cycle.

New `session.pr_state_changed` event carries the PR's own state as `old`/`new`, emitted from `_session_stage` where `_pr_info`'s answer is already in hand. Guards:

- a `None` lookup is never a transition (`_pr_info` returns `None` for both "no PR" and "could not ask")
- first sighting seeds silently, so a restart cannot re-announce an already-merged PR
- a branch change re-seeds rather than reporting the previous branch's PR as closed

The notify rule and both toasts key off it. The client addon needed no change — it matches rules generically off `/api/notify/config`.

## Expanding a pinned prompt no longer shoves the terminal

The prompt body was an in-flow flex item, so opening it shrank `.term-container`, refit xterm and resized the real tmux pane — reading a prompt reflowed the output you were reading it against, and cost a PTY resize per toggle. It is now an overlay anchored at the bar's own top: the first line lands exactly where the collapsed summary was, no blank row, no duplicated line, and the bar stays one line tall in both states.

## Verification

- Backend `4128 passed`; 6 new tests in `tests/unit/test_pr_state_events.py` cover churn-under-open-PR silence, single-fire on merge, no fabricated close on a failed lookup, and branch-switch re-seeding.
- Three existing tests that encoded the old stage-based inference (`test_ntfy.py`, `test_frontend_wave2.py`, `test_frontend_wave5.py`) were updated to the new contract rather than deleted.
- Frontend `257 passed`, typecheck clean, bundle rebuilt and verified by the pre-push gate.
- Pin geometry checked in headless Chrome: bar height, terminal top and terminal height identical open vs closed; panel top == bar top; arrow still the hit target when open.