### PR TITLE
Answer "are the downloads new users?" on the traffic screen, with axes

### DIFF
--- a/backend/web/addons/traffic.py
+++ b/backend/web/addons/traffic.py
@@ -1,10 +1,18 @@
 """Traffic addon: MindFlock's own public reach, over HTTP.
 
 Exposes ``GET /api/traffic`` — GitHub stars/forks, per-release download counts,
-and per-day click counts for the tracked ``mindflock.ai/go/<slug>`` redirects
-(see the ``webpage/worker`` Cloudflare Worker in the marketing-site repo) — so
-the desktop app's dev-only Settings → Site traffic screen has one endpoint to
-poll instead of stitching three sources together in the browser.
+and per-day click AND visitor counts for the tracked ``mindflock.ai/go/<slug>``
+redirects (see the ``webpage/worker`` Cloudflare Worker in the marketing-site
+repo) — so the desktop app's dev-only Settings → Site traffic screen has one
+endpoint to poll instead of stitching three sources together in the browser.
+
+One asymmetry runs through this module and the screen it feeds: the Worker
+knows how many distinct PEOPLE clicked and which of them were first-timers,
+because it derives a pseudonymous visitor id per click. GitHub's
+``download_count`` is an opaque tally with no identity attached — it counts
+updates and re-downloads and cannot be split into new versus returning users
+by any means. So "new user" figures come from the click side only, and the
+download side is labelled for what it is.
 
 Every upstream call is best-effort: a GitHub rate limit or the click-tracking
 worker being unreachable degrades that ONE section (``errors.github`` /
@@ -207,16 +215,38 @@ async def _fetch_star_history(token: str) -> tuple[list, str]:
     return history, ""
 
 
+def _empty_clicks(days: int, error: str) -> dict:
+    return {
+        "days": days,
+        "series": [],
+        "totals_by_slug": {},
+        "visitors_by_day": [],
+        "visitors_by_slug": [],
+        "totals": None,
+        "downloads": None,
+        "error": error,
+    }
+
+
 async def _fetch_clicks(days: int) -> dict:
+    """Per-day click counts plus, when the Worker reports them, per-day and
+    per-link VISITOR counts.
+
+    The people-shaped sections (``visitors_by_day``, ``visitors_by_slug``,
+    ``totals``, ``downloads``) are passed through rather than derived, because
+    unique counts are not additive: summing per-day unique visitors over a
+    month does not give monthly unique visitors, so only the store holding the
+    visitor ids can count a given grain. Deriving them here would produce
+    numbers that look right and are quietly wrong.
+
+    They stay ``None``/empty against a Worker that predates visitor
+    attribution, so the screen can say "not available yet" instead of drawing
+    a chart of zeros.
+    """
     status, data = await _get_json("{}?days={}".format(_CLICKS_STATS_URL, days))
     if status != 200 or not isinstance(data, dict):
         detail = data.get("error") if isinstance(data, dict) else data
-        return {
-            "days": days,
-            "series": [],
-            "totals_by_slug": {},
-            "error": str(detail or status),
-        }
+        return _empty_clicks(days, str(detail or status))
 
     series = data.get("series") or []
     totals: dict[str, int] = {}
@@ -225,7 +255,25 @@ async def _fetch_clicks(days: int) -> dict:
             continue
         slug = str(row.get("slug") or "")
         totals[slug] = totals.get(slug, 0) + int(row.get("clicks") or 0)
-    return {"days": days, "series": series, "totals_by_slug": totals, "error": ""}
+
+    def _list(key: str) -> list:
+        value = data.get(key)
+        return value if isinstance(value, list) else []
+
+    def _dict(key: str) -> Optional[dict]:
+        value = data.get(key)
+        return value if isinstance(value, dict) else None
+
+    return {
+        "days": days,
+        "series": series,
+        "totals_by_slug": totals,
+        "visitors_by_day": _list("visitors_by_day"),
+        "visitors_by_slug": _list("visitors_by_slug"),
+        "totals": _dict("totals"),
+        "downloads": _dict("downloads"),
+        "error": "",
+    }
 
 
 class TrafficAddon(Addon):

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -28722,13 +28722,13 @@ function RunningCover({ paneRef }) {
 function CtxLine({ inst }) {
   const ds = inst.diff_stat;
   const files = ds.files || 0, additions = ds.additions || 0, deletions = ds.deletions || 0;
-  const plural = files === 1 ? " file" : " files";
+  const plural2 = files === 1 ? " file" : " files";
   const ctxNum = (n) => {
     if (n < 1e3) return String(n);
     const k = n / 1e3;
     return (k < 10 ? k.toFixed(1) : String(Math.round(k))).replace(/\.0$/, "") + "k";
   };
-  let tip = `Total change vs base: +${additions} −${deletions} across ${files}${plural}`;
+  let tip = `Total change vs base: +${additions} −${deletions} across ${files}${plural2}`;
   const un = ds.uncommitted;
   if (un) tip += ` · uncommitted +${un.additions || 0} −${un.deletions || 0}`;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ctxline", title: tip, children: [
@@ -28743,7 +28743,7 @@ function CtxLine({ inst }) {
     /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ctx-files", children: [
       "· ",
       files,
-      plural
+      plural2
     ] })
   ] });
 }
@@ -34591,6 +34591,24 @@ function UninstallSection() {
     }, children: isWindows ? "Open Windows uninstall…" : "Uninstall MindFlock…" })
   ] });
 }
+function hasVisitorData(data) {
+  var _a2;
+  return !!((_a2 = data == null ? void 0 : data.clicks) == null ? void 0 : _a2.totals);
+}
+function shownMetric(requested, data) {
+  return hasVisitorData(data) ? requested : "clicks";
+}
+function niceTicks(rawMax, targetCount = 4) {
+  const hi = Number.isFinite(rawMax) && rawMax > 0 ? Math.ceil(rawMax) : 1;
+  const intervals = Math.max(1, Math.round(targetCount));
+  const rough = hi / intervals;
+  const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+  const step = [1, 2, 2.5, 5, 10].map((m) => m * pow).filter((s) => Number.isInteger(s) && s >= 1).find((s) => s >= rough) ?? Math.max(1, Math.ceil(rough));
+  const max = Math.ceil(hi / step) * step;
+  const ticks = [];
+  for (let v = 0; v <= max; v += step) ticks.push(v);
+  return { max, ticks };
+}
 const DAYS_OPTIONS = [30, 90];
 const SLUG_LABEL = {
   mac: "macOS download",
@@ -34617,6 +34635,33 @@ function fmtDate(iso) {
     return iso;
   }
 }
+function fmtPct(part, whole) {
+  if (!whole) return "—";
+  return (part / whole * 100).toFixed(1) + "%";
+}
+function plural(n, word) {
+  return `${fmtInt(n)} ${word}${n === 1 ? "" : "s"}`;
+}
+const CHART_W = 640;
+const CHART_H = 160;
+const PAD_L = 4;
+const PAD_B = 18;
+const PAD_T = 10;
+const PLOT_H = CHART_H - PAD_B;
+function scaleFor(axisMax) {
+  return (v) => v / axisMax * (PLOT_H - PAD_T);
+}
+function Gridlines({ ticks, yAt }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("g", { "aria-hidden": "true", children: ticks.filter((t) => t > 0).map((t) => /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: yAt(t), x2: CHART_W, y2: yAt(t), className: "traffic-gridline" }, t)) });
+}
+function YAxis({ ticks, yAt }) {
+  const width = Math.max(...ticks.map((t) => fmtInt(t).length));
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-yaxis", style: { width: `${width}ch` }, "aria-hidden": "true", children: ticks.map((t) => /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-ytick", style: { top: `${yAt(t) / CHART_H * 100}%` }, children: fmtInt(t) }, t)) });
+}
+function barRadius(width, height) {
+  return Math.max(0, Math.min(3, width / 2, height / 3));
+}
+const OUTLINE_MIN_BAR_W = 8;
 function dailyTotals(series) {
   const byDay = /* @__PURE__ */ new Map();
   for (const row of series) {
@@ -34638,47 +34683,47 @@ function StarsChart({ points }) {
   if (points.length === 1) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Only one day of star history so far — check back once there's a trend." });
   }
-  const w = 640;
-  const h = 160;
-  const padL = 4;
-  const padB = 18;
-  const plotH = h - padB;
-  const max = Math.max(1, ...points.map((p) => p.stars));
-  const stepX = (w - padL) / (points.length - 1);
-  const xAt = (i) => padL + i * stepX;
-  const yAt = (v) => plotH - v / max * (plotH - 8);
+  const { max, ticks } = niceTicks(Math.max(...points.map((p) => p.stars)));
+  const scale = scaleFor(max);
+  const stepX = (CHART_W - PAD_L) / (points.length - 1);
+  const xAt = (i) => PAD_L + i * stepX;
+  const yAt = (v) => PLOT_H - scale(v);
   const pathD = points.map((p, i) => `${i === 0 ? "M" : "L"}${xAt(i).toFixed(2)},${yAt(p.stars).toFixed(2)}`).join(" ");
   const handleMove = (e) => {
     const rect = e.currentTarget.getBoundingClientRect();
-    const relX = (e.clientX - rect.left) / rect.width * w;
-    const idx = Math.max(0, Math.min(points.length - 1, Math.round((relX - padL) / stepX)));
+    const relX = (e.clientX - rect.left) / rect.width * CHART_W;
+    const idx = Math.max(0, Math.min(points.length - 1, Math.round((relX - PAD_L) / stepX)));
     setHoverIdx(idx);
   };
   const hovered = hoverIdx != null ? points[hoverIdx] : null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-wrap", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "svg",
-      {
-        className: "traffic-chart",
-        viewBox: `0 0 ${w} ${h}`,
-        preserveAspectRatio: "none",
-        role: "img",
-        "aria-label": `Cumulative GitHub stars, ${fmtDate(points[0].day)} through ${fmtDate(points[points.length - 1].day)}`,
-        onMouseMove: handleMove,
-        onMouseLeave: () => setHoverIdx(null),
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: pathD, className: "traffic-line", fill: "none" }),
-          hoverIdx != null && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: xAt(hoverIdx), y1: 0, x2: xAt(hoverIdx), y2: plotH, className: "traffic-crosshair" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("circle", { cx: xAt(hoverIdx), cy: yAt(points[hoverIdx].stars), r: 4, className: "traffic-line-dot" })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: plotH, x2: w, y2: plotH, className: "traffic-baseline" })
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(points[0].day) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(points[points.length - 1].day) })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-plot", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(YAxis, { ticks, yAt }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "svg",
+        {
+          className: "traffic-chart",
+          viewBox: `0 0 ${CHART_W} ${CHART_H}`,
+          preserveAspectRatio: "none",
+          role: "img",
+          "aria-label": `Cumulative GitHub stars, ${fmtDate(points[0].day)} through ${fmtDate(points[points.length - 1].day)}, on a vertical scale of 0 to ${fmtInt(max)} stars`,
+          onMouseMove: handleMove,
+          onMouseLeave: () => setHoverIdx(null),
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Gridlines, { ticks, yAt }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: pathD, className: "traffic-line", fill: "none" }),
+            hoverIdx != null && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: xAt(hoverIdx), y1: PAD_T, x2: xAt(hoverIdx), y2: PLOT_H, className: "traffic-crosshair" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("circle", { cx: xAt(hoverIdx), cy: yAt(points[hoverIdx].stars), r: 4, className: "traffic-line-dot" })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: PLOT_H, x2: CHART_W, y2: PLOT_H, className: "traffic-baseline" })
+          ]
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(points[0].day) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(points[points.length - 1].day) })
+      ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-tooltip", "aria-live": "polite", children: hovered ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: fmtDate(hovered.day) }),
@@ -34698,51 +34743,51 @@ function ReleasesChart({ releases }) {
   if (!chrono.length) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No published releases yet." });
   }
-  const max = Math.max(1, ...chrono.map((r) => r.total_downloads));
-  const w = 640;
-  const h = 160;
-  const padL = 4;
-  const padB = 18;
-  const plotH = h - padB;
+  const { max, ticks } = niceTicks(Math.max(...chrono.map((r) => r.total_downloads)));
+  const scale = scaleFor(max);
   const barGap = 3;
-  const barW = Math.max(1, (w - padL) / chrono.length - barGap);
+  const barW = Math.max(1, (CHART_W - PAD_L) / chrono.length - barGap);
   const hovered = hover != null ? chrono[hover] : null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-wrap", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "svg",
-      {
-        className: "traffic-chart",
-        viewBox: `0 0 ${w} ${h}`,
-        preserveAspectRatio: "none",
-        role: "img",
-        "aria-label": `Downloads per release, ${chrono[0].tag} through ${chrono[chrono.length - 1].tag}`,
-        onMouseLeave: () => setHover(null),
-        children: [
-          chrono.map((r, i) => {
-            const barH = Math.max(1, r.total_downloads / max * (plotH - 8));
-            const x = padL + i * (barW + barGap);
-            const y = plotH - barH;
-            return /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "rect",
-              {
-                x,
-                y,
-                width: barW,
-                height: barH,
-                rx: Math.min(3, barW / 2),
-                className: "traffic-bar" + (hover === i ? " hover" : ""),
-                onMouseEnter: () => setHover(i)
-              },
-              r.tag
-            );
-          }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: plotH, x2: w, y2: plotH, className: "traffic-baseline" })
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(chrono[0].published_at) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(chrono[chrono.length - 1].published_at) })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-plot", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(YAxis, { ticks, yAt: (v) => PLOT_H - scale(v) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "svg",
+        {
+          className: "traffic-chart",
+          viewBox: `0 0 ${CHART_W} ${CHART_H}`,
+          preserveAspectRatio: "none",
+          role: "img",
+          "aria-label": `Downloads per release, ${chrono[0].tag} through ${chrono[chrono.length - 1].tag}, on a vertical scale of 0 to ${fmtInt(max)} downloads`,
+          onMouseLeave: () => setHover(null),
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Gridlines, { ticks, yAt: (v) => PLOT_H - scale(v) }),
+            chrono.map((r, i) => {
+              const barH = Math.max(1, scale(r.total_downloads));
+              const x = PAD_L + i * (barW + barGap);
+              const y = PLOT_H - barH;
+              return /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "rect",
+                {
+                  x,
+                  y,
+                  width: barW,
+                  height: barH,
+                  rx: barRadius(barW, barH),
+                  className: "traffic-bar" + (hover === i ? " hover" : ""),
+                  onMouseEnter: () => setHover(i)
+                },
+                r.tag
+              );
+            }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: PLOT_H, x2: CHART_W, y2: PLOT_H, className: "traffic-baseline" })
+          ]
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(chrono[0].published_at) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(chrono[chrono.length - 1].published_at) })
+      ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-tooltip", "aria-live": "polite", children: hovered ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: hovered.tag }),
@@ -34762,57 +34807,223 @@ function ReleasesChart({ releases }) {
     ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Hover a bar for that release's per-asset breakdown." }) })
   ] });
 }
+function VisitorsChart({ days }) {
+  const [hover, setHover] = reactExports.useState(null);
+  if (!days.length) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No visitors recorded in this window yet." });
+  }
+  const { max, ticks } = niceTicks(Math.max(...days.map((d) => d.visitors)));
+  const barGap = 2;
+  const barW = Math.max(1, (CHART_W - PAD_L) / days.length - barGap);
+  const SEG_GAP = 2;
+  const scale = scaleFor(max);
+  const yAt = (v) => PLOT_H - scale(v);
+  const hovered = hover != null ? days[hover] : null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-wrap", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-legend", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-legend-item", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-swatch new", "aria-hidden": "true" }),
+        " First-time"
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-legend-item", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-swatch returning", "aria-hidden": "true" }),
+        " Returning"
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-plot", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(YAxis, { ticks, yAt }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "svg",
+        {
+          className: "traffic-chart",
+          viewBox: `0 0 ${CHART_W} ${CHART_H}`,
+          preserveAspectRatio: "none",
+          role: "img",
+          "aria-label": `Daily visitors split into first-time and returning, ${days[0].day} through ${days[days.length - 1].day}, on a vertical scale of 0 to ${fmtInt(max)} visitors`,
+          onMouseLeave: () => setHover(null),
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Gridlines, { ticks, yAt }),
+            days.map((d, i) => {
+              const x = PAD_L + i * (barW + barGap);
+              const newH = scale(d.new_visitors);
+              const restH = scale(d.visitors - d.new_visitors);
+              const gap = newH > SEG_GAP && restH > SEG_GAP ? SEG_GAP : 0;
+              const outlined = barW >= OUTLINE_MIN_BAR_W ? " outlined" : "";
+              return /* @__PURE__ */ jsxRuntimeExports.jsxs("g", { onMouseEnter: () => setHover(i), className: hover === i ? "hover" : "", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("rect", { x, y: 0, width: barW + barGap, height: PLOT_H, className: "traffic-hit" }),
+                restH > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "rect",
+                  {
+                    x,
+                    y: PLOT_H - newH - gap - restH,
+                    width: barW,
+                    height: restH,
+                    rx: barRadius(barW, restH),
+                    className: "traffic-seg-returning" + outlined + (hover === i ? " hover" : "")
+                  }
+                ),
+                newH > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "rect",
+                  {
+                    x,
+                    y: PLOT_H - newH,
+                    width: barW,
+                    height: newH,
+                    rx: barRadius(barW, newH),
+                    className: "traffic-seg-new" + (hover === i ? " hover" : "")
+                  }
+                )
+              ] }, d.day);
+            }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: PLOT_H, x2: CHART_W, y2: PLOT_H, className: "traffic-baseline" })
+          ]
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[0].day) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[days.length - 1].day) })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-tooltip", "aria-live": "polite", children: hovered ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: fmtDate(hovered.day) }),
+      " — ",
+      plural(hovered.visitors, "visitor"),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tooltip-detail", children: [
+        " ",
+        "(",
+        fmtInt(hovered.new_visitors),
+        " first-time, ",
+        fmtInt(hovered.returning_visitors),
+        " ",
+        "returning",
+        hovered.unknown_visitors > 0 && `, ${fmtInt(hovered.unknown_visitors)} unattributed`,
+        ")"
+      ] })
+    ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Hover a bar for that day's first-time / returning split." }) })
+  ] });
+}
+function DownloadFunnel({ funnel, days }) {
+  const { new_visitors: total, new_visitors_clicked: clicked } = funnel;
+  if (!total) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No first-time visitors recorded in this window yet — the funnel fills in as the tracked links get clicked." });
+  }
+  const rows = [
+    { label: "First-time visitors", value: total },
+    { label: "…who started a download", value: clicked, rate: fmtPct(clicked, total) }
+  ];
+  const { max: axisMax, ticks } = niceTicks(total, 5);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-funnel", children: [
+    rows.map((r) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-funnel-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-funnel-label", children: r.label }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-funnel-track", children: [
+        ticks.slice(1, -1).map((t) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "span",
+          {
+            className: "traffic-funnel-grid",
+            style: { left: `${t / axisMax * 100}%` }
+          },
+          t
+        )),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "span",
+          {
+            className: "traffic-funnel-fill",
+            style: { width: `${r.value / axisMax * 100}%` }
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-funnel-num", children: fmtInt(r.value) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-funnel-rate", children: r.rate || "" })
+    ] }, r.label)),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-funnel-axis", "aria-hidden": "true", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-funnel-ticks", children: ticks.map((t, i) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "span",
+        {
+          className: "traffic-funnel-tick" + (i === 0 ? " first" : i === ticks.length - 1 ? " last" : ""),
+          style: { left: `${t / axisMax * 100}%` },
+          children: fmtInt(t)
+        },
+        t
+      )) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "traffic-table traffic-funnel-table", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { children: "Platform" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "First-time" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "All visitors" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "Clicks" })
+      ] }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: funnel.by_slug.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { children: slugLabel(s.slug) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt(s.new_visitors) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt(s.visitors) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt(s.clicks) })
+      ] }, s.slug)) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "set-hint", children: [
+      "Download ",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("em", { children: "intent" }),
+      ", not installs, over the last ",
+      days,
+      " days: someone pressing a platform button on mindflock.ai. It misses anyone who downloaded straight from the GitHub repo page, and a click is not a finished install. Per-platform first-timers can overlap (one person pressing both macOS and Linux is in both rows), so they may add up to more than the ",
+      fmtInt(clicked),
+      " above — that figure is the deduplicated one."
+    ] })
+  ] });
+}
 function ClicksChart({ series }) {
   const days = reactExports.useMemo(() => dailyTotals(series), [series]);
   const [hover, setHover] = reactExports.useState(null);
   if (!days.length) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No clicks recorded in this window yet." });
   }
-  const max = Math.max(1, ...days.map((d) => d.total));
-  const w = 640;
-  const h = 160;
-  const padL = 4;
-  const padB = 18;
-  const plotH = h - padB;
+  const { max, ticks } = niceTicks(Math.max(...days.map((d) => d.total)));
+  const scale = scaleFor(max);
+  const yAt = (v) => PLOT_H - scale(v);
   const barGap = 2;
-  const barW = Math.max(1, (w - padL) / days.length - barGap);
+  const barW = Math.max(1, (CHART_W - PAD_L) / days.length - barGap);
   const hovered = hover != null ? days[hover] : null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-wrap", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "svg",
-      {
-        className: "traffic-chart",
-        viewBox: `0 0 ${w} ${h}`,
-        preserveAspectRatio: "none",
-        role: "img",
-        "aria-label": `Daily clicks across all tracked links, ${days[0].day} through ${days[days.length - 1].day}`,
-        onMouseLeave: () => setHover(null),
-        children: [
-          days.map((d, i) => {
-            const barH = Math.max(1, d.total / max * (plotH - 8));
-            const x = padL + i * (barW + barGap);
-            const y = plotH - barH;
-            return /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "rect",
-              {
-                x,
-                y,
-                width: barW,
-                height: barH,
-                rx: Math.min(3, barW / 2),
-                className: "traffic-bar" + (hover === i ? " hover" : ""),
-                onMouseEnter: () => setHover(i)
-              },
-              d.day
-            );
-          }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: plotH, x2: w, y2: plotH, className: "traffic-baseline" })
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[0].day) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[days.length - 1].day) })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-plot", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(YAxis, { ticks, yAt }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "svg",
+        {
+          className: "traffic-chart",
+          viewBox: `0 0 ${CHART_W} ${CHART_H}`,
+          preserveAspectRatio: "none",
+          role: "img",
+          "aria-label": `Daily clicks across all tracked links, ${days[0].day} through ${days[days.length - 1].day}, on a vertical scale of 0 to ${fmtInt(max)} clicks`,
+          onMouseLeave: () => setHover(null),
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Gridlines, { ticks, yAt }),
+            days.map((d, i) => {
+              const barH = Math.max(1, scale(d.total));
+              const x = PAD_L + i * (barW + barGap);
+              const y = PLOT_H - barH;
+              return /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "rect",
+                {
+                  x,
+                  y,
+                  width: barW,
+                  height: barH,
+                  rx: barRadius(barW, barH),
+                  className: "traffic-bar" + (hover === i ? " hover" : ""),
+                  onMouseEnter: () => setHover(i)
+                },
+                d.day
+              );
+            }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: 0, y1: PLOT_H, x2: CHART_W, y2: PLOT_H, className: "traffic-baseline" })
+          ]
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-chart-axis", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[0].day) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: fmtDate(days[days.length - 1].day) })
+      ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "traffic-tooltip", "aria-live": "polite", children: hovered ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: fmtDate(hovered.day) }),
@@ -34832,6 +35043,7 @@ function ClicksChart({ series }) {
 function Traffic(_) {
   var _a2, _b2;
   const [days, setDays] = reactExports.useState(90);
+  const [metric, setMetric] = reactExports.useState("people");
   const [refreshing, setRefreshing] = reactExports.useState(false);
   const q = useTraffic(true, days);
   const data = q.data;
@@ -34839,6 +35051,14 @@ function Traffic(_) {
     if (!data) return [];
     return Object.entries(data.clicks.totals_by_slug).sort((a, b) => b[1] - a[1]);
   }, [data]);
+  const visitorsBySlug = reactExports.useMemo(() => {
+    const map = /* @__PURE__ */ new Map();
+    for (const row of (data == null ? void 0 : data.clicks.visitors_by_slug) ?? []) map.set(row.slug, row);
+    return map;
+  }, [data]);
+  const people = (data == null ? void 0 : data.clicks.totals) ?? null;
+  const funnel = (data == null ? void 0 : data.clicks.downloads) ?? null;
+  const shown = shownMetric(metric, data);
   const doRefresh = async () => {
     setRefreshing(true);
     try {
@@ -34865,6 +35085,30 @@ function Traffic(_) {
         ] })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tiles", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile primary", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt(people == null ? void 0 : people.new_visitors) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tile-label", children: [
+            "First-time visitors (",
+            data.clicks.days,
+            "d)"
+          ] })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt(people == null ? void 0 : people.visitors) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tile-label", children: [
+            "Unique visitors (",
+            data.clicks.days,
+            "d)"
+          ] })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt((people == null ? void 0 : people.clicks) ?? clickTotalsSorted.reduce((s, [, n]) => s + n, 0)) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tile-label", children: [
+            "Tracked link clicks (",
+            data.clicks.days,
+            "d)"
+          ] })
+        ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt((_a2 = data.repo) == null ? void 0 : _a2.stars) }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-label", children: "GitHub stars" })
@@ -34875,59 +35119,103 @@ function Traffic(_) {
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt(data.downloads_total) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-label", children: "Total downloads (all releases)" })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-tile", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-num", children: fmtInt(clickTotalsSorted.reduce((s, [, n]) => s + n, 0)) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "traffic-tile-label", children: [
-            "Tracked link clicks (",
-            data.clicks.days,
-            "d)"
-          ] })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "traffic-tile-label", children: "Downloads (all releases, all-time)" })
         ] })
       ] }),
+      !people && !data.errors.clicks && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "set-hint", children: [
+        "Visitor counts are empty because the click Worker hasn't been redeployed with visitor attribution yet (see ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "worker/README.md" }),
+        " in the webpage repo — it needs the",
+        " ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "VISITORS" }),
+        " KV namespace and the ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("code", { children: "VISITOR_SALT" }),
+        " secret). Clicks below are unaffected. Numbers start accumulating at deploy time, so expect visitors to trail clicks until the window fills in."
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "set-section-title", children: [
+        "New user funnel (",
+        data.clicks.days,
+        "d)"
+      ] }),
+      funnel ? /* @__PURE__ */ jsxRuntimeExports.jsx(DownloadFunnel, { funnel, days: data.clicks.days }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Not available until the click Worker reports visitor attribution. GitHub's download counters can't stand in for it — they're opaque tallies that include updates and re-downloads, with no way to tell one person from another." }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "GitHub stars over time" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(StarsChart, { points: data.star_history ?? [] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: shown === "people" ? "Visitors over time" : "Clicks over time" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "set-row traffic-range-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "usage-periods traffic-range", children: DAYS_OPTIONS.map((d) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "button",
-          {
-            type: "button",
-            className: "usage-period" + (days === d ? " active" : ""),
-            onClick: () => setDays(d),
-            children: [
-              d,
-              "d"
-            ]
-          },
-          d
-        )) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "traffic-controls", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "usage-periods traffic-range", children: DAYS_OPTIONS.map((d) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "button",
+            {
+              type: "button",
+              className: "usage-period" + (days === d ? " active" : ""),
+              onClick: () => setDays(d),
+              children: [
+                d,
+                "d"
+              ]
+            },
+            d
+          )) }),
+          people && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "usage-periods traffic-range", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                type: "button",
+                className: "usage-period" + (shown === "people" ? " active" : ""),
+                onClick: () => setMetric("people"),
+                children: "People"
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                type: "button",
+                className: "usage-period" + (shown === "clicks" ? " active" : ""),
+                onClick: () => setMetric("clicks"),
+                children: "Clicks"
+              }
+            )
+          ] })
+        ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "test-row", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className: "test-btn", onClick: doRefresh, disabled: refreshing, children: refreshing ? "Refreshing…" : "Refresh" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "set-hint", children: "Cached ~5 min server-side to stay under GitHub's rate limit — this bypasses it." })
         ] })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ClicksChart, { series: data.clicks.series }),
+      shown === "people" ? /* @__PURE__ */ jsxRuntimeExports.jsx(VisitorsChart, { days: data.clicks.visitors_by_day }) : /* @__PURE__ */ jsxRuntimeExports.jsx(ClicksChart, { series: data.clicks.series }),
       clickTotalsSorted.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "set-section-title", children: [
-          "Clicks by link (",
+          "By link (",
           data.clicks.days,
           "d)"
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "traffic-table", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("th", { children: "Link" }),
+            people && /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "First-time" }),
+            people && /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "Visitors" }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "num", children: "Clicks" })
           ] }) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: clickTotalsSorted.map(([slug, n]) => /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { children: slugLabel(slug) }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt(n) })
-          ] }, slug)) })
-        ] })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: clickTotalsSorted.map(([slug, n]) => {
+            var _a3, _b3;
+            return /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("td", { children: slugLabel(slug) }),
+              people && /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt((_a3 = visitorsBySlug.get(slug)) == null ? void 0 : _a3.new_visitors) }),
+              people && /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt((_b3 = visitorsBySlug.get(slug)) == null ? void 0 : _b3.visitors) }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "num", children: fmtInt(n) })
+            ] }, slug);
+          }) })
+        ] }),
+        people && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Visitor columns are deduplicated per link over the window, so they don't add up down the column — one person clicking two links is one visitor on each row and one visitor overall." })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Downloads over time" }),
       data.releases.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No releases found." }) : /* @__PURE__ */ jsxRuntimeExports.jsx(ReleasesChart, { releases: data.releases }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Downloads by version" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "set-hint", children: [
+        "GitHub's raw asset counters. These are ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("em", { children: "not" }),
+        " people: they include updates and repeat downloads, and GitHub attaches no identity to them, so there is no way to split them into new versus returning users. For new-user numbers use the funnel above. Note too that MindFlock's updater opens the releases page in a browser rather than fetching the asset itself, so an update looks exactly like a first-time download here."
+      ] }),
       data.releases.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "No releases found." }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "traffic-table", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("th", { children: "Version" }),

--- a/backend/web/static/style.css
+++ b/backend/web/static/style.css
@@ -9041,9 +9041,15 @@ body.no-ticketing .ik-panel[data-caps-need~="ticketing"]>.caps-gate[data-caps-ga
 }
 } /* 280 */ @layer components{
 
-/* Settings → Site traffic (dev shell only). Stat tiles, a single-hue click
-   chart, and two data tables — no chart library, consistent with the rest of
-   the app's hand-rolled, zero-dep components. */
+/* Settings → Site traffic (dev shell only). Stat tiles, single-hue charts, a
+   first-time-visitor funnel, and data tables — no chart library, consistent
+   with the rest of the app's hand-rolled, zero-dep components.
+
+   Everything chromatic here is derived from --accent, never a hand-picked
+   companion colour: Settings → Appearance repaints --accent per theme, so a
+   second fixed hue would collide with some of them. Where two things must be
+   told apart, it is done with weight (opacity + outline), which is achromatic
+   and therefore also safe for colour-vision deficiency. */
 
 .traffic-warn {
   border: 1px solid var(--red);
@@ -9079,6 +9085,14 @@ body.no-ticketing .ik-panel[data-caps-need~="ticketing"]>.caps-gate[data-caps-ga
   color: var(--text);
 }
 
+/* The one tile the screen exists to show. Marked with an accent edge rather
+   than an accent number, so it reads as the lead without pulling the numeric
+   styling of the tiles out of alignment. */
+.traffic-tile.primary {
+  border-color: var(--accent);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
 .traffic-tile-label {
   font-size: 11px;
   color: var(--muted);
@@ -9089,6 +9103,13 @@ body.no-ticketing .ik-panel[data-caps-need~="ticketing"]>.caps-gate[data-caps-ga
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  flex-wrap: wrap;
+}
+
+.traffic-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
@@ -9103,10 +9124,64 @@ body.no-ticketing .ik-panel[data-caps-need~="ticketing"]>.caps-gate[data-caps-ga
   gap: 4px;
 }
 
+/* Plot frame: y-axis gutter | plot area, with the date row beneath the plot
+   COLUMN only, so the first and last dates stay flush with the first and last
+   marks instead of being pushed right by the width of the tick labels. */
+.traffic-plot {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: 6px;
+}
+
+.traffic-plot > .traffic-yaxis {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.traffic-plot > .traffic-chart {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.traffic-plot > .traffic-chart-axis {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+/* Must stay equal to CHART_H in Traffic.tsx: the y-axis ticks are placed as a
+   percentage of this height and the gridlines they label are placed in viewBox
+   units, so the two only line up while one viewBox unit is one pixel. */
 .traffic-chart {
   width: 100%;
   height: 160px;
   display: block;
+}
+
+/* The tick labels are HTML, not SVG <text> — the charts stretch horizontally to
+   fill the panel (preserveAspectRatio="none"), which would smear glyphs. Height
+   comes from stretching to the plot's grid row, hence no explicit height here. */
+.traffic-yaxis {
+  position: relative;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.traffic-ytick {
+  position: absolute;
+  right: 0;
+  transform: translateY(-50%);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Hairline, solid, and a step quieter than the baseline: enough to read a bar's
+   value off, not enough to compete with the bars for attention. */
+.traffic-gridline {
+  stroke: var(--border);
+  stroke-width: 1;
+  stroke-opacity: 0.55;
+  vector-effect: non-scaling-stroke;
 }
 
 /* Sequential magnitude-over-time, one series — the app's single accent hue is
@@ -9125,6 +9200,181 @@ body.no-ticketing .ik-panel[data-caps-need~="ticketing"]>.caps-gate[data-caps-ga
 .traffic-baseline {
   stroke: var(--border);
   stroke-width: 1;
+}
+
+/* --- Visitors: first-time vs returning ------------------------------------
+   Part-to-whole with a focus, not two co-equal categories, so it is ONE hue at
+   two weights rather than a categorical pair — which also means it survives
+   Settings → Appearance repainting --accent to anything.
+
+   The returning segment is outlined at full strength because its fill alone
+   sits near 1.6:1 against the panel at every alpha that still reads as
+   recessive (checked, not guessed). The outline is what makes the mark
+   perceivable; the fill is what keeps it quiet. */
+.traffic-seg-new {
+  fill: var(--accent);
+  opacity: 0.85;
+  transition: opacity 0.1s;
+}
+
+.traffic-seg-new.hover {
+  opacity: 1;
+}
+
+.traffic-seg-returning {
+  fill: var(--accent);
+  fill-opacity: 0.3;
+  transition: fill-opacity 0.1s;
+}
+
+/* The outline is applied by Traffic.tsx only above a minimum bar width. On the
+   ~5px bars of a 90-day range a 1px stroke per side IS most of the bar, so it
+   filled the recessive segment in solid and erased the very distinction it was
+   added to make; at that density the fill difference alone carries it. */
+.traffic-seg-returning.outlined {
+  stroke: var(--accent);
+  stroke-opacity: 0.75;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-seg-returning.hover {
+  fill-opacity: 0.5;
+}
+
+/* Column-wide hover target: thin bars and zero days must still be reachable,
+   so the hit area is the whole column rather than the drawn ink. */
+.traffic-hit {
+  fill: transparent;
+}
+
+.traffic-legend {
+  display: flex;
+  gap: 14px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.traffic-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.traffic-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.traffic-swatch.new {
+  background: var(--accent);
+  opacity: 0.85;
+}
+
+.traffic-swatch.returning {
+  background: rgba(var(--accent-rgb), 0.3);
+  border: 1px solid rgba(var(--accent-rgb), 0.75);
+}
+
+/* --- New user funnel ------------------------------------------------------ */
+.traffic-funnel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.traffic-funnel-row,
+.traffic-funnel-axis {
+  display: grid;
+  /* The label column fits "…who started a download" on one line; wrapping it
+     pushed the two funnel rows out of vertical rhythm with each other, which
+     is exactly the comparison the bars are there to support. The tick row
+     shares the template so its numbers stay under the track they measure. */
+  grid-template-columns: minmax(170px, auto) minmax(80px, 3fr) auto 52px;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.traffic-funnel-label {
+  color: var(--text);
+}
+
+.traffic-funnel-track {
+  position: relative;
+  height: 14px;
+  border-radius: 4px;
+  background: var(--panel-2, var(--panel));
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.traffic-funnel-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  opacity: 0.85;
+  border-radius: 3px;
+}
+
+/* Interior gridlines, one per labelled tick. The end ticks are left out: the
+   track's own border already draws both, and a line on top of it would just
+   thicken the edge. They sit UNDER the fill (which follows them in the DOM), so
+   a bar covers the ticks it has passed — the same way the bar charts read. */
+.traffic-funnel-grid {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+  opacity: 0.55;
+}
+
+.traffic-funnel-ticks {
+  position: relative;
+  display: block;
+  height: 12px;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.traffic-funnel-tick {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Pinned inside the track's ends instead of centred, so 0 doesn't drift under
+   the row label and the top tick doesn't collide with the count column. */
+.traffic-funnel-tick.first {
+  transform: none;
+}
+
+.traffic-funnel-tick.last {
+  transform: translateX(-100%);
+}
+
+.traffic-funnel-num {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text);
+  text-align: right;
+}
+
+.traffic-funnel-rate {
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--muted);
+  text-align: right;
+}
+
+.traffic-funnel-table {
+  margin-top: 6px;
 }
 
 /* Cumulative stars line (StarsChart) — thin 2px stroke, single accent hue

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -444,6 +444,66 @@ across reloads).
 one-call status of every external integration (GitHub, active ticketing
 provider, agent CLI, tailscale) for the Settings → Connections screen.
 
+**Traffic** (addon id `traffic`) — `GET /api/traffic?days=90&refresh=0`: the
+product's *own* public reach, for the dev-only Settings → Site traffic screen
+(see [web-ui.md](web-ui.md)). `days` is clamped to `1..90`; the whole payload is
+cached **5 minutes** per `days` value (longer than Doctor's 30 s — this hits
+GitHub's REST API and an external Worker, neither of which needs re-asking on
+every panel open), and `refresh=1` bypasses that cache. Unlike every other
+GitHub integration here it resolves no workspace remote: it always means
+`MindFlock/MindFlock`.
+
+```jsonc
+{
+  "generated": 1755100000.0,
+  "repo": {"stars": 0, "forks": 0, "open_issues": 0, "url": "…"},  // or null
+  "star_history": [{"day": "2026-08-10", "stars": 42}],            // cumulative
+  "releases": [{"tag", "published_at", "prerelease", "assets": [{"name", "downloads"}], "total_downloads"}],
+  "downloads_total": 0,
+  "clicks": {
+    "days": 90,
+    "series": [{"day", "slug", "os", "clicks"}],
+    "totals_by_slug": {"mac": 0},
+    "visitors_by_day": [{"day", "visitors", "new_visitors", "returning_visitors", "unknown_visitors"}],
+    "visitors_by_slug": [{"slug", "visitors", "new_visitors", "clicks"}],
+    "totals": {"clicks", "visitors", "new_visitors"},              // or null
+    "downloads": {"new_visitors", "new_visitors_clicked", "by_slug": [...]},  // or null
+    "error": ""
+  },
+  "errors": {"github": null, "clicks": null}
+}
+```
+
+Three contracts are worth stating outright, because a client that gets them
+wrong produces plausible, wrong numbers rather than an obvious failure:
+
+- **Per-upstream degradation.** Every call is best-effort and the endpoint
+  always answers **200**. A GitHub rate limit sets `errors.github` and costs the
+  `repo`/`releases`/`star_history` sections; an unreachable click Worker sets
+  `errors.clicks` and costs only the `clicks` section. The two share nothing, so
+  a click-tracking hiccup never hides stars the request already has.
+- **Absent ≠ zero.** `clicks.totals` and `clicks.downloads` are `null` (never
+  `0`) and `visitors_by_day`/`visitors_by_slug` are `[]` against a click Worker
+  deployed before visitor attribution, or one answering with the wrong types.
+  **`clicks.totals` is the capability marker** clients should branch on — the
+  Worker emits the visitor sections together or not at all. The failure payload
+  (`_empty_clicks`) carries every key the success payload does, so a client can
+  index the sections unconditionally.
+- **Unique counts are not additive.** Summing `visitors_by_day[].visitors` does
+  **not** give `totals.visitors` — one person visiting on ten days is ten daily
+  uniques and one window unique. Only the Worker holding the visitor ids can
+  count a grain, so the server passes these sections through rather than
+  deriving them, and so should any consumer. `new_visitors` is the one field
+  that sums across days, since a first sighting happens on exactly one date.
+
+**Cross-repo prerequisite.** The visitor sections come from the `webpage/worker`
+Cloudflare Worker in the *marketing-site* repo (it derives a pseudonymous
+per-click visitor id), and nothing in this repo can produce them. They stay
+`null`/`[]` until that Worker is redeployed with a `VISITORS` KV namespace and a
+`VISITOR_SALT` secret — see `worker/README.md` there. Counting starts at deploy
+time, so visitors trail clicks until the window fills in. The Site traffic
+screen says as much in place when `clicks.totals` is `null`.
+
 **Templates** (addon id `templates`, prefix `/api/templates`) — saved
 new-session templates (`~/.mindflock/session_templates.json`):
 

--- a/frontend/src/__tests__/traffic.test.ts
+++ b/frontend/src/__tests__/traffic.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import type { TrafficResponse } from "../api/types";
+import { hasVisitorData, niceTicks, shownMetric } from "../lib/traffic";
+
+/** A payload from a click Worker that predates visitor attribution: clicks
+ * only, with every people-shaped section absent rather than zeroed. */
+const withoutVisitors = {
+  clicks: {
+    days: 90,
+    series: [{ day: "2026-08-10", slug: "mac", os: "mac", clicks: 3 }],
+    totals_by_slug: { mac: 3 },
+    visitors_by_day: [],
+    visitors_by_slug: [],
+    totals: null,
+    downloads: null,
+    error: "",
+  },
+} as unknown as TrafficResponse;
+
+const withVisitors = {
+  clicks: {
+    ...withoutVisitors.clicks,
+    totals: { clicks: 3, visitors: 2, new_visitors: 1 },
+  },
+} as unknown as TrafficResponse;
+
+describe("hasVisitorData", () => {
+  it("is false for a Worker that reports no visitor totals", () => {
+    expect(hasVisitorData(withoutVisitors)).toBe(false);
+  });
+
+  it("is false before the payload has loaded", () => {
+    expect(hasVisitorData(undefined)).toBe(false);
+    expect(hasVisitorData(null)).toBe(false);
+  });
+
+  it("is true once totals are present", () => {
+    expect(hasVisitorData(withVisitors)).toBe(true);
+  });
+});
+
+describe("shownMetric", () => {
+  it("honours the request when visitor data exists", () => {
+    expect(shownMetric("people", withVisitors)).toBe("people");
+    expect(shownMetric("clicks", withVisitors)).toBe("clicks");
+  });
+
+  it("falls back to clicks when there is no visitor data", () => {
+    // "people" is the INITIAL state, so without this the screen drew a clicks
+    // chart under a "Visitors over time" heading with People styled active.
+    expect(shownMetric("people", withoutVisitors)).toBe("clicks");
+  });
+
+  it("never traps the user on clicks once visitor data arrives", () => {
+    // The regression this file exists for. The toggle used to render People
+    // `disabled` whenever visitor data was missing — and since "people" is the
+    // default, pressing Clicks moved you into a state with no way back. The
+    // screen now only offers the toggle when both options are real, and the
+    // requested metric has to survive the payload gaining visitor data so that
+    // a deploy mid-session restores the People view rather than pinning it.
+    const requested = "people";
+    expect(shownMetric(requested, withoutVisitors)).toBe("clicks");
+    expect(shownMetric(requested, withVisitors)).toBe("people");
+  });
+
+  it("shows clicks while the payload is still loading", () => {
+    expect(shownMetric("people", undefined)).toBe("clicks");
+  });
+});
+
+describe("niceTicks", () => {
+  it("keeps the step whole for the small counts this screen mostly shows", () => {
+    // The reason this helper exists rather than a bare 1/2/5×10ⁿ ladder: at a
+    // peak of 3 that ladder wants a step of 0.75, labelling three positions no
+    // count can occupy.
+    expect(niceTicks(3)).toEqual({ max: 3, ticks: [0, 1, 2, 3] });
+    expect(niceTicks(1)).toEqual({ max: 1, ticks: [0, 1] });
+    expect(niceTicks(6)).toEqual({ max: 6, ticks: [0, 2, 4, 6] });
+  });
+
+  it("rounds the axis top up to a tick, above the data's own peak", () => {
+    // 90 is what a busy click day looks like; the axis stops at a round 100 so
+    // the top gridline is a number worth reading.
+    expect(niceTicks(90)).toEqual({ max: 100, ticks: [0, 25, 50, 75, 100] });
+    expect(niceTicks(142).max).toBe(150);
+    // A peak that is already round is left alone rather than padded past it.
+    expect(niceTicks(1000)).toEqual({ max: 1000, ticks: [0, 250, 500, 750, 1000] });
+  });
+
+  it("always spans the data", () => {
+    for (const peak of [1, 2, 7, 13, 99, 100, 101, 999, 4321, 87654]) {
+      const { max, ticks } = niceTicks(peak);
+      expect(max).toBeGreaterThanOrEqual(peak);
+      expect(ticks[0]).toBe(0);
+      expect(ticks[ticks.length - 1]).toBe(max);
+      expect(ticks.every(Number.isInteger)).toBe(true);
+      // Enough gridlines to interpolate between, few enough to stay quiet. The
+      // floor is 2 because a peak of 1 has nowhere to put a third whole tick.
+      expect(ticks.length).toBeGreaterThanOrEqual(2);
+      expect(ticks.length).toBeLessThanOrEqual(7);
+    }
+  });
+
+  it("gives an empty or all-zero window a real 0–1 axis", () => {
+    // Math.max() of no arguments is -Infinity, and an all-zero window is 0 —
+    // both reach this helper, and neither may divide the scale by zero.
+    expect(niceTicks(0)).toEqual({ max: 1, ticks: [0, 1] });
+    expect(niceTicks(-Infinity)).toEqual({ max: 1, ticks: [0, 1] });
+    expect(niceTicks(NaN)).toEqual({ max: 1, ticks: [0, 1] });
+  });
+});

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -261,6 +261,47 @@ export interface TrafficClickRow {
   clicks: number;
 }
 
+/* The people-shaped click sections. Every grain is counted by the Worker at
+ * that grain and must be READ at that grain: unique visitors are not additive,
+ * so summing `TrafficVisitorDay.visitors` over a window does NOT give
+ * `TrafficClickTotals.visitors` — one person visiting on ten days is ten daily
+ * uniques and one window unique. `new_visitors` is the one field that does
+ * sum, since a first sighting happens on exactly one date.
+ *
+ * All of these are null/empty against a Worker deployed before visitor
+ * attribution existed, and against click rows written before that deploy. */
+export interface TrafficVisitorDay {
+  day: string;
+  visitors: number;
+  new_visitors: number;
+  returning_visitors: number;
+  unknown_visitors: number;
+}
+
+export interface TrafficVisitorSlug {
+  slug: string;
+  visitors: number;
+  new_visitors: number;
+  clicks: number;
+}
+
+export interface TrafficClickTotals {
+  clicks: number;
+  visitors: number;
+  new_visitors: number;
+}
+
+/** First-time visitors who went on to click a platform download button —
+ * the closest observable proxy for new-user acquisition, since GitHub's
+ * download counters carry no identity. `by_slug` can overlap (one person
+ * clicking macOS and Linux is in both), so it may sum to more than
+ * `new_visitors_clicked`; that field is the deduped one. */
+export interface TrafficDownloadFunnel {
+  new_visitors: number;
+  new_visitors_clicked: number;
+  by_slug: Array<{ slug: string; new_visitors: number; visitors: number; clicks: number }>;
+}
+
 export interface TrafficResponse {
   generated: number;
   repo: { stars: number | null; forks: number | null; open_issues: number | null; url: string } | null;
@@ -271,6 +312,10 @@ export interface TrafficResponse {
     days: number;
     series: TrafficClickRow[];
     totals_by_slug: Record<string, number>;
+    visitors_by_day: TrafficVisitorDay[];
+    visitors_by_slug: TrafficVisitorSlug[];
+    totals: TrafficClickTotals | null;
+    downloads: TrafficDownloadFunnel | null;
     error: string;
   };
   errors: { github: string | null; clicks: string | null };

--- a/frontend/src/components/settings/screens/Traffic.tsx
+++ b/frontend/src/components/settings/screens/Traffic.tsx
@@ -1,14 +1,34 @@
 /** Settings → Site traffic (dev shell only): GitHub stars/forks, per-release
- * download counts, and click totals for the mindflock.ai/go/ tracked links
- * (macOS/Windows/Linux buttons, GitHub, Product Hunt, NxGn — see the Worker in
- * the webpage repo's worker/ directory). This is the maintainer's own reach
- * dashboard, not something an end user's build needs, hence the dev-shell
- * gate in SettingsDialog.tsx via isDevShell(). */
+ * download counts, and click/visitor totals for the mindflock.ai/go/ tracked
+ * links (macOS/Windows/Linux buttons, GitHub, Product Hunt, NxGn — see the
+ * Worker in the webpage repo's worker/ directory). This is the maintainer's own
+ * reach dashboard, not something an end user's build needs, hence the dev-shell
+ * gate in SettingsDialog.tsx via isDevShell().
+ *
+ * The screen leads with FIRST-TIME visitors, because "is anyone new showing up"
+ * is the question it exists to answer. Two things about that are worth knowing
+ * before reading any number here:
+ *
+ * - Unique counts are not additive. The Worker counts each grain separately and
+ *   this screen never sums one grain to make another — see the note on
+ *   TrafficVisitorDay in api/types.ts.
+ * - GitHub's download counters carry NO identity. They cannot be split into new
+ *   versus updating users by any means, so they are labelled as the raw tallies
+ *   they are, and the new-user funnel is built from download-button clicks
+ *   (which the Worker can attribute) instead.
+ */
 
 import { useMemo, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { refreshTraffic, useTraffic } from "../../../state/queries";
-import type { TrafficClickRow, TrafficRelease, TrafficStarPoint } from "../../../api/types";
+import type {
+  TrafficClickRow,
+  TrafficDownloadFunnel,
+  TrafficRelease,
+  TrafficStarPoint,
+  TrafficVisitorDay,
+} from "../../../api/types";
+import { niceTicks, shownMetric, type TrafficMetric } from "../../../lib/traffic";
 import type { ScreenProps } from "../SettingsDialog";
 
 const DAYS_OPTIONS = [30, 90] as const;
@@ -41,6 +61,102 @@ function fmtDate(iso: string | null): string {
     return iso;
   }
 }
+
+function fmtPct(part: number, whole: number): string {
+  if (!whole) return "—";
+  return ((part / whole) * 100).toFixed(1) + "%";
+}
+
+function plural(n: number, word: string): string {
+  return `${fmtInt(n)} ${word}${n === 1 ? "" : "s"}`;
+}
+
+/* --- Shared chart geometry -------------------------------------------------
+ * All four charts here are the same box, so the box is defined once. The user
+ * unit is the SVG unit; the charts stretch horizontally (preserveAspectRatio
+ * none) but their CSS height matches CHART_H, so one vertical unit is one CSS
+ * pixel — which is what lets the y-axis ticks be positioned as a percentage of
+ * the same height and stay in register with the gridlines. */
+const CHART_W = 640;
+const CHART_H = 160;
+const PAD_L = 4;
+/** Room under the baseline. The date labels live in HTML below the SVG, so this
+ * is just breathing space, not a text box. */
+const PAD_B = 18;
+/** Room above the topmost tick, so the highest gridline's label has somewhere
+ * to sit without being cut off by the top of the plot. */
+const PAD_T = 10;
+const PLOT_H = CHART_H - PAD_B;
+
+/** Pixels-per-unit mapping onto the plot, against a ROUND axis maximum rather
+ * than the data's own peak — that is what puts the top gridline on a labelled
+ * value instead of at whatever height the biggest bar happened to reach. */
+function scaleFor(axisMax: number) {
+  return (v: number) => (v / axisMax) * (PLOT_H - PAD_T);
+}
+
+/** Horizontal gridlines at each labelled tick.
+ *
+ * Hairline, solid, one step off the surface (see traffic.css) — recessive
+ * enough to read the value off without competing with the marks. Zero is
+ * skipped: the baseline is already drawn there, at full border weight.
+ *
+ * Rendered inside the SVG (the geometry has to stretch with the plot) while the
+ * numbers themselves are HTML in YAxis below (text must NOT stretch). */
+function Gridlines({ ticks, yAt }: { ticks: number[]; yAt: (v: number) => number }) {
+  return (
+    <g aria-hidden="true">
+      {ticks
+        .filter((t) => t > 0)
+        .map((t) => (
+          <line key={t} x1={0} y1={yAt(t)} x2={CHART_W} y2={yAt(t)} className="traffic-gridline" />
+        ))}
+    </g>
+  );
+}
+
+/** The y-axis tick labels: HTML in a gutter beside the plot, not SVG <text>.
+ *
+ * The charts scale to their container with preserveAspectRatio="none", so
+ * anything drawn inside the SVG is stretched horizontally by whatever the panel
+ * width happens to be — fine for lines and rectangles, ruinous for glyphs. The
+ * numbers therefore sit outside the SVG and are positioned as a percentage of
+ * the plot's height, which the gutter shares with it.
+ *
+ * aria-hidden because each chart's role="img" label already states the range in
+ * words; the visible ticks would otherwise read out as a row of bare numbers. */
+function YAxis({ ticks, yAt }: { ticks: number[]; yAt: (v: number) => number }) {
+  // Absolutely-positioned children contribute nothing to the gutter's width, so
+  // it is sized from the widest label. `ch` is the width of a "0", and the ticks
+  // are tabular, so digits are exact and separators come in slightly under.
+  const width = Math.max(...ticks.map((t) => fmtInt(t).length));
+  return (
+    <div className="traffic-yaxis" style={{ width: `${width}ch` }} aria-hidden="true">
+      {ticks.map((t) => (
+        <span key={t} className="traffic-ytick" style={{ top: `${(yAt(t) / CHART_H) * 100}%` }}>
+          {fmtInt(t)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** Corner radius for a bar of this width and height.
+ *
+ * Bounded by the HEIGHT as well as the width, which the width-only version
+ * wasn't: at a 90-day range the bars are ~5px wide, so a radius of half the
+ * width turned every short bar into a lozenge — a 4px-tall count rendered as
+ * an oval reads as a blob rather than as a magnitude anchored to the baseline.
+ * Dividing by 3 keeps the softening visible on tall bars and negligible on
+ * short ones. */
+function barRadius(width: number, height: number): number {
+  return Math.max(0, Math.min(3, width / 2, height / 3));
+}
+
+/** Below this the bars are too narrow to outline: a 1px stroke on each side of
+ * a ~5px bar is most of the bar, so the recessive segment fills in solid and
+ * stops being distinguishable from the segment it's stacked against. */
+const OUTLINE_MIN_BAR_W = 8;
 
 /** Collapse the flat (day, slug) rows into one totals-per-day series for the
  * bar chart — a single magnitude over time, so one hue (--accent) is the
@@ -83,21 +199,17 @@ function StarsChart({ points }: { points: TrafficStarPoint[] }) {
     return <p className="set-hint">Only one day of star history so far — check back once there's a trend.</p>;
   }
 
-  const w = 640;
-  const h = 160;
-  const padL = 4;
-  const padB = 18;
-  const plotH = h - padB;
-  const max = Math.max(1, ...points.map((p) => p.stars));
-  const stepX = (w - padL) / (points.length - 1);
-  const xAt = (i: number) => padL + i * stepX;
-  const yAt = (v: number) => plotH - (v / max) * (plotH - 8);
+  const { max, ticks } = niceTicks(Math.max(...points.map((p) => p.stars)));
+  const scale = scaleFor(max);
+  const stepX = (CHART_W - PAD_L) / (points.length - 1);
+  const xAt = (i: number) => PAD_L + i * stepX;
+  const yAt = (v: number) => PLOT_H - scale(v);
   const pathD = points.map((p, i) => `${i === 0 ? "M" : "L"}${xAt(i).toFixed(2)},${yAt(p.stars).toFixed(2)}`).join(" ");
 
   const handleMove = (e: ReactMouseEvent<SVGSVGElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
-    const relX = ((e.clientX - rect.left) / rect.width) * w;
-    const idx = Math.max(0, Math.min(points.length - 1, Math.round((relX - padL) / stepX)));
+    const relX = ((e.clientX - rect.left) / rect.width) * CHART_W;
+    const idx = Math.max(0, Math.min(points.length - 1, Math.round((relX - PAD_L) / stepX)));
     setHoverIdx(idx);
   };
 
@@ -105,27 +217,31 @@ function StarsChart({ points }: { points: TrafficStarPoint[] }) {
 
   return (
     <div className="traffic-chart-wrap">
-      <svg
-        className="traffic-chart"
-        viewBox={`0 0 ${w} ${h}`}
-        preserveAspectRatio="none"
-        role="img"
-        aria-label={`Cumulative GitHub stars, ${fmtDate(points[0].day)} through ${fmtDate(points[points.length - 1].day)}`}
-        onMouseMove={handleMove}
-        onMouseLeave={() => setHoverIdx(null)}
-      >
-        <path d={pathD} className="traffic-line" fill="none" />
-        {hoverIdx != null && (
-          <>
-            <line x1={xAt(hoverIdx)} y1={0} x2={xAt(hoverIdx)} y2={plotH} className="traffic-crosshair" />
-            <circle cx={xAt(hoverIdx)} cy={yAt(points[hoverIdx].stars)} r={4} className="traffic-line-dot" />
-          </>
-        )}
-        <line x1={0} y1={plotH} x2={w} y2={plotH} className="traffic-baseline" />
-      </svg>
-      <div className="traffic-chart-axis">
-        <span>{fmtDate(points[0].day)}</span>
-        <span>{fmtDate(points[points.length - 1].day)}</span>
+      <div className="traffic-plot">
+        <YAxis ticks={ticks} yAt={yAt} />
+        <svg
+          className="traffic-chart"
+          viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`Cumulative GitHub stars, ${fmtDate(points[0].day)} through ${fmtDate(points[points.length - 1].day)}, on a vertical scale of 0 to ${fmtInt(max)} stars`}
+          onMouseMove={handleMove}
+          onMouseLeave={() => setHoverIdx(null)}
+        >
+          <Gridlines ticks={ticks} yAt={yAt} />
+          <path d={pathD} className="traffic-line" fill="none" />
+          {hoverIdx != null && (
+            <>
+              <line x1={xAt(hoverIdx)} y1={PAD_T} x2={xAt(hoverIdx)} y2={PLOT_H} className="traffic-crosshair" />
+              <circle cx={xAt(hoverIdx)} cy={yAt(points[hoverIdx].stars)} r={4} className="traffic-line-dot" />
+            </>
+          )}
+          <line x1={0} y1={PLOT_H} x2={CHART_W} y2={PLOT_H} className="traffic-baseline" />
+        </svg>
+        <div className="traffic-chart-axis">
+          <span>{fmtDate(points[0].day)}</span>
+          <span>{fmtDate(points[points.length - 1].day)}</span>
+        </div>
       </div>
       <div className="traffic-tooltip" aria-live="polite">
         {hovered ? (
@@ -158,49 +274,49 @@ function ReleasesChart({ releases }: { releases: TrafficRelease[] }) {
     return <p className="set-hint">No published releases yet.</p>;
   }
 
-  const max = Math.max(1, ...chrono.map((r) => r.total_downloads));
-  const w = 640;
-  const h = 160;
-  const padL = 4;
-  const padB = 18;
-  const plotH = h - padB;
+  const { max, ticks } = niceTicks(Math.max(...chrono.map((r) => r.total_downloads)));
+  const scale = scaleFor(max);
   const barGap = 3;
-  const barW = Math.max(1, (w - padL) / chrono.length - barGap);
+  const barW = Math.max(1, (CHART_W - PAD_L) / chrono.length - barGap);
 
   const hovered = hover != null ? chrono[hover] : null;
 
   return (
     <div className="traffic-chart-wrap">
-      <svg
-        className="traffic-chart"
-        viewBox={`0 0 ${w} ${h}`}
-        preserveAspectRatio="none"
-        role="img"
-        aria-label={`Downloads per release, ${chrono[0].tag} through ${chrono[chrono.length - 1].tag}`}
-        onMouseLeave={() => setHover(null)}
-      >
-        {chrono.map((r, i) => {
-          const barH = Math.max(1, (r.total_downloads / max) * (plotH - 8));
-          const x = padL + i * (barW + barGap);
-          const y = plotH - barH;
-          return (
-            <rect
-              key={r.tag}
-              x={x}
-              y={y}
-              width={barW}
-              height={barH}
-              rx={Math.min(3, barW / 2)}
-              className={"traffic-bar" + (hover === i ? " hover" : "")}
-              onMouseEnter={() => setHover(i)}
-            />
-          );
-        })}
-        <line x1={0} y1={plotH} x2={w} y2={plotH} className="traffic-baseline" />
-      </svg>
-      <div className="traffic-chart-axis">
-        <span>{fmtDate(chrono[0].published_at)}</span>
-        <span>{fmtDate(chrono[chrono.length - 1].published_at)}</span>
+      <div className="traffic-plot">
+        <YAxis ticks={ticks} yAt={(v) => PLOT_H - scale(v)} />
+        <svg
+          className="traffic-chart"
+          viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`Downloads per release, ${chrono[0].tag} through ${chrono[chrono.length - 1].tag}, on a vertical scale of 0 to ${fmtInt(max)} downloads`}
+          onMouseLeave={() => setHover(null)}
+        >
+          <Gridlines ticks={ticks} yAt={(v) => PLOT_H - scale(v)} />
+          {chrono.map((r, i) => {
+            const barH = Math.max(1, scale(r.total_downloads));
+            const x = PAD_L + i * (barW + barGap);
+            const y = PLOT_H - barH;
+            return (
+              <rect
+                key={r.tag}
+                x={x}
+                y={y}
+                width={barW}
+                height={barH}
+                rx={barRadius(barW, barH)}
+                className={"traffic-bar" + (hover === i ? " hover" : "")}
+                onMouseEnter={() => setHover(i)}
+              />
+            );
+          })}
+          <line x1={0} y1={PLOT_H} x2={CHART_W} y2={PLOT_H} className="traffic-baseline" />
+        </svg>
+        <div className="traffic-chart-axis">
+          <span>{fmtDate(chrono[0].published_at)}</span>
+          <span>{fmtDate(chrono[chrono.length - 1].published_at)}</span>
+        </div>
       </div>
       <div className="traffic-tooltip" aria-live="polite">
         {hovered ? (
@@ -228,6 +344,232 @@ function ReleasesChart({ releases }: { releases: TrafficRelease[] }) {
   );
 }
 
+/** Visitors per day, split first-time vs returning.
+ *
+ * Stacked, and stacked with ONE hue at two weights rather than two colors. The
+ * split is part-to-whole with a clear focus — first-timers are the thing being
+ * watched, returning visitors are the context they sit in — not two co-equal
+ * categories, so a categorical pair would overstate the second series. It also
+ * has to survive Settings → Appearance repainting --accent to any hue, which a
+ * hand-picked companion colour would not.
+ *
+ * The returning segment carries a full-strength outline because its fill alone
+ * lands near 1.6:1 on the panel at every alpha that still reads as recessive —
+ * the edge is what makes the mark perceivable, and it keeps the fill quiet. */
+function VisitorsChart({ days }: { days: TrafficVisitorDay[] }) {
+  const [hover, setHover] = useState<number | null>(null);
+
+  if (!days.length) {
+    return <p className="set-hint">No visitors recorded in this window yet.</p>;
+  }
+
+  const { max, ticks } = niceTicks(Math.max(...days.map((d) => d.visitors)));
+  const barGap = 2;
+  const barW = Math.max(1, (CHART_W - PAD_L) / days.length - barGap);
+  // Segment spacer from the mark spec — omitted when a bar is too short to
+  // give up 2px without the smaller segment vanishing entirely.
+  const SEG_GAP = 2;
+
+  const scale = scaleFor(max);
+  const yAt = (v: number) => PLOT_H - scale(v);
+  const hovered = hover != null ? days[hover] : null;
+
+  return (
+    <div className="traffic-chart-wrap">
+      <div className="traffic-legend">
+        <span className="traffic-legend-item">
+          <span className="traffic-swatch new" aria-hidden="true" /> First-time
+        </span>
+        <span className="traffic-legend-item">
+          <span className="traffic-swatch returning" aria-hidden="true" /> Returning
+        </span>
+      </div>
+      <div className="traffic-plot">
+        <YAxis ticks={ticks} yAt={yAt} />
+        <svg
+          className="traffic-chart"
+          viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`Daily visitors split into first-time and returning, ${days[0].day} through ${days[days.length - 1].day}, on a vertical scale of 0 to ${fmtInt(max)} visitors`}
+          onMouseLeave={() => setHover(null)}
+        >
+          <Gridlines ticks={ticks} yAt={yAt} />
+          {days.map((d, i) => {
+            const x = PAD_L + i * (barW + barGap);
+            const newH = scale(d.new_visitors);
+            const restH = scale(d.visitors - d.new_visitors);
+            const gap = newH > SEG_GAP && restH > SEG_GAP ? SEG_GAP : 0;
+            const outlined = barW >= OUTLINE_MIN_BAR_W ? " outlined" : "";
+            return (
+              <g key={d.day} onMouseEnter={() => setHover(i)} className={hover === i ? "hover" : ""}>
+                {/* An invisible full-height target so thin bars and empty days
+                    are still hoverable — the hit area is the column, not the ink. */}
+                <rect x={x} y={0} width={barW + barGap} height={PLOT_H} className="traffic-hit" />
+                {restH > 0 && (
+                  <rect
+                    x={x}
+                    y={PLOT_H - newH - gap - restH}
+                    width={barW}
+                    height={restH}
+                    rx={barRadius(barW, restH)}
+                    className={"traffic-seg-returning" + outlined + (hover === i ? " hover" : "")}
+                  />
+                )}
+                {newH > 0 && (
+                  <rect
+                    x={x}
+                    y={PLOT_H - newH}
+                    width={barW}
+                    height={newH}
+                    rx={barRadius(barW, newH)}
+                    className={"traffic-seg-new" + (hover === i ? " hover" : "")}
+                  />
+                )}
+              </g>
+            );
+          })}
+          <line x1={0} y1={PLOT_H} x2={CHART_W} y2={PLOT_H} className="traffic-baseline" />
+        </svg>
+        <div className="traffic-chart-axis">
+          <span>{fmtDate(days[0].day)}</span>
+          <span>{fmtDate(days[days.length - 1].day)}</span>
+        </div>
+      </div>
+      <div className="traffic-tooltip" aria-live="polite">
+        {hovered ? (
+          <>
+            <strong>{fmtDate(hovered.day)}</strong> — {plural(hovered.visitors, "visitor")}
+            <span className="traffic-tooltip-detail">
+              {" "}
+              ({fmtInt(hovered.new_visitors)} first-time, {fmtInt(hovered.returning_visitors)}{" "}
+              returning
+              {hovered.unknown_visitors > 0 && `, ${fmtInt(hovered.unknown_visitors)} unattributed`})
+            </span>
+          </>
+        ) : (
+          <span className="set-hint">Hover a bar for that day's first-time / returning split.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** How many first-time visitors went on to start a download.
+ *
+ * This is the screen's answer to "are the downloads new users?", and it is a
+ * proxy — it counts people who clicked a platform button on mindflock.ai, not
+ * installs. It misses anyone who downloaded straight from the GitHub repo page,
+ * and it counts an intent that may never finish. Both are stated on-screen
+ * rather than left for the reader to assume, because the honest version of this
+ * number is more useful than a flattering one.
+ *
+ * Bars are drawn against the same denominator so the funnel's two rows are
+ * directly comparable in length, which is the whole point of drawing it. */
+function DownloadFunnel({ funnel, days }: { funnel: TrafficDownloadFunnel; days: number }) {
+  const { new_visitors: total, new_visitors_clicked: clicked } = funnel;
+
+  if (!total) {
+    return (
+      <p className="set-hint">
+        No first-time visitors recorded in this window yet — the funnel fills in as the tracked
+        links get clicked.
+      </p>
+    );
+  }
+
+  const rows = [
+    { label: "First-time visitors", value: total },
+    { label: "…who started a download", value: clicked, rate: fmtPct(clicked, total) },
+  ];
+
+  // The funnel's axis runs 0 to a round number at or above the first-time count,
+  // so the bars land against labelled ticks. That means the top bar no longer
+  // fills its track — the leftover is the rounding headroom, not missing data,
+  // and the two rows stay comparable because both are drawn to the same scale.
+  // Five intervals rather than the charts' four: these bars are as wide as the
+  // panel, so there is room for more ticks, and the extra one keeps the ceiling
+  // closer to the count (45 rounds to 50 rather than to 60, which would leave a
+  // quarter of the track looking like missing data).
+  const { max: axisMax, ticks } = niceTicks(total, 5);
+
+  return (
+    <div className="traffic-funnel">
+      {rows.map((r) => (
+        <div className="traffic-funnel-row" key={r.label}>
+          <span className="traffic-funnel-label">{r.label}</span>
+          <span className="traffic-funnel-track">
+            {ticks.slice(1, -1).map((t) => (
+              <span
+                key={t}
+                className="traffic-funnel-grid"
+                style={{ left: `${(t / axisMax) * 100}%` }}
+              />
+            ))}
+            <span
+              className="traffic-funnel-fill"
+              style={{ width: `${(r.value / axisMax) * 100}%` }}
+            />
+          </span>
+          <span className="traffic-funnel-num">{fmtInt(r.value)}</span>
+          <span className="traffic-funnel-rate">{r.rate || ""}</span>
+        </div>
+      ))}
+
+      {/* The tick scale, in the funnel row's own grid so the numbers sit under
+          the track they measure. The end labels are pinned inside the track's
+          edges rather than centred on their ticks, which would hang them over
+          the label and count columns either side. */}
+      <div className="traffic-funnel-axis" aria-hidden="true">
+        <span />
+        <span className="traffic-funnel-ticks">
+          {ticks.map((t, i) => (
+            <span
+              key={t}
+              className={
+                "traffic-funnel-tick" +
+                (i === 0 ? " first" : i === ticks.length - 1 ? " last" : "")
+              }
+              style={{ left: `${(t / axisMax) * 100}%` }}
+            >
+              {fmtInt(t)}
+            </span>
+          ))}
+        </span>
+      </div>
+
+      <table className="traffic-table traffic-funnel-table">
+        <thead>
+          <tr>
+            <th>Platform</th>
+            <th className="num">First-time</th>
+            <th className="num">All visitors</th>
+            <th className="num">Clicks</th>
+          </tr>
+        </thead>
+        <tbody>
+          {funnel.by_slug.map((s) => (
+            <tr key={s.slug}>
+              <td>{slugLabel(s.slug)}</td>
+              <td className="num">{fmtInt(s.new_visitors)}</td>
+              <td className="num">{fmtInt(s.visitors)}</td>
+              <td className="num">{fmtInt(s.clicks)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <p className="set-hint">
+        Download <em>intent</em>, not installs, over the last {days} days: someone pressing a
+        platform button on mindflock.ai. It misses anyone who downloaded straight from the GitHub
+        repo page, and a click is not a finished install. Per-platform first-timers can overlap
+        (one person pressing both macOS and Linux is in both rows), so they may add up to more than
+        the {fmtInt(clicked)} above — that figure is the deduplicated one.
+      </p>
+    </div>
+  );
+}
+
 function ClicksChart({ series }: { series: TrafficClickRow[] }) {
   const days = useMemo(() => dailyTotals(series), [series]);
   const [hover, setHover] = useState<number | null>(null);
@@ -236,49 +578,50 @@ function ClicksChart({ series }: { series: TrafficClickRow[] }) {
     return <p className="set-hint">No clicks recorded in this window yet.</p>;
   }
 
-  const max = Math.max(1, ...days.map((d) => d.total));
-  const w = 640;
-  const h = 160;
-  const padL = 4;
-  const padB = 18;
-  const plotH = h - padB;
+  const { max, ticks } = niceTicks(Math.max(...days.map((d) => d.total)));
+  const scale = scaleFor(max);
+  const yAt = (v: number) => PLOT_H - scale(v);
   const barGap = 2;
-  const barW = Math.max(1, (w - padL) / days.length - barGap);
+  const barW = Math.max(1, (CHART_W - PAD_L) / days.length - barGap);
 
   const hovered = hover != null ? days[hover] : null;
 
   return (
     <div className="traffic-chart-wrap">
-      <svg
-        className="traffic-chart"
-        viewBox={`0 0 ${w} ${h}`}
-        preserveAspectRatio="none"
-        role="img"
-        aria-label={`Daily clicks across all tracked links, ${days[0].day} through ${days[days.length - 1].day}`}
-        onMouseLeave={() => setHover(null)}
-      >
-        {days.map((d, i) => {
-          const barH = Math.max(1, (d.total / max) * (plotH - 8));
-          const x = padL + i * (barW + barGap);
-          const y = plotH - barH;
-          return (
-            <rect
-              key={d.day}
-              x={x}
-              y={y}
-              width={barW}
-              height={barH}
-              rx={Math.min(3, barW / 2)}
-              className={"traffic-bar" + (hover === i ? " hover" : "")}
-              onMouseEnter={() => setHover(i)}
-            />
-          );
-        })}
-        <line x1={0} y1={plotH} x2={w} y2={plotH} className="traffic-baseline" />
-      </svg>
-      <div className="traffic-chart-axis">
-        <span>{fmtDate(days[0].day)}</span>
-        <span>{fmtDate(days[days.length - 1].day)}</span>
+      <div className="traffic-plot">
+        <YAxis ticks={ticks} yAt={yAt} />
+        <svg
+          className="traffic-chart"
+          viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`Daily clicks across all tracked links, ${days[0].day} through ${days[days.length - 1].day}, on a vertical scale of 0 to ${fmtInt(max)} clicks`}
+          onMouseLeave={() => setHover(null)}
+        >
+          <Gridlines ticks={ticks} yAt={yAt} />
+          {days.map((d, i) => {
+            const barH = Math.max(1, scale(d.total));
+            const x = PAD_L + i * (barW + barGap);
+            const y = PLOT_H - barH;
+            return (
+              <rect
+                key={d.day}
+                x={x}
+                y={y}
+                width={barW}
+                height={barH}
+                rx={barRadius(barW, barH)}
+                className={"traffic-bar" + (hover === i ? " hover" : "")}
+                onMouseEnter={() => setHover(i)}
+              />
+            );
+          })}
+          <line x1={0} y1={PLOT_H} x2={CHART_W} y2={PLOT_H} className="traffic-baseline" />
+        </svg>
+        <div className="traffic-chart-axis">
+          <span>{fmtDate(days[0].day)}</span>
+          <span>{fmtDate(days[days.length - 1].day)}</span>
+        </div>
       </div>
       <div className="traffic-tooltip" aria-live="polite">
         {hovered ? (
@@ -307,6 +650,7 @@ function ClicksChart({ series }: { series: TrafficClickRow[] }) {
 
 export function Traffic(_: ScreenProps) {
   const [days, setDays] = useState<(typeof DAYS_OPTIONS)[number]>(90);
+  const [metric, setMetric] = useState<TrafficMetric>("people");
   const [refreshing, setRefreshing] = useState(false);
   const q = useTraffic(true, days);
   const data = q.data;
@@ -315,6 +659,24 @@ export function Traffic(_: ScreenProps) {
     if (!data) return [];
     return Object.entries(data.clicks.totals_by_slug).sort((a, b) => b[1] - a[1]);
   }, [data]);
+
+  /** Per-link visitor counts, keyed by slug for the clicks table to join on.
+   * Empty against a Worker that predates visitor attribution. */
+  const visitorsBySlug = useMemo(() => {
+    const map = new Map<string, { visitors: number; new_visitors: number }>();
+    for (const row of data?.clicks.visitors_by_slug ?? []) map.set(row.slug, row);
+    return map;
+  }, [data]);
+
+  // `totals` is absent (not zero) until the Worker carrying visitor attribution
+  // is deployed — the difference matters, since zeros would read as "nobody
+  // came" rather than "not measured yet".
+  const people = data?.clicks.totals ?? null;
+  const funnel = data?.clicks.downloads ?? null;
+
+  // What the chart may actually draw, as opposed to what was last asked for —
+  // see lib/traffic.ts for why this is derived rather than read off state.
+  const shown = shownMetric(metric, data);
 
   const doRefresh = async () => {
     setRefreshing(true);
@@ -349,6 +711,22 @@ export function Traffic(_: ScreenProps) {
           )}
 
           <div className="traffic-tiles">
+            <div className="traffic-tile primary">
+              <span className="traffic-tile-num">{fmtInt(people?.new_visitors)}</span>
+              <span className="traffic-tile-label">
+                First-time visitors ({data.clicks.days}d)
+              </span>
+            </div>
+            <div className="traffic-tile">
+              <span className="traffic-tile-num">{fmtInt(people?.visitors)}</span>
+              <span className="traffic-tile-label">Unique visitors ({data.clicks.days}d)</span>
+            </div>
+            <div className="traffic-tile">
+              <span className="traffic-tile-num">
+                {fmtInt(people?.clicks ?? clickTotalsSorted.reduce((s, [, n]) => s + n, 0))}
+              </span>
+              <span className="traffic-tile-label">Tracked link clicks ({data.clicks.days}d)</span>
+            </div>
             <div className="traffic-tile">
               <span className="traffic-tile-num">{fmtInt(data.repo?.stars)}</span>
               <span className="traffic-tile-label">GitHub stars</span>
@@ -359,15 +737,30 @@ export function Traffic(_: ScreenProps) {
             </div>
             <div className="traffic-tile">
               <span className="traffic-tile-num">{fmtInt(data.downloads_total)}</span>
-              <span className="traffic-tile-label">Total downloads (all releases)</span>
-            </div>
-            <div className="traffic-tile">
-              <span className="traffic-tile-num">
-                {fmtInt(clickTotalsSorted.reduce((s, [, n]) => s + n, 0))}
-              </span>
-              <span className="traffic-tile-label">Tracked link clicks ({data.clicks.days}d)</span>
+              <span className="traffic-tile-label">Downloads (all releases, all-time)</span>
             </div>
           </div>
+
+          {!people && !data.errors.clicks && (
+            <p className="set-hint">
+              Visitor counts are empty because the click Worker hasn't been redeployed with visitor
+              attribution yet (see <code>worker/README.md</code> in the webpage repo — it needs the{" "}
+              <code>VISITORS</code> KV namespace and the <code>VISITOR_SALT</code> secret). Clicks
+              below are unaffected. Numbers start accumulating at deploy time, so expect visitors to
+              trail clicks until the window fills in.
+            </p>
+          )}
+
+          <h3 className="set-section-title">New user funnel ({data.clicks.days}d)</h3>
+          {funnel ? (
+            <DownloadFunnel funnel={funnel} days={data.clicks.days} />
+          ) : (
+            <p className="set-hint">
+              Not available until the click Worker reports visitor attribution. GitHub's download
+              counters can't stand in for it — they're opaque tallies that include updates and
+              re-downloads, with no way to tell one person from another.
+            </p>
+          )}
 
           <h3 className="set-section-title">GitHub stars over time</h3>
           {/* A server running code from before this field existed answers without
@@ -377,18 +770,53 @@ export function Traffic(_: ScreenProps) {
               type. */}
           <StarsChart points={data.star_history ?? []} />
 
+          <h3 className="set-section-title">
+            {shown === "people" ? "Visitors over time" : "Clicks over time"}
+          </h3>
+
           <div className="set-row traffic-range-row">
-            <div className="usage-periods traffic-range">
-              {DAYS_OPTIONS.map((d) => (
-                <button
-                  key={d}
-                  type="button"
-                  className={"usage-period" + (days === d ? " active" : "")}
-                  onClick={() => setDays(d)}
-                >
-                  {d}d
-                </button>
-              ))}
+            <div className="traffic-controls">
+              <div className="usage-periods traffic-range">
+                {DAYS_OPTIONS.map((d) => (
+                  <button
+                    key={d}
+                    type="button"
+                    className={"usage-period" + (days === d ? " active" : "")}
+                    onClick={() => setDays(d)}
+                  >
+                    {d}d
+                  </button>
+                ))}
+              </div>
+              {/* People and clicks are different quantities on different scales
+                  (one person can click many links), so they get one chart and a
+                  switch rather than two y-axes on the same plot.
+
+                  The switch only exists when there is something to switch
+                  between. It used to render with People disabled whenever the
+                  Worker had no visitor data, which was a one-way door: `metric`
+                  starts at "people", so People drew as active, and pressing
+                  Clicks moved you to a state you could not leave. A control
+                  whose default value is the one it disables is a trap, so when
+                  there is one option it is simply not a control. */}
+              {people && (
+                <div className="usage-periods traffic-range">
+                  <button
+                    type="button"
+                    className={"usage-period" + (shown === "people" ? " active" : "")}
+                    onClick={() => setMetric("people")}
+                  >
+                    People
+                  </button>
+                  <button
+                    type="button"
+                    className={"usage-period" + (shown === "clicks" ? " active" : "")}
+                    onClick={() => setMetric("clicks")}
+                  >
+                    Clicks
+                  </button>
+                </div>
+              )}
             </div>
             <span className="test-row">
               <button type="button" className="test-btn" onClick={doRefresh} disabled={refreshing}>
@@ -400,15 +828,21 @@ export function Traffic(_: ScreenProps) {
             </span>
           </div>
 
-          <ClicksChart series={data.clicks.series} />
+          {shown === "people" ? (
+            <VisitorsChart days={data.clicks.visitors_by_day} />
+          ) : (
+            <ClicksChart series={data.clicks.series} />
+          )}
 
           {clickTotalsSorted.length > 0 && (
             <>
-              <h3 className="set-section-title">Clicks by link ({data.clicks.days}d)</h3>
+              <h3 className="set-section-title">By link ({data.clicks.days}d)</h3>
               <table className="traffic-table">
                 <thead>
                   <tr>
                     <th>Link</th>
+                    {people && <th className="num">First-time</th>}
+                    {people && <th className="num">Visitors</th>}
                     <th className="num">Clicks</th>
                   </tr>
                 </thead>
@@ -416,11 +850,24 @@ export function Traffic(_: ScreenProps) {
                   {clickTotalsSorted.map(([slug, n]) => (
                     <tr key={slug}>
                       <td>{slugLabel(slug)}</td>
+                      {people && (
+                        <td className="num">{fmtInt(visitorsBySlug.get(slug)?.new_visitors)}</td>
+                      )}
+                      {people && (
+                        <td className="num">{fmtInt(visitorsBySlug.get(slug)?.visitors)}</td>
+                      )}
                       <td className="num">{fmtInt(n)}</td>
                     </tr>
                   ))}
                 </tbody>
               </table>
+              {people && (
+                <p className="set-hint">
+                  Visitor columns are deduplicated per link over the window, so they don't add up
+                  down the column — one person clicking two links is one visitor on each row and one
+                  visitor overall.
+                </p>
+              )}
             </>
           )}
 
@@ -432,6 +879,13 @@ export function Traffic(_: ScreenProps) {
           )}
 
           <h3 className="set-section-title">Downloads by version</h3>
+          <p className="set-hint">
+            GitHub's raw asset counters. These are <em>not</em> people: they include updates and
+            repeat downloads, and GitHub attaches no identity to them, so there is no way to split
+            them into new versus returning users. For new-user numbers use the funnel above. Note
+            too that MindFlock's updater opens the releases page in a browser rather than fetching
+            the asset itself, so an update looks exactly like a first-time download here.
+          </p>
           {data.releases.length === 0 ? (
             <p className="set-hint">No releases found.</p>
           ) : (

--- a/frontend/src/components/settings/screens/traffic.css
+++ b/frontend/src/components/settings/screens/traffic.css
@@ -1,6 +1,12 @@
-/* Settings → Site traffic (dev shell only). Stat tiles, a single-hue click
-   chart, and two data tables — no chart library, consistent with the rest of
-   the app's hand-rolled, zero-dep components. */
+/* Settings → Site traffic (dev shell only). Stat tiles, single-hue charts, a
+   first-time-visitor funnel, and data tables — no chart library, consistent
+   with the rest of the app's hand-rolled, zero-dep components.
+
+   Everything chromatic here is derived from --accent, never a hand-picked
+   companion colour: Settings → Appearance repaints --accent per theme, so a
+   second fixed hue would collide with some of them. Where two things must be
+   told apart, it is done with weight (opacity + outline), which is achromatic
+   and therefore also safe for colour-vision deficiency. */
 
 .traffic-warn {
   border: 1px solid var(--red);
@@ -36,6 +42,14 @@
   color: var(--text);
 }
 
+/* The one tile the screen exists to show. Marked with an accent edge rather
+   than an accent number, so it reads as the lead without pulling the numeric
+   styling of the tiles out of alignment. */
+.traffic-tile.primary {
+  border-color: var(--accent);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
 .traffic-tile-label {
   font-size: 11px;
   color: var(--muted);
@@ -46,6 +60,13 @@
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  flex-wrap: wrap;
+}
+
+.traffic-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
@@ -60,10 +81,64 @@
   gap: 4px;
 }
 
+/* Plot frame: y-axis gutter | plot area, with the date row beneath the plot
+   COLUMN only, so the first and last dates stay flush with the first and last
+   marks instead of being pushed right by the width of the tick labels. */
+.traffic-plot {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: 6px;
+}
+
+.traffic-plot > .traffic-yaxis {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.traffic-plot > .traffic-chart {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.traffic-plot > .traffic-chart-axis {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+/* Must stay equal to CHART_H in Traffic.tsx: the y-axis ticks are placed as a
+   percentage of this height and the gridlines they label are placed in viewBox
+   units, so the two only line up while one viewBox unit is one pixel. */
 .traffic-chart {
   width: 100%;
   height: 160px;
   display: block;
+}
+
+/* The tick labels are HTML, not SVG <text> — the charts stretch horizontally to
+   fill the panel (preserveAspectRatio="none"), which would smear glyphs. Height
+   comes from stretching to the plot's grid row, hence no explicit height here. */
+.traffic-yaxis {
+  position: relative;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.traffic-ytick {
+  position: absolute;
+  right: 0;
+  transform: translateY(-50%);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Hairline, solid, and a step quieter than the baseline: enough to read a bar's
+   value off, not enough to compete with the bars for attention. */
+.traffic-gridline {
+  stroke: var(--border);
+  stroke-width: 1;
+  stroke-opacity: 0.55;
+  vector-effect: non-scaling-stroke;
 }
 
 /* Sequential magnitude-over-time, one series — the app's single accent hue is
@@ -82,6 +157,181 @@
 .traffic-baseline {
   stroke: var(--border);
   stroke-width: 1;
+}
+
+/* --- Visitors: first-time vs returning ------------------------------------
+   Part-to-whole with a focus, not two co-equal categories, so it is ONE hue at
+   two weights rather than a categorical pair — which also means it survives
+   Settings → Appearance repainting --accent to anything.
+
+   The returning segment is outlined at full strength because its fill alone
+   sits near 1.6:1 against the panel at every alpha that still reads as
+   recessive (checked, not guessed). The outline is what makes the mark
+   perceivable; the fill is what keeps it quiet. */
+.traffic-seg-new {
+  fill: var(--accent);
+  opacity: 0.85;
+  transition: opacity 0.1s;
+}
+
+.traffic-seg-new.hover {
+  opacity: 1;
+}
+
+.traffic-seg-returning {
+  fill: var(--accent);
+  fill-opacity: 0.3;
+  transition: fill-opacity 0.1s;
+}
+
+/* The outline is applied by Traffic.tsx only above a minimum bar width. On the
+   ~5px bars of a 90-day range a 1px stroke per side IS most of the bar, so it
+   filled the recessive segment in solid and erased the very distinction it was
+   added to make; at that density the fill difference alone carries it. */
+.traffic-seg-returning.outlined {
+  stroke: var(--accent);
+  stroke-opacity: 0.75;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.traffic-seg-returning.hover {
+  fill-opacity: 0.5;
+}
+
+/* Column-wide hover target: thin bars and zero days must still be reachable,
+   so the hit area is the whole column rather than the drawn ink. */
+.traffic-hit {
+  fill: transparent;
+}
+
+.traffic-legend {
+  display: flex;
+  gap: 14px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.traffic-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.traffic-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.traffic-swatch.new {
+  background: var(--accent);
+  opacity: 0.85;
+}
+
+.traffic-swatch.returning {
+  background: rgba(var(--accent-rgb), 0.3);
+  border: 1px solid rgba(var(--accent-rgb), 0.75);
+}
+
+/* --- New user funnel ------------------------------------------------------ */
+.traffic-funnel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.traffic-funnel-row,
+.traffic-funnel-axis {
+  display: grid;
+  /* The label column fits "…who started a download" on one line; wrapping it
+     pushed the two funnel rows out of vertical rhythm with each other, which
+     is exactly the comparison the bars are there to support. The tick row
+     shares the template so its numbers stay under the track they measure. */
+  grid-template-columns: minmax(170px, auto) minmax(80px, 3fr) auto 52px;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.traffic-funnel-label {
+  color: var(--text);
+}
+
+.traffic-funnel-track {
+  position: relative;
+  height: 14px;
+  border-radius: 4px;
+  background: var(--panel-2, var(--panel));
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.traffic-funnel-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  opacity: 0.85;
+  border-radius: 3px;
+}
+
+/* Interior gridlines, one per labelled tick. The end ticks are left out: the
+   track's own border already draws both, and a line on top of it would just
+   thicken the edge. They sit UNDER the fill (which follows them in the DOM), so
+   a bar covers the ticks it has passed — the same way the bar charts read. */
+.traffic-funnel-grid {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+  opacity: 0.55;
+}
+
+.traffic-funnel-ticks {
+  position: relative;
+  display: block;
+  height: 12px;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.traffic-funnel-tick {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Pinned inside the track's ends instead of centred, so 0 doesn't drift under
+   the row label and the top tick doesn't collide with the count column. */
+.traffic-funnel-tick.first {
+  transform: none;
+}
+
+.traffic-funnel-tick.last {
+  transform: translateX(-100%);
+}
+
+.traffic-funnel-num {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text);
+  text-align: right;
+}
+
+.traffic-funnel-rate {
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--muted);
+  text-align: right;
+}
+
+.traffic-funnel-table {
+  margin-top: 6px;
 }
 
 /* Cumulative stars line (StarsChart) — thin 2px stroke, single accent hue

--- a/frontend/src/lib/traffic.ts
+++ b/frontend/src/lib/traffic.ts
@@ -1,0 +1,75 @@
+/** Pure helpers for Settings → Site traffic.
+ *
+ * The visitor sections of /api/traffic are optional — they are absent, rather
+ * than zero, against a click Worker deployed before visitor attribution
+ * existed. Deciding what the screen may show is therefore a real rule with a
+ * wrong answer, so it lives here where it can be tested rather than inline in
+ * the component. */
+
+import type { TrafficResponse } from "../api/types";
+
+export type TrafficMetric = "people" | "clicks";
+
+/** Whether the payload can support the people-shaped views at all.
+ *
+ * `totals` is the marker: the Worker emits it alongside the other visitor
+ * sections or emits none of them, and it is absent (not zero) when visitor
+ * attribution has not been deployed. */
+export function hasVisitorData(data: TrafficResponse | undefined | null): boolean {
+  return !!data?.clicks?.totals;
+}
+
+/** The metric the chart may actually draw, given what the user asked for and
+ * what the payload can support.
+ *
+ * Deriving this instead of trusting the raw state is what keeps the heading,
+ * the toggle and the chart from disagreeing. `metric` initialises to "people",
+ * so without this a payload carrying only clicks drew a clicks chart under a
+ * "Visitors over time" heading, with People styled as the active tab.
+ *
+ * It also closes a one-way door. The toggle used to render People `disabled`
+ * whenever visitor data was missing — but "people" is the INITIAL state, so
+ * pressing Clicks moved you somewhere you could not come back from. A control
+ * whose default value is the one it disables is a trap; the fix is that the
+ * toggle is only offered when both options are real, and this function makes
+ * the single-option case render correctly on its own. */
+export function shownMetric(
+  requested: TrafficMetric,
+  data: TrafficResponse | undefined | null
+): TrafficMetric {
+  return hasVisitorData(data) ? requested : "clicks";
+}
+
+/** Y-axis ticks for a count axis: 0 up to a round ceiling at or above `rawMax`.
+ *
+ * Every quantity on this screen is a count of whole things — stars, clicks,
+ * visitors, downloads — so the step is forced to a whole number. Without that,
+ * a chart whose peak is 3 gets ticks at 0.75 / 1.5 / 2.25, labelling positions
+ * no data point can occupy. That is the case the naive 1/2/5×10ⁿ ladder gets
+ * wrong, since below a peak of ~10 the "nice" step it wants is fractional.
+ *
+ * The returned `max` is the axis top, NOT the data max: scaling bars against a
+ * round ceiling is what makes the top gridline land on a labelled value. It is
+ * always ≥ 1, so a chart with no data (or an all-zero window) still draws a
+ * 0–1 axis rather than dividing by zero.
+ *
+ * `targetCount` is the number of intervals aimed for, not a guarantee — the
+ * step is snapped to a round number first, so the result can come back with one
+ * more or fewer gap than asked for. */
+export function niceTicks(rawMax: number, targetCount = 4): { max: number; ticks: number[] } {
+  const hi = Number.isFinite(rawMax) && rawMax > 0 ? Math.ceil(rawMax) : 1;
+  const intervals = Math.max(1, Math.round(targetCount));
+  const rough = hi / intervals;
+  const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+  // 2.5 earns its place at 10ⁿ ≥ 10 (250, 2,500 — familiar tick values) but is
+  // dropped below that, where it would be a fractional step.
+  const step =
+    [1, 2, 2.5, 5, 10]
+      .map((m) => m * pow)
+      .filter((s) => Number.isInteger(s) && s >= 1)
+      .find((s) => s >= rough) ?? Math.max(1, Math.ceil(rough));
+  const max = Math.ceil(hi / step) * step;
+  const ticks: number[] = [];
+  for (let v = 0; v <= max; v += step) ticks.push(v);
+  return { max, ticks };
+}

--- a/tests/unit/test_traffic_addon.py
+++ b/tests/unit/test_traffic_addon.py
@@ -1,10 +1,12 @@
 """Traffic addon (Settings → Site traffic, dev-shell only).
 
-Covers the two things that decide whether the screen shows numbers at all:
+Covers the things that decide whether the screen shows numbers at all:
 
 * which token it calls GitHub with — the shared web-layer chain, whose last
   rung (``gh auth token``) is where the token normally lives;
-* that one dead upstream costs you ONE section, not the whole payload.
+* that one dead upstream costs you ONE section, not the whole payload;
+* that the visitor sections are passed through rather than derived, and stay
+  absent (not zero) when the Worker cannot supply them.
 """
 
 from __future__ import annotations
@@ -172,3 +174,137 @@ def test_unreachable_click_worker_leaves_github_intact(stub_http, monkeypatch):
     assert payload["errors"]["github"] is None
     assert "mindflock.ai" in payload["errors"]["clicks"]
     assert payload["clicks"]["series"] == []
+    # The failure shape must carry every key the success shape does — the
+    # screen reads clicks.visitors_by_day/.totals unconditionally.
+    assert payload["clicks"]["visitors_by_day"] == []
+    assert payload["clicks"]["totals"] is None
+    assert payload["clicks"]["downloads"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Visitor attribution
+# --------------------------------------------------------------------------- #
+def _clicks_with_visitors(**overrides) -> tuple:
+    body = {
+        "series": [{"day": "2026-08-10", "slug": "mac", "clicks": 9}],
+        "visitors_by_day": [
+            {
+                "day": "2026-08-10",
+                "visitors": 4,
+                "new_visitors": 3,
+                "returning_visitors": 1,
+                "unknown_visitors": 0,
+            }
+        ],
+        "visitors_by_slug": [
+            {"slug": "mac", "visitors": 4, "new_visitors": 3, "clicks": 9}
+        ],
+        "totals": {"clicks": 9, "visitors": 4, "new_visitors": 3},
+        "downloads": {
+            "new_visitors": 3,
+            "new_visitors_clicked": 2,
+            "by_slug": [{"slug": "mac", "new_visitors": 2, "visitors": 3, "clicks": 9}],
+        },
+    }
+    body.update(overrides)
+    return (200, body)
+
+
+def test_visitor_sections_are_passed_through_not_recomputed(stub_http, monkeypatch):
+    """Unique counts are not additive, so the addon must never derive them.
+
+    Only the store holding the visitor ids can count a given grain: summing
+    per-day uniques over a window does not give window uniques (one person
+    visiting on ten days is ten daily uniques and one window unique). If this
+    layer ever starts computing these, the screen shows numbers that look
+    plausible and are wrong — note that the window total here (4) deliberately
+    does NOT match what naive arithmetic over the click series (9) would give.
+    """
+    stub_http(
+        {
+            "/stargazers": (200, []),
+            "/releases": _RELEASES_OK,
+            "/repos/MindFlock/MindFlock": _REPO_OK,
+            "/go/_stats": _clicks_with_visitors(),
+        }
+    )
+
+    async def _token():
+        return "ghp_x"
+
+    monkeypatch.setattr(traffic, "_token", _token)
+    clicks = asyncio.run(traffic.TrafficAddon()._payload(days=7, refresh=True))[
+        "clicks"
+    ]
+
+    assert clicks["totals"] == {"clicks": 9, "visitors": 4, "new_visitors": 3}
+    assert clicks["visitors_by_day"][0]["new_visitors"] == 3
+    assert clicks["visitors_by_slug"][0]["visitors"] == 4
+    assert clicks["downloads"]["new_visitors_clicked"] == 2
+    # The pre-existing click rollup is untouched by any of this.
+    assert clicks["totals_by_slug"] == {"mac": 9}
+
+
+def test_worker_without_attribution_reports_absent_not_zero(stub_http, monkeypatch):
+    """A Worker deployed before visitor tracking must not read as "nobody came".
+
+    The distinction is the whole point: ``None`` lets the screen say "not
+    measured yet" and point at the deploy step, where a zero would look like a
+    real and very bad number.
+    """
+    stub_http(
+        {
+            "/stargazers": (200, []),
+            "/releases": _RELEASES_OK,
+            "/repos/MindFlock/MindFlock": _REPO_OK,
+            "/go/_stats": _CLICKS_OK,  # the old payload: series only
+        }
+    )
+
+    async def _token():
+        return "ghp_x"
+
+    monkeypatch.setattr(traffic, "_token", _token)
+    clicks = asyncio.run(traffic.TrafficAddon()._payload(days=7, refresh=True))[
+        "clicks"
+    ]
+
+    assert clicks["totals"] is None
+    assert clicks["downloads"] is None
+    assert clicks["visitors_by_day"] == []
+    assert clicks["visitors_by_slug"] == []
+    # Clicks still work — losing attribution costs the people numbers, nothing else.
+    assert clicks["totals_by_slug"] == {"mac": 3}
+    assert clicks["error"] == ""
+
+
+def test_malformed_visitor_sections_are_dropped(stub_http, monkeypatch):
+    """A Worker answering with the wrong shape degrades to "not measured".
+
+    The screen indexes into these, so a string where a list belongs has to be
+    discarded here rather than thrown at the renderer.
+    """
+    stub_http(
+        {
+            "/stargazers": (200, []),
+            "/releases": _RELEASES_OK,
+            "/repos/MindFlock/MindFlock": _REPO_OK,
+            "/go/_stats": _clicks_with_visitors(
+                visitors_by_day="nope", totals=[], downloads=None
+            ),
+        }
+    )
+
+    async def _token():
+        return "ghp_x"
+
+    monkeypatch.setattr(traffic, "_token", _token)
+    clicks = asyncio.run(traffic.TrafficAddon()._payload(days=7, refresh=True))[
+        "clicks"
+    ]
+
+    assert clicks["visitors_by_day"] == []
+    assert clicks["totals"] is None
+    assert clicks["downloads"] is None
+    # A good section alongside the bad ones still survives.
+    assert clicks["visitors_by_slug"][0]["slug"] == "mac"


### PR DESCRIPTION
## What

Two things on the dev-only **Settings → Site traffic** screen.

**1. It can now answer "are the downloads new users?"** The click Worker derives a
pseudonymous visitor id per click, so `/api/traffic` passes through per-day and
per-link visitor counts, a first-time/returning split, and a download funnel. The
screen leads with first-time visitors and gains a People/Clicks toggle.

**2. Every chart has a y-axis.** They previously had none — each was a shape with
no magnitude, readable only by hovering mark after mark. All four charts (stars
line, clicks bars, stacked visitors, downloads per release) now carry round ticks
plus hairline gridlines, and the funnel bars sit on a labelled scale too.

## Contracts worth knowing

- **Unique counts are not additive.** Every grain is passed through from the store
  holding the visitor ids rather than summed here; summing per-day uniques over a
  month yields a number that looks right and is wrong.
- **GitHub's `download_count` carries no identity.** It includes updates and
  re-downloads and cannot be split into new versus returning users, so the funnel
  is built from download-button clicks (which the Worker can attribute) and the
  raw GitHub tallies are labelled as the opaque counts they are.
- **Absent, not zero.** The visitor sections come back `null` against a Worker
  deployed before attribution, so the screen says "not measured yet" instead of
  drawing a chart of zeros.
- **The funnel is download *intent*.** It counts button presses on mindflock.ai,
  misses anyone downloading from the repo page, and a click is not an install —
  all stated on-screen.

## Axis implementation notes

- Bars scale to a **round ceiling**, not the data's own peak — that is what puts
  the top gridline on a value worth reading.
- Tick labels are **HTML beside the SVG**, not `<text>` inside it: the charts
  stretch to the panel with `preserveAspectRatio="none"`, which is fine for rects
  and ruinous for glyphs. They position as a percentage of the height the gutter
  shares with the plot.
- Tick steps are forced to **whole numbers**, because every quantity here is a
  count of whole things. The plain 1/2/5×10ⁿ ladder wants a step of 0.75 when the
  peak is 3, labelling three positions no data point can occupy.

## Testing

- `pytest tests/` — 4131 passed.
- `vitest` — 268 passed, including a new `niceTicks` suite (whole-number steps at
  small peaks, ceiling above the peak, always spanning the data, and the
  empty-window `Math.max()` → `-Infinity` path).
- `tsc --noEmit` + `vite build` clean; committed bundle verified fresh by the
  pre-push hook.
- Rendered every chart and the funnel headless in **light and dark** at peaks of
  3 / 37 / 45 / 90 / 1,240 / 3,605 to check tick-to-gridline registration, gutter
  width, and label collisions.
- Verified against live data on the running server: 7 star-history points, 18
  releases, 49 click-day rows, funnel 45 → 41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
