### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-25
+
 ### Added
 
 - **Verify — "it merged" is not "it works".** The pipeline's last honest
@@ -1441,7 +1443,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.1.17...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/MindFlock/MindFlock/releases/tag/v0.2.0
 [0.1.17]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.17
 [0.1.16]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.16
 [0.1.15]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.15

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.1.17",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.1.17",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.1.17"
+version = "0.2.0"
 description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.1.17"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump across the four manifests + `uv.lock`, and the CHANGELOG's
`[Unreleased]` rolled into `[0.2.0] - 2026-08-25`. No code changes.

A minor bump rather than a patch: this cycle adds **Verify** — the back half of
the pipeline, which asks whether what merged actually works — along with
Intake's Auto-start tab, Reopen, the per-launch CLI / depth / effort pickers,
the ↺ back-to-idle control, and Take a break with the idle flock.

Tag `v0.2.0` goes on the merge commit once this lands, which is what builds and
publishes the wheel, sdist and the three desktop installers.