### PR TITLE
Enhance session management and notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Your agent has finished" is now a claim MindFlock can back up.** The idle
+  notification fired on the wrong fact. A session's chip goes grey when its CLI
+  reports a turn ended, and a coding CLI reports that at the end of *every*
+  assistant reply — so a ten-turn conversation announced "finished" ten times,
+  a queue draining ten prompts announced it between each pair, and a window you
+  merely clicked back open announced it for an agent that had not run anything
+  at all.
+
+  That last one is the one people saw most, and it was two bugs standing on each
+  other. Opening a pane relaunches an agent whose tmux session has died — and
+  the activity layer *threw away everything it knew about a session* on every
+  poll while it was offline, so the relaunched CLI arrived as a stranger. Facing
+  a pane it had never seen, the classifier assumed it was working, on the theory
+  that a fresh agent usually is. It held the badge at **running** for eight
+  seconds, decayed to **idle**, and rang the bell — a whole work cycle
+  hallucinated out of a mouse click. The stale hook marker left behind by the
+  *previous* run could do the same thing on its own: nothing deletes those, and
+  they are trusted for six hours.
+
+  Three changes, one per layer. The classifier **no longer guesses**: a pane it
+  has never seen is read for the two things a single frame can actually prove —
+  a usage-limit banner, and the interrupt hint that means a turn is live right
+  now — and anything else is reported as idle, because nothing on that screen
+  says otherwise. Its memory is now scoped to a tmux **incarnation** rather than
+  wiped on every hiccup, so a session that briefly went offline comes back with
+  its history intact, while a genuinely relaunched one starts clean — and a hook
+  marker written before the current session existed no longer speaks for it.
+  Finally, "the agent has finished" became its own event, `session.turn_ended`,
+  which fires only once MindFlock has **watched that agent work**, seen it stay
+  idle for 45 seconds, and confirmed nothing is queued to wake it. Once per
+  cycle of real work, however long the session then sits there. A turn the
+  usage cap cut short does not count — it did not finish, so the evidence is
+  dropped rather than left armed to claim "done" the moment the banner scrolls
+  off the pane.
+
+  Everything that has to stay fast stayed fast. **Needs your input** and **ran
+  out of usage** still fire on the instant signal — those are "come here now",
+  and a dwell on them would be a bug of its own. The chip still flips the moment
+  the state does. What changed is only which of those moments is worth
+  interrupting you for.
+
+  Two things fixed themselves on the way. The bell's own feed had no rule and no
+  rate limit at all, so it logged "finished — now idle" even for people who had
+  never turned the notification on; it now follows the same rule as every other
+  channel. And the sidebar's **"idle 25m with unfinished work — possibly stuck"**
+  warning turns out never to have appeared once: it reads a timestamp the app
+  had never written under that name. It works now — and, on its first outing,
+  it means what it says: a *committed* branch is finished work waiting for a
+  push, not a stuck session, so only uncommitted output nobody is touching
+  earns the row.
+
+- **A "ran out of usage" push no longer swallows a "needs your input" push.**
+  Both channels collapsed repeat notifications per *(session, event)* for five
+  seconds, and three different rules ride the same activity event — so an agent
+  that hit its usage cap and then asked a question inside that window sent one
+  alert, not two, and it was the less actionable one. Worse in the browser: that
+  same key is the notification's `tag`, which Windows and macOS treat as
+  "replace the one already on screen", so a popup you were still reading was
+  overwritten. Both are keyed by **rule** now, so each rule speaks for itself.
+
+- **The break clock no longer counts the hours you were not here.** A deadline
+  is wall-clock, so on its own it kept running through a closed window, a
+  shut-down machine and a slept laptop — and whoever opened MindFlock in the
+  morning was met immediately by the break card, its away-clock already at
+  nine hours and still climbing. Time away from the app is time away from the
+  desk, which is the break itself.
+
+  The app now stamps a heartbeat while it is running, and a gap of more than
+  five minutes starts the interval over rather than resuming it: on opening, and
+  also mid-run, which is the only thing that notices a machine that slept with
+  the window open — that case takes the stale card down with it. **Opening the
+  app starts the countdown**, whatever yesterday left behind. A refresh still
+  cannot dodge a break: the two are told apart by navigation type, so every
+  reload path (F5, the palette, the reload every tab does when the server
+  restarts, the API client's reload on a lost session) keeps its deadline, while
+  a shell launch or a new tab is an open. The five-minute tolerance is wide
+  because a hidden tab's timer is throttled to about one tick a minute, which
+  must not read as an absence.
+
+- **Windows dev builds head their notifications with a name.** A toast is
+  labelled with the display name of the Start-menu shortcut registered for the
+  app id that raised it. The prod app gets one from its installer; the isolated
+  dev shell has its own app id and no installer, so Windows printed the raw
+  `ai.mindflock.desktop.dev` across the top of every toast. A dev run now writes
+  that shortcut itself — `MindFlock-dev.lnk`, rewritten only when missing or
+  stale, best-effort — and the toasts read **MindFlock-dev**. It doubles as a
+  working launcher, so it is also the thing to pin to the taskbar. Prod is
+  untouched. Development-facing only; see `electron/README.md` and
+  [docs/development.md](docs/development.md).
+
 ## [0.2.0] - 2026-08-25
 
 ### Added
@@ -75,7 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whose description is the sentence it configures — *Reminder to take a break
   every `[N]` minutes*, with N editable in place (5–480, default 60). When it
   fires, a card asks you to get up, with the murmuration from mindflock.ai flying
-  over your actual grid. **Snooze 5 min** pushes it back; **Resumed work** (or
+  over your actual grid. **Snooze 5 min** pushes it back; **Resume Working** (or
   Escape) restarts the clock. Off by default. The countdown is wall-clock and
   survives a reload — a refresh is not a way to dodge a break — while changing
   the interval re-arms it from now.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,10 @@ a feature race; those two change what your day looks like:
 - **The whole git loop is guided.** Every session carries a one-click
   commit → push → PR → merge action bar and live workflow-stage badges, so you
   drive the change home without leaving the app. The push is plain `git push`
-  over the remote your repo already has — SSH or HTTPS, your choice.
+  over the remote your repo already has — SSH or HTTPS, your choice. When you
+  want to keep working on a branch the ladder considers finished, **↺** puts the
+  window back to idle so it stops asking — nothing is undone, and it clears
+  itself the moment you commit again.
 - **Provider-agnostic by design.** A coding agent in MindFlock is just a TOML
   file — binary, launch args, prompt seeding, activity-detection hooks, model
   pricing — so it drives *any* CLI (Claude Code, Codex, Antigravity, aider,
@@ -683,6 +686,13 @@ feeds:
 - **Phone push via [ntfy](https://ntfy.sh)** — off until you turn it on. The
   *server* publishes to a topic your phone subscribes to, so an alert reaches
   you with MindFlock closed and no tab anywhere.
+
+The quietest of the opt-ins is **"a session finishes its work"**, and it means
+it. It does not fire when the chip goes grey — a coding CLI reports a turn ended
+at the end of *every* reply, so that would buzz once per exchange. MindFlock
+sends it only once it has watched that agent actually work, seen it stay idle
+for 45 seconds since, and confirmed nothing is queued to wake it back up: once
+per stretch of real work, however long the session then sits there.
 
 To set it up: install the free ntfy app, then in Settings → Notifications →
 **Phone push (ntfy)** hit **Generate** for a random topic, scan the QR into the

--- a/backend/web/addons/notify.py
+++ b/backend/web/addons/notify.py
@@ -131,15 +131,29 @@ NOTIFY_RULES: List[dict] = [
         "tags": ["arrows_counterclockwise"],
     },
     {
-        # Opt-in (noisy): fires whenever a session finishes its turn and goes
-        # idle — useful for babysitting a long autonomous run.
+        # Opt-in: a session's work really is over — useful for babysitting a
+        # long autonomous run.
+        #
+        # Keyed on ``session.turn_ended``, NOT on ``session.activity_changed``
+        # with ``new == "idle"``. That was the same rule this used to be, and it
+        # fired on a chip colour: at the end of every assistant turn (ten per
+        # conversation), on a session that had merely booted to a bare prompt,
+        # between two prompts of a draining queue, and on every re-opened window
+        # — because the CLI's Stop hook says a turn ENDED and says nothing about
+        # whether one ever began. ``turn_ended`` asserts the three things this
+        # sentence has always claimed: the agent was observed working, it has
+        # stayed idle since, and nothing is queued to wake it up.
+        #
+        # The id is unchanged on purpose: an existing opt-in in
+        # settings.notifications.enabled_rules carries straight over and simply
+        # gets quieter, with no migration.
         "id": "session_idle",
-        "label": "A session finishes and goes idle",
-        "event": "session.activity_changed",
+        "label": "A session finishes its work and stays idle",
+        "event": "session.turn_ended",
         "old": None,
-        "new": "idle",
-        "title": "{session} is idle",
-        "body": "The agent finished its turn and is waiting.",
+        "new": None,
+        "title": "{session} has finished",
+        "body": "The agent finished its turn and has been idle since, with nothing queued.",
         "default_enabled": False,
         "priority": 2,
         "tags": ["zzz"],
@@ -181,9 +195,16 @@ NOTIFY_RULES: List[dict] = [
 #: resolved ``enabled``) and the ntfy-only presentation hints.
 _INTERNAL_RULE_FIELDS = ("default_enabled", "priority", "tags")
 
-#: At most one push per (session, event) per this many seconds. Mirrors
-#: ``DEDUPE_MS`` in static/addons/notify.js so both channels collapse a flapping
-#: transition the same way.
+#: At most one push per (session, RULE) per this many seconds — the key is the
+#: rule id, not the event name, because three rules ride
+#: ``session.activity_changed`` and an event-keyed window lets whichever fires
+#: first swallow the others (a ``limit`` push eating a ``needs_input`` push,
+#: both default-on). ``DEDUPE_MS`` in static/addons/notify.js keys the same way,
+#: so both channels collapse a flapping transition identically.
+#:
+#: This is a FLAP collapser and nothing more. It is meaningless at turn cadence,
+#: which is why "the agent has finished" is deduped by spending its evidence
+#: instead — see ``server._note_turn_boundary``.
 _DEDUPE_SECONDS = 5.0
 
 

--- a/backend/web/core/agent_state.py
+++ b/backend/web/core/agent_state.py
@@ -114,10 +114,25 @@ def _session_find_prompt(inst, prefix: str) -> Optional[str]:
 
 
 # Layered activity detection (roadmap A1). Per-title rolling record of the
-# agent pane: {hash, changed_epoch, state, streak}. Authoritative signals (exit
-# marker, foreground process, provider hook marker) are consulted first; the
-# pane-hash fallback is hardened with noise stripping + asymmetric hysteresis
-# so a single changed frame can't flip the badge every poll.
+# agent pane. Authoritative signals (exit marker, foreground process, provider
+# hook marker) are consulted first; the pane-hash fallback is hardened with
+# noise stripping + asymmetric hysteresis so a single changed frame can't flip
+# the badge every poll.
+#
+# The record carries two independent groups of keys:
+#
+# * **pane-inspection bookkeeping**, written only by :func:`_pane_hash_activity`
+#   and meaningful only to it — ``hash`` / ``changed`` / ``state`` / ``streak``
+#   / ``size`` / ``cpu`` / ``cpu_at`` / ``busy_at`` / ``tokens``. ``state`` is
+#   *that layer's* running verdict, not the session's.
+# * **layer-wide provenance**, written by :func:`_verdict` on EVERY return path
+#   of :func:`_agent_activity` — ``created`` / ``reported`` / ``state_since`` /
+#   ``worked_at``. Before these existed only the pane path wrote anything, so a
+#   session reporting through its CLI's hooks (the common Claude case) left no
+#   trail at all: ``activity_since`` was dead for exactly those sessions, and
+#   nothing downstream could tell "this agent worked and then stopped" from
+#   "this agent has never done anything", which is precisely the distinction a
+#   notification needs (see ``server._note_turn_boundary``).
 _ACTIVITY_CACHE: Dict[str, dict] = {}
 _ACTIVITY_IDLE_AFTER = (
     8.0  # static-pane seconds before working -> idle (2x the UI's 4s poll)
@@ -141,6 +156,173 @@ _LIMIT_PROBE: Dict[str, dict] = {}  # title -> {"at": epoch, "limit": bool}
 # often per session — discovery stats on-disk stores and the id changes rarely.
 _THREAD_RECORD_EVERY_S = 20.0
 _THREAD_RECORD_AT: dict = {}
+
+
+def _activity_record(title: str, created) -> dict:
+    """The per-title rolling record, reset when the tmux INCARNATION changes.
+
+    This used to be created ad hoc inside :func:`_pane_hash_activity` and
+    POPPED on every ``offline`` poll. Both halves were wrong.
+
+    Popping meant a session whose tmux merely hiccuped — or one the user closed
+    and re-opened, which relaunches the agent through
+    ``agent_sessions._ensure_agent_session`` — came back with no hysteresis, no
+    CPU baseline and no history, straight into the pane layer's "first sighting"
+    branch. It also defeated the resize rebaseline below, which exists precisely
+    so that *clicking a tab must not read as activity*: that guard can only
+    protect a record that still exists.
+
+    But a record must not survive a RELAUNCH either. ``worked_at`` asserts "this
+    agent process was observed doing work", and ``tmux new-session`` starts a
+    different process; carrying the old answer over is how a freshly rebooted
+    session inherits the dead run's history. tmux's own ``session_created`` is
+    the incarnation id — the same fact :func:`_agent_exited` already uses to
+    reject an exit marker left by a previous session of the same name.
+
+    An EXISTING record with no ``created`` yet (a hand-seeded one in tests, or
+    the pane layer's own re-fetch) simply adopts the stamp: adopting is not a
+    reset. A record being MINTED without one is never stored at all — see below.
+    """
+    rec = _ACTIVITY_CACHE.get(title)
+    try:
+        stamp = None if created is None else float(created)
+    except (TypeError, ValueError):
+        stamp = None
+    if rec is None:
+        rec = {
+            "created": stamp,
+            "reported": None,
+            "state_since": 0.0,
+            "worked_at": None,
+        }
+        if stamp is not None:
+            _ACTIVITY_CACHE[title] = rec
+        # A brand-new record with NO incarnation stamp is never kept. That
+        # happens when `tmux display-message` fails while `has-session`
+        # succeeded, so `_pane_meta` answers all-None: the poll can still
+        # capture a pane and reach a verdict, but there is no identity to file
+        # it under. Storing it would create a record that the next successful
+        # stamp has to either adopt — smuggling a dead run's work evidence into
+        # a new incarnation through the one door this function exists to shut —
+        # or discard, which is what a throwaway does anyway, one poll earlier
+        # and without the ambiguity. Losing a poll's memory fails quiet: no
+        # evidence, so nothing can be announced.
+        return rec
+    if stamp is None:
+        rec.setdefault("reported", None)
+        rec.setdefault("state_since", 0.0)
+        rec.setdefault("worked_at", None)
+        return rec
+    if rec.get("created") is None:
+        # An EXISTING record with no stamp is a hand-seeded one (tests, and
+        # `_pane_hash_activity`'s own re-fetch). Adopting is not a reset.
+        rec.setdefault("reported", None)
+        rec.setdefault("state_since", 0.0)
+        rec.setdefault("worked_at", None)
+        rec["created"] = stamp
+        return rec
+    if rec["created"] != stamp:
+        # A new tmux session under the same name: every observation in the
+        # record describes a process that no longer exists. The limit probe
+        # goes with it — its verdict is cached for _LIMIT_RECHECK_S, and a
+        # window reopened inside that span would otherwise report a fresh
+        # process as usage-limited (and 'usage_limit' is a default-ON rule).
+        rec.clear()
+        rec.update(
+            {"created": stamp, "reported": None, "state_since": 0.0, "worked_at": None}
+        )
+        _LIMIT_PROBE.pop(title, None)
+    return rec
+
+
+def _verdict(rec: Optional[dict], value: str, now: float) -> str:
+    """Record ``value`` as this session's reading and return it.
+
+    THE SINGLE EXIT POINT for every layer of :func:`_agent_activity`, so
+    ``state_since`` and ``worked_at`` mean the same thing whether the answer
+    came from the exit marker, a hook marker, the process tree or the pane.
+
+    ``worked_at`` is stamped only by ``working`` — never by ``clarify``, and
+    never by ``idle``. It is the evidence a notification needs before it may
+    claim a turn ENDED, so it has to mean "we watched this agent work", not
+    "something happened on this pane". A trust/MCP gate on a brand-new session
+    reports ``clarify`` before the agent has been handed anything to do; a
+    session that boots to a bare prompt reports ``idle`` forever. Neither is a
+    turn, and neither may arm one.
+
+    ``limit`` actively DROPS it. A turn the account's cap cut short is not a
+    turn that finished, and the reading only says ``limit`` while the banner is
+    on the pane — press a key, or let the throttled re-check expire against a
+    redrawn prompt, and the session reads plain idle again with the cut-short
+    turn's evidence still armed, ready to report "has finished" on work that
+    was abandoned mid-thought. Autopilot drops its own idle dwell on a limit for
+    exactly this reason. A resume re-earns the evidence on the next ``working``.
+    """
+    if rec is None:
+        return value
+    if rec.get("reported") != value:
+        rec["reported"] = value
+        rec["state_since"] = now
+    if value == "working":
+        rec["worked_at"] = now
+    elif value == "limit":
+        rec["worked_at"] = None
+    return value
+
+
+def worked_at(title: str) -> Optional[float]:
+    """Epoch this session was last OBSERVED working in its current tmux
+    incarnation, or None — the provenance behind ``session.turn_ended``.
+
+    None means one of three things, and all three are "there is no turn to
+    announce": the session has never been seen working, its tmux session was
+    relaunched since (:func:`_activity_record` resets the record), or a turn
+    end has already been announced for the work we saw (:func:`claim_work`).
+
+    A read, for gating. The announcement itself must go through
+    :func:`claim_work`, which is the same question asked atomically.
+    """
+    val = (_ACTIVITY_CACHE.get(title) or {}).get("worked_at")
+    return float(val) if isinstance(val, (int, float)) else None
+
+
+#: Guards the read-and-clear in :func:`claim_work`. Nothing else needs it —
+#: every other access is a single GIL-atomic dict operation.
+_WORK_CLAIM_LOCK = threading.Lock()
+
+
+def claim_work(title: str) -> Optional[float]:
+    """Atomically SPEND this session's work evidence, or None if it is gone.
+
+    One turn-end announcement per observed work cycle; the next ``working``
+    reading re-arms it. Atomic because two unsynchronised 4s tickers
+    (``_instances_tick`` and ``_tick_state_changes``) plus an on-demand
+    ``_republish_session`` all run this check, and a plain read-then-clear lets
+    two of them satisfy the dwell in the same instant and announce twice — which
+    the per-channel dedupe would hide on the phone and not in the bell, whose
+    rows are keyed by event seq. Winning the claim IS the permission to emit.
+    """
+    with _WORK_CLAIM_LOCK:
+        rec = _ACTIVITY_CACHE.get(title)
+        val = (rec or {}).get("worked_at")
+        if not isinstance(val, (int, float)):
+            return None
+        rec["worked_at"] = None
+        return float(val)
+
+
+def state_since(title: str) -> float:
+    """Epoch the session's REPORTED activity last changed value, or 0.0.
+
+    Feeds ``/api/instances``' ``activity_since`` (attention ordering and the
+    wedged-session watchdog). Distinct from the notification layer's own
+    ``activity_at``, which stamps when the *announced* value was adopted —
+    the watchdog wants the pane's truth, the notification wants what the user
+    was told, and neither may gate the other.
+    """
+    val = (_ACTIVITY_CACHE.get(title) or {}).get("state_since")
+    return float(val) if isinstance(val, (int, float)) else 0.0
+
 
 # Last live branch observed per session title, so the stage pill can follow a
 # branch switch inside one workspace (in-place sessions especially): on drift,
@@ -568,6 +750,49 @@ def _limit_on_pane(srv, name: str, provider) -> bool:
         return False
 
 
+def _marker_is_current(provider, name: str, created) -> bool:
+    """Whether the CLI's hook marker was written by the tmux session that is
+    running RIGHT NOW.
+
+    A marker is otherwise trusted on AGE alone — an ``idle`` one at any age (a
+    Stop hook from two hours ago on a still-running CLI is genuinely idle), a
+    ``working``/``clarify`` one inside :data:`_MARKER_TRUST_WINDOW_S`. Both
+    properties have to survive. What must not survive is a marker from a
+    PREVIOUS incarnation. The marker file is keyed by tmux session name, nothing
+    deletes it (``_ensure_agent_session`` clears the exit marker and the thread
+    marker, never this one), no provider maps a session-start event to a state,
+    and it only expires after six hours. So a window closed and re-opened
+    reported the dead run's state for as long as its age allowed: an ``idle``
+    announced a turn that had ended before the session existed, and a
+    ``working`` — from a session killed mid-turn — painted a fresh CLI as
+    running for up to 45s and stamped it with work evidence it had not earned.
+
+    Same guard, same reason, as :func:`_agent_exited`'s mtime-vs-created check.
+    Unknowable inputs answer True: without a creation stamp or a marker age
+    there is nothing to compare, and the long-standing behaviour is to trust the
+    CLI. Claude's live ``agents --json`` path reports age ``0.0``, so it always
+    passes — it is real-time by construction.
+
+    The clock is sampled HERE rather than taken from the caller: the caller's
+    ``now`` predates the probes between it and this call (a pane capture, a
+    ``claude agents --json`` shell-out), and subtracting a freshly-measured age
+    from a stale ``now`` places the write earlier than it happened — rejecting,
+    of all things, the first marker of a genuinely fresh session.
+    """
+    if created is None:
+        return True
+    try:
+        age = provider.activity_state_age(name)
+    except Exception:  # noqa: BLE001 — an unreadable age is not evidence
+        return True
+    if age is None:
+        return True
+    try:
+        return (time.time() - float(age)) >= float(created)
+    except (TypeError, ValueError):
+        return True
+
+
 def _idle_or_limit(srv, title: str, name: str, provider) -> str:
     """``"limit"`` when a session that LOOKS idle is really parked on a
     usage-limit screen, else ``"idle"``.
@@ -599,8 +824,9 @@ def _pane_hash_activity(
     Reached only once the authoritative signals (exit marker, hook marker,
     process tree) are inconclusive. Captures the pane and decides:
 
-    * First sighting of ``title`` -> assume 'working' (a fresh agent usually
-      is) and seed the rolling record; it settles once CPU/pane go quiet.
+    * First sighting of this PANE -> classify from what one frame can prove
+      (limit banner / interrupt hint) and otherwise report 'idle'; never a
+      guess. See the seeding block for why.
     * A pane RESIZE (a web tab attaching reflows tmux) rebaselines the hash /
       CPU / token counter and keeps the PRIOR state — clicking a tab must not
       read as activity.
@@ -637,25 +863,58 @@ def _pane_hash_activity(
     h = _normalized_pane_hash(text)
     now = time.time()
     cpu_now = srv._pane_cpu_jiffies(pane_pid)
-    rec = _ACTIVITY_CACHE.get(title)
-    if rec is None:
-        # First sighting: assume working (a fresh agent usually is); it
-        # settles to idle once CPU (or the pane) stays quiet past the
-        # threshold.
-        _ACTIVITY_CACHE[title] = {
-            "hash": h,
-            "changed": now,
-            "state": "working",
-            "streak": 0,
-            "size": pane_size,
-            "cpu": cpu_now,
-            "cpu_at": now,
-            "busy_at": now,
-            # Baseline the turn-token counter now so the NEXT poll can already
-            # tell a climb (work) from a flat counter (idle).
-            "tokens": _parse_progress_tokens(text, provider),
-        }
-        return "working"
+    rec = _activity_record(title, None)
+    if rec.get("hash") is None:
+        # FIRST SIGHTING OF THIS PANE — classify from the evidence one frame
+        # can actually carry, and never from optimism.
+        #
+        # This used to seed 'working' outright ("a fresh agent usually is"),
+        # holding the pane text and the CPU counter and consulting neither.
+        # That guess was the phantom behind "I click an offline session and it
+        # goes running for a moment and then idle": the record is rebuilt from
+        # scratch whenever a session's tmux comes back (clicking a pane
+        # relaunches the agent through `_ensure_agent_session`), so the guess
+        # fired on a CLI that had been handed nothing to do, held the badge at
+        # 'running' for _ACTIVITY_IDLE_AFTER seconds, and then decayed — a
+        # working->idle pair the agent never earned, and a "finished" the user
+        # had no reason to be told about.
+        #
+        # Two of the four signals need two samples (CPU rate, a climbing token
+        # counter) and so cannot speak here. The other two are single-frame
+        # facts and do: a usage-limit banner, and the provider's interrupt hint
+        # ("esc to interrupt") which means a turn is live right now. A pane
+        # showing neither is, on all available evidence, parked — so we say so.
+        # 'clarify' is deliberately NOT attempted: the established path only
+        # matches a waiting prompt on a STABLE pane, and one frame cannot
+        # establish stability. The next poll catches it 4s later.
+        tokens = _parse_progress_tokens(text, provider)
+        wpats = provider.working_pane_patterns()
+        if is_limit_screen(text):
+            state = "limit"
+        elif wpats and any(re.search(p, text) for p in wpats):
+            state = "working"
+        else:
+            state = "idle"
+        rec.update(
+            {
+                "hash": h,
+                "changed": now,
+                "state": state,
+                "streak": 0,
+                "size": pane_size,
+                "cpu": cpu_now,
+                "cpu_at": now,
+                # Only a session we have PROOF is busy gets an idle-settle
+                # clock; absent it, `busy_at` stays unset and the hysteresis
+                # below falls back to `changed`, which is now — so a pane that
+                # stays quiet simply stays idle.
+                "busy_at": now if state == "working" else None,
+                # Baseline the turn-token counter now so the NEXT poll can
+                # already tell a climb (work) from a flat counter (idle).
+                "tokens": tokens,
+            }
+        )
+        return state
     # A pane RESIZE (opening/focusing the session in the web UI attaches a
     # terminal, which resizes tmux and reflows the pane) changes the captured
     # text without the agent doing anything. Rebaseline hash + CPU and DON'T
@@ -736,10 +995,20 @@ def _pane_hash_activity(
             rec["streak"] = 0
             rec["state"] = "working"
             return "working"
+        # NO pane-change promotion here, deliberately. On this branch CPU is the
+        # authoritative signal and a changing pane is noise: an idle Claude
+        # redraws its spinner and token counter every frame at ~8 jiffies/s, so
+        # promoting on "the text moved" is precisely the bug the CPU probe was
+        # added to kill. A provider whose work is invisible to both CPU and the
+        # status line needs a ``working_patterns`` regex (Settings → Providers),
+        # not a looser rule here.
         # Otherwise keep the prior state through brief lulls (streaming
         # pauses / model round-trips), then settle to idle after the same
         # hysteresis window — regardless of cosmetic pane churn.
-        busy_at = rec.get("busy_at", rec.get("changed", now))
+        # ``or`` rather than a dict default: a pane first seen parked stores
+        # busy_at=None (no proof of work to run a clock from), and the honest
+        # fallback there is when the record itself started.
+        busy_at = rec.get("busy_at") or rec.get("changed") or now
         if now - busy_at >= _ACTIVITY_IDLE_AFTER:
             rec["streak"] = 0
             rec["state"] = "idle"
@@ -791,9 +1060,10 @@ def _agent_activity(inst, title: str) -> str:
        Code Stop/UserPromptSubmit/Notification hooks, A2) -> returned as-is
        (above the shell heuristic on purpose: the CLI's own report outvotes
        what the pane's foreground command looks like). An ``idle`` marker is
-       first re-checked against the pane for a usage-limit screen: the hook
-       fires identically whether the turn ENDED or was CUT OFF by the account's
-       limit (:func:`_idle_or_limit`);
+       first checked for belonging to the CURRENT tmux incarnation
+       (:func:`_marker_is_current`) and then re-checked against the pane for a
+       usage-limit screen: the hook fires identically whether the turn ENDED or
+       was CUT OFF by the account's limit (:func:`_idle_or_limit`);
     2. process tree — a bare shell holds the pane AND no non-shell descendant
        is alive -> the agent isn't running -> idle. A wrapper shell (the
        provisioned launcher script) with a live ``claude`` child falls through
@@ -811,6 +1081,16 @@ def _agent_activity(inst, title: str) -> str:
        Either one means the turn is still live even at ~0 CPU — the fix for
        extended thinking (work runs server-side, so the local process blocks on
        a network read and looks exactly like an idle prompt to CPU alone).
+
+    Every layer returns through :func:`_verdict`, which stamps the session's
+    rolling record with what was reported and when — and, for ``working``, that
+    the agent was OBSERVED doing something in this tmux incarnation. That trail
+    is what lets the notification layer distinguish a turn that ended from a
+    session that has simply never run one; see ``server._note_turn_boundary``.
+    The two ``offline`` returns that precede :func:`_pane_meta` (not started /
+    paused, and no tmux session) record nothing on purpose: there is no
+    incarnation to attribute a reading to, and every consumer of
+    ``activity_since`` already gates on a live state.
     """
     try:
         srv = _server()
@@ -827,30 +1107,48 @@ def _agent_activity(inst, title: str) -> str:
             == 0
         )
         if not exists:
-            _ACTIVITY_CACHE.pop(title, None)
+            # NOT a cache pop. The record used to be dropped here on every
+            # offline poll, which guaranteed that the moment the session came
+            # back the pane layer had no history and fell into its
+            # first-sighting branch — the phantom "running" flash. A record
+            # belongs to a tmux INCARNATION, and `_activity_record` retires it
+            # against tmux's own `session_created` when a genuinely new one
+            # appears; a dead session simply has no reading to report.
             return "offline"
         fg, created, pane_pid, pane_size = srv._pane_meta(name)
+        now = time.time()
+        rec = _activity_record(title, created)
         # Layer -1 (F2 safety net, startup only): auto-answer a trust/MCP gate
         # on a freshly-created session BEFORE any hook-marker short-circuit
         # below, so a seeded (PR/ticket) prompt can't sit parked behind it.
         if _startup_trust_gate_clarify(srv, inst, title, name, created):
-            return "clarify"
+            return _verdict(rec, "clarify", now)
         # Layer 0: the agent command ENDED (exit marker written this session).
         if srv._agent_exited(name, created):
-            return "idle"
+            return _verdict(rec, "idle", now)
         # Layer 1: the CLI's own report (Claude Code hook marker).
         provider = providers.resolve(getattr(inst, "Program", "") or "")
         # Bind this window to its own conversation id while it runs (throttled)
         # so a per-window `resume <id>` after a crash targets the right thread.
         _maybe_record_thread(provider, inst, name, created)
         marked = provider.activity_state(name)
+        # A marker written before this tmux session existed describes a process
+        # that no longer does — WHATEVER state it names. Discarded once, here,
+        # rather than per-branch: a stale ``working`` is every bit as wrong as a
+        # stale ``idle``, and worse in one way, because it is the reading that
+        # stamps the work evidence a turn-end announcement is later built on.
+        # (Relaunching clears the exit marker and the thread marker and not this
+        # one; see :func:`_marker_is_current`.)
+        if marked and not _marker_is_current(provider, name, created):
+            marked = None
         if marked == "idle":
-            # Stop hook fired -> the turn definitively ended; trust at any age.
+            # Stop hook fired -> the turn definitively ended; trust at any age
+            # WITHIN THIS INCARNATION (see :func:`_marker_is_current`).
             # WHY it ended is another question: a turn the account's usage limit
             # cut short fires the same hook as a completed one, so the pane is
             # checked (throttled) before this idle is passed on. See
             # :func:`_idle_or_limit`.
-            return _idle_or_limit(srv, title, name, provider)
+            return _verdict(rec, _idle_or_limit(srv, title, name, provider), now)
         if marked in ("working", "clarify"):
             # working/clarify markers only refresh on hook events (tool call,
             # prompt submit, notification). A long thinking/generating stretch
@@ -869,8 +1167,8 @@ def _agent_activity(inst, title: str) -> str:
                 # treats it as a human gate and the queue stalls behind a menu
                 # that never clears on its own, even after the window reopens.
                 if marked == "clarify" and _limit_on_pane(srv, name, provider):
-                    return "limit"
-                return marked
+                    return _verdict(rec, "limit", now)
+                return _verdict(rec, marked, now)
         # Layer 2: a bare shell holds the pane AND nothing but shells lives
         # under it -> the agent isn't running, whatever the pane looks like.
         if (
@@ -878,13 +1176,15 @@ def _agent_activity(inst, title: str) -> str:
             and fg.lower() in _BARE_SHELLS
             and not srv._pane_has_agent_process(pane_pid)
         ):
-            return "idle"
+            return _verdict(rec, "idle", now)
         # Layers 3-4: live-pane inspection (CPU rate + status-line proof under
         # asymmetric hysteresis, with a pane-hash fallback where /proc CPU is
         # unavailable). Kept in its own helper so the layered dispatch above
         # reads as a sequence of authoritative-first probes.
-        return _pane_hash_activity(
-            srv, inst, title, name, provider, pane_pid, pane_size
+        return _verdict(
+            rec,
+            _pane_hash_activity(srv, inst, title, name, provider, pane_pid, pane_size),
+            now,
         )
     except Exception:  # noqa: BLE001
         return "offline"

--- a/backend/web/core/events.py
+++ b/backend/web/core/events.py
@@ -73,6 +73,17 @@ EVENT_NAMES = (
     # Running OUT needs no event of its own: that is
     # ``session.activity_changed`` with ``new == "limit"``.
     "session.usage_restored",
+    # A session's TURN genuinely ended: it was observed working in its current
+    # tmux incarnation, has been idle continuously since (server.
+    # _TURN_END_DWELL_S), and has nothing queued to wake it back up
+    # (data: {"idle_for": float}). Emitted once per cycle of observed work.
+    #
+    # Not the same fact as ``session.activity_changed`` with ``new == "idle"``,
+    # which is a chip colour: that fires at the end of EVERY assistant turn (a
+    # ten-turn conversation fires it ten times), on /clear, on a session that
+    # merely booted to a bare prompt, and on any reading that settles to idle
+    # out of offline. This is the one that is worth telling a human about.
+    "session.turn_ended",
     # Verify (test plans): a session's branch genuinely REACHED origin — emitted
     # by the live_stage push watcher at the instant the remote branch head equals
     # the local one (data: {"branch": str, "sha": str, "wt": str}). This is not

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -122,6 +122,7 @@ from backend.web.core import ntfy as _ntfy
 from backend.web.core import test_plans as _test_plans
 from backend.web.core import window_refresh as _window_refresh
 from backend.web.core import worktree_setup as _wt_setup
+from backend.web.core import agent_state as _agent_state
 from backend.web.core.agent_state import (
     _ACTIVITY_CACHE,
     _ACTIVITY_CONFIRM_POLLS,
@@ -779,6 +780,15 @@ def _emit_state_changes(title: str, status: str, activity: str, stage: str) -> N
                 snap["pending_activity"] = pending
             # else: settled — snap keeps the new activity and the diff below
             # emits the transition.
+        # When the ANNOUNCED activity was adopted. Deliberately not
+        # agent_state's ``state_since`` (when the raw reading changed): the
+        # dwell below must measure how long we have been telling people this,
+        # and the wedged-session watchdog must measure what the pane is
+        # actually doing. Neither may gate the other.
+        if prev is None or snap["activity"] != prev.get("activity"):
+            snap["activity_at"] = now
+        else:
+            snap["activity_at"] = prev.get("activity_at", now)
         _EVENT_SNAPSHOT[title] = snap
     if prev is None:
         return
@@ -805,6 +815,115 @@ def _emit_state_changes(title: str, status: str, activity: str, stage: str) -> N
     # this fires on a stage TRANSITION, not on every tick.
     if prev.get("stage") != stage and stage == "pushed":
         _ensure_test_plan(title)
+    # Turn boundaries are decided on every pass, not only on a transition: the
+    # dwell below is a duration, and the tick that satisfies it is by
+    # definition one where nothing changed.
+    _note_turn_boundary(title, snap, now)
+
+
+# ---- "a turn ended" vs "the activity value is idle" ----------------------- #
+# ``session.activity_changed new="idle"`` is a UI fact: paint the chip grey. It
+# fires at the end of EVERY assistant turn (claude.py's _HOOK_EVENT_STATES maps
+# both Stop and SessionEnd to idle), on /clear, on a session that merely booted
+# to a bare prompt, and on any reading that settles to idle out of offline. It
+# is the wrong fact to interrupt a human with — a ten-turn conversation
+# produced ten "finished" alerts, and re-opening a closed window produced one
+# for a session that had run nothing at all.
+#
+# ``session.turn_ended`` is the notification-grade fact, and it asserts three
+# things at once: this agent was OBSERVED working in this tmux incarnation, it
+# has been continuously idle since, and nothing is queued to wake it back up.
+# Every "the agent is done" channel keys on THIS; nothing keys on the raw idle.
+#
+# Why 45s, given the whole pipeline already debounces:
+#   * `_ACTIVITY_SETTLE_SECONDS` (3.0) is a FLICKER filter — it can only
+#     suppress a reading that reverts, and a session parked at its prompt never
+#     reverts. It is structurally incapable of answering this question.
+#   * It must exceed the inter-turn gap of an interactive conversation. A human
+#     reading a long answer and typing a follow-up is 10-30s, and the Stop hook
+#     fires in that gap every single time.
+#   * It must exceed the prompt queue's whole send path — `_QUEUE_IDLE_SETTLE`
+#     (12.0) + a 5s drain pass + `_QUEUE_SEND_COOLDOWN` (8.0) — so an
+#     unattended queued run never announces "finished" between two prompts. The
+#     queue check below makes that exact rather than a race; the number is the
+#     belt to its braces.
+#   * It must exceed autopilot's own idle settle (autopilot.IDLE_SETTLE_S, 30.0)
+#     so the order is always "the chain decided the agent was done, THEN we said
+#     so" — never the reverse.
+#   * It must be large against the 4s tick so two unsynchronised tickers plus an
+#     on-demand `_republish_session` shift the answer by ~±9%, not ±25%.
+# The cost of being wrong is 45s of latency on a "your agent is done" push. The
+# alternative was a buzz per turn.
+_TURN_END_DWELL_S = 45.0
+
+
+def _note_turn_boundary(title: str, snap: dict, now: float) -> None:
+    """Emit ``session.turn_ended`` once per observed work cycle. Never raises.
+
+    Called from the tail of :func:`_emit_state_changes` with the settled
+    snapshot, so it sees exactly the activity the rest of the app was told
+    about. Five gates, in cheapest-first order:
+
+    1. **The settled activity is idle.** ``limit`` is deliberately excluded — a
+       turn the usage cap cut short is not a turn that ended, and the
+       default-on ``usage_limit`` rule already covers it. So is ``offline``.
+    2. **Boot quiet**, for the same reason the diff events observe it: a
+       restart rediscovers every parked session and none of that is news.
+    3. **Provenance.** ``agent_state.worked_at`` is None unless this agent was
+       seen working in its CURRENT tmux incarnation. This is the whole
+       offline-click fix: re-opening a window relaunches its CLI, and the fresh
+       incarnation has no work behind it, so no amount of idling produces a
+       "finished".
+    4. **Dwell**, asked of both clocks: `_TURN_END_DWELL_S` since the announced
+       activity became idle, AND since the agent was last seen working. They can
+       disagree, and the second is what the sentence actually claims.
+    5. **Nothing queued.** An exact check, not a race against the drain's own
+       `_QUEUE_IDLE_SETTLE`: a run with prompts still to feed has not finished.
+
+    Emitting SPENDS the evidence (``agent_state.claim_work``). That, not a
+    seconds window, is the real dedupe: one announcement per cycle of observed
+    work, however long the session then sits there. The next ``working`` reading
+    re-arms it. The claim is atomic because two 4s tickers and an on-demand
+    republish all run this, and winning the claim is what grants the right to
+    speak.
+    """
+    try:
+        if snap.get("activity") != "idle" or _in_boot_quiet():
+            return
+        worked = _agent_state.worked_at(title)
+        if worked is None:
+            return
+        idle_for = now - float(snap.get("activity_at") or now)
+        if idle_for < _TURN_END_DWELL_S:
+            return
+        # The same dwell against the EVIDENCE's own clock. The two can disagree:
+        # ``activity_at`` moves only when a settled reading reaches this
+        # function, while ``worked_at`` is stamped by every ``_agent_activity``
+        # call — including the deliberately UNCACHED ones the prompt-queue drain
+        # and the autopilot driver make on their own 5s cadences, which never
+        # feed a snapshot. So a session that has been idle for ten minutes and
+        # then picks up a queued prompt can have fresh work evidence while the
+        # tickers are still serving "idle" out of the 2.5s probe memo, and the
+        # announcement would land at the moment the agent STARTED a turn. Asking
+        # both clocks closes the whole class — memo skew, snapshot lag, and the
+        # two uncached probes — with one comparison. (Epoch here, monotonic
+        # above; each is compared only against its own kind.)
+        if time.time() - float(worked) < _TURN_END_DWELL_S:
+            return
+        if _prompt_queue.peek_next(title) is not None:
+            return
+        # Claiming the evidence is what grants permission to speak: two
+        # unsynchronised tickers can reach this line in the same instant, and
+        # only one of them can win the clear.
+        if _agent_state.claim_work(title) is None:
+            return
+        _events.BUS.emit(
+            "session.turn_ended",
+            session=title,
+            data={"idle_for": round(idle_for, 1)},
+        )
+    except Exception:  # noqa: BLE001 — a notification never breaks the tick
+        pass
 
 
 def _seed_event_snapshot(title: str) -> None:
@@ -928,16 +1047,56 @@ def _drop_failed_start(title: str, inst) -> bool:
 
 
 def _forget_probes(title: str) -> None:
-    """Drop every memoized probe result for one session (kill/delete paths),
-    so a session recreated under the same title starts from fresh probes —
-    and so the per-title rolling state doesn't accumulate dead entries for
-    the server's lifetime under session churn."""
+    """Drop the memoized probe RESULTS for one session, so the next read
+    recomputes instead of serving a value from before an action.
+
+    The freshness half of what used to be one function. Its callers are the
+    workflow verbs — commit, push, make-PR, merge, and autopilot's own commit —
+    which all want the same thing: "I just changed this session's git state,
+    don't hand anyone a 2.5s-old stage". None of them wants the session's
+    ROLLING STATE forgotten, and forgetting it was actively harmful: it wiped
+    the record's ``worked_at``, so a session that had genuinely been working
+    lost the evidence behind its turn-end announcement the moment you pressed
+    Commit. That lives in :func:`_forget_session_state` now, which only the
+    delete path calls.
+    """
     with _PROBE_CACHE_LOCK:
         for k in [k for k in _PROBE_CACHE if k[1] == title]:
             _PROBE_CACHE.pop(k, None)
-    for _d in (_ACTIVITY_CACHE, _LIMIT_PROBE, _THREAD_RECORD_AT, _TRUST_DISMISS_AT):
-        _d.pop(title, None)
     _forget_tokens(title)
+
+
+def _forget_session_state(title: str) -> None:
+    """Forget a session ENTIRELY — memoized results and rolling per-title state.
+
+    For the delete path only. Titles are reused (``untitled-2`` comes straight
+    back), so a namesake must not inherit the dead session's pane hash, CPU
+    baseline, limit verdict or work history; and without this the per-title
+    dicts accumulate dead entries for the life of the server under churn.
+    """
+    _forget_probes(title)
+    for _d in (_ACTIVITY_CACHE, _LIMIT_PROBE, _TRUST_DISMISS_AT):
+        _d.pop(title, None)
+    # Keyed by TMUX SESSION NAME, not by title (see agent_state._maybe_record_
+    # thread), so it needs the translation the others do not.
+    _THREAD_RECORD_AT.pop(tmux.to_mindflock_tmux_name(title), None)
+
+
+def _prune_session_state(live_titles) -> None:
+    """Drop per-title probe state for sessions that are no longer in the engine.
+
+    The backstop behind :func:`_forget_session_state`, for the removals that
+    never reach a route: a workspace deleted from Settings, and the tombstone
+    convergence that pops instances another MindFlock deleted. Without it those
+    dicts only ever grow, for the life of the process.
+    """
+    live = set(live_titles or ())
+    live_names = {tmux.to_mindflock_tmux_name(t) for t in live}
+    for _d in (_ACTIVITY_CACHE, _LIMIT_PROBE, _TRUST_DISMISS_AT):
+        for dead in [t for t in list(_d) if t not in live]:
+            _d.pop(dead, None)
+    for dead in [n for n in list(_THREAD_RECORD_AT) if n not in live_names]:
+        _THREAD_RECORD_AT.pop(dead, None)
 
 
 def _session_stage_cached(inst) -> dict:
@@ -1059,6 +1218,16 @@ _QUEUE_REBOOT_COOLDOWN = 30.0  # min seconds between reboots of a dead session
 # re-marks "working", would otherwise let the drain fire a queued prompt prematurely.
 # Requiring idle to hold this long absorbs that flicker while still resuming promptly.
 _QUEUE_IDLE_SETTLE = 12.0
+# After WE rebooted a dead agent, hold the queue this long regardless of what the
+# activity probe says. A CLI relaunching with a large `--continue` transcript can
+# spend twenty seconds on a quiet, I/O-bound start, and a quiet pane is exactly
+# what the classifier now reports as idle — correctly, since nothing on that
+# screen says work is happening. But typing into a CLI that has not drawn its
+# input box loses the prompt, and `armed` is cleared by the send, so the retry
+# only comes after _QUEUE_REARM_IDLE (five minutes). The old classifier hid this
+# behind a guess ("a pane I have never seen is working"), which bought roughly
+# this much grace by accident; stating it here says what is actually meant.
+_QUEUE_BOOT_GRACE = 20.0
 _QUEUE_STATE: Dict[str, dict] = (
     {}
 )  # title -> {"armed", "sent_at", "rebooted_at", "idle_since"}
@@ -1369,6 +1538,8 @@ def _drain_one_queue(title: str) -> None:
     # any age — so require idle to PERSIST for _QUEUE_IDLE_SETTLE before the first send.
     # This absorbs a transient Stop between turns / the brief lull before the next
     # working marker, which otherwise let the drain fire a prompt prematurely.
+    if now - rec.get("rebooted_at", 0.0) < _QUEUE_BOOT_GRACE:
+        return  # we only just relaunched it; let the CLI draw its prompt
     if rec.get("idle_since") is None:
         rec["idle_since"] = now
         return
@@ -4349,11 +4520,14 @@ def _session_snapshot(i, queues: dict) -> dict:
     d["activity"] = _agent_activity_cached(
         i, i.Title
     )  # working | clarify | limit | idle | offline
-    # Epoch when the activity state last changed (from the pane-hash
-    # record), so the UI can rank how long a session has been waiting
-    # (attention ordering + wedged-session watchdog). 0 = unknown.
-    _act_rec = _ACTIVITY_CACHE.get(i.Title) or {}
-    d["activity_since"] = float(_act_rec.get("changed_epoch") or 0.0)
+    # Epoch when the reported activity last changed, so the UI can rank how
+    # long a session has been waiting (attention ordering + wedged-session
+    # watchdog). 0 = unknown — a session with no live reading, e.g. offline.
+    # This read used to name a key (``changed_epoch``) that nothing has ever
+    # written, so it answered 0.0 for every session and the watchdog branch it
+    # feeds never rendered once; ``agent_state.state_since`` is the real thing,
+    # and every layer now writes it (see agent_state._verdict).
+    d["activity_since"] = _agent_state.state_since(i.Title)
     # L3: latest-turn snippet (≤120 chars) for N-session triage, or null.
     d["last_turn"] = _session_last_turn_cached(i)
     # The newest USER prompt (first line) — the panes pin it above the
@@ -4430,8 +4604,7 @@ def _session_snapshot_cheap(i, queues: dict, prev: Optional[dict] = None) -> dic
     d["tokens_model"] = ""
     d["budget"] = _budget_status_for(i.Title, 0.0)
     d["activity"] = "idle"
-    _act_rec = _ACTIVITY_CACHE.get(i.Title) or {}
-    d["activity_since"] = float(_act_rec.get("changed_epoch") or 0.0)
+    d["activity_since"] = _agent_state.state_since(i.Title)
     d["last_turn"] = None
     d["last_prompt"] = None
     d["last_prompt_full"] = None
@@ -4600,6 +4773,18 @@ def _instances_tick() -> None:
         _stage_reset.prune(list(ENGINE.instances.keys()))
     except Exception:  # noqa: BLE001 — housekeeping can't fail the tick
         pass
+    # Same sweep for the per-title probe state. Dropping a record used to be a
+    # side effect of the offline poll, and before that of `_forget_probes` on
+    # every commit — both gone, deliberately, because both destroyed a live
+    # session's history. Route-level teardown covers delete/close/cleanup, but
+    # not every way a session leaves: a workspace deleted from Settings, or a
+    # tombstone converged from another MindFlock on the same state file, pops
+    # the instance without passing through a route here. One set difference per
+    # tick over dicts that are normally the size of the flock.
+    try:
+        _prune_session_state(list(ENGINE.instances.keys()))
+    except Exception:  # noqa: BLE001 — housekeeping can't fail the tick
+        pass
     # Publish the freshly computed state so AppContext.sessions() (Addon API
     # v2) and GET /api/instances can serve it without recomputing it.
     _events.set_sessions_snapshot(out)
@@ -4620,11 +4805,12 @@ def _republish_session(title: str):
     by re-reading races the publish and sees the PREVIOUS snapshot. Here the row
     is in place before anyone is told to look.
 
-    Deliberately does NOT call :func:`_forget_probes`. That would pop
-    ``_ACTIVITY_CACHE[title]`` — the only source of ``activity_since``, which
-    feeds attention ordering and the wedged-session watchdog — and drop the
-    token memo, for no benefit: ``_session_stage_fresh`` already guarantees the
-    stage is current. Do not re-add it.
+    Deliberately does NOT call :func:`_forget_probes` — it would drop the token
+    memo for no benefit, since ``_session_stage_fresh`` already guarantees the
+    stage is current. Do not re-add it. (Its original reason, that popping
+    ``_ACTIVITY_CACHE`` destroys ``activity_since``, is now handled at the
+    source: only :func:`_forget_session_state`, on the delete path, touches the
+    rolling record at all.)
 
     Returns the fresh row, or None if the session is gone. Never raises.
     """
@@ -5763,7 +5949,7 @@ async def delete_instance(title: str) -> JSONResponse:
     _EVENT_SNAPSHOT.pop(title, None)
     _aliases.drop(title)
     _BUDGET_FIRED.pop(title, None)
-    _forget_probes(title)
+    _forget_session_state(title)
     # A recreated same-title session must start with a fresh branch baseline.
     _LAST_BRANCH.pop(title, None)
     _ports.release(title)
@@ -6730,6 +6916,7 @@ async def instance_cleanup(title: str) -> JSONResponse:
         ENGINE.instances.pop(title, None)
     ENGINE.save(exclude_titles={title})
     _EVENT_SNAPSHOT.pop(title, None)
+    _forget_session_state(title)
     _aliases.drop(title)
     _events.BUS.emit("session.deleted", session=title, data={"cleaned": True})
     return JSONResponse({"ok": True})
@@ -6767,6 +6954,11 @@ async def close_instance(title: str) -> JSONResponse:
         ENGINE.instances.pop(title, None)
     ENGINE.save(exclude_titles={title})
     _EVENT_SNAPSHOT.pop(title, None)
+    # Titles come straight back — a reopen restores this very one — so the
+    # rolling record goes with the session rather than lingering to be
+    # inherited. (The incarnation stamp would retire it anyway; this keeps the
+    # dicts from growing under churn.)
+    _forget_session_state(title)
     _aliases.drop(title)
     _events.BUS.emit("session.deleted", session=title, data={"closed": True})
     return JSONResponse({"ok": True})

--- a/backend/web/static/addons/notify.js
+++ b/backend/web/static/addons/notify.js
@@ -17,7 +17,13 @@
 // clicking it focuses this tab.
 
 const STORE_KEY = "mindflock.notify.enabled";
-const DEDUPE_MS = 5000; // at most one notification per (session, event) per 5s
+// At most one notification per (session, RULE) per 5s — keyed by rule id, not
+// by event name, matching _DEDUPE_SECONDS in backend/web/addons/notify.py.
+// Three rules ride session.activity_changed (needs_input, usage_limit, and
+// formerly session_idle); an event-keyed window let whichever matched first
+// swallow the rest, and since the same key is the Notification `tag`, a later
+// rule's popup also replaced a still-visible earlier one.
+const DEDUPE_MS = 5000;
 
 function isEnabled() {
   try {
@@ -134,7 +140,7 @@ window.mindflockAddons.notify = {
       for (const rule of rules) {
         if (rule.enabled === false) continue;  // user muted this rule
         if (!ruleMatches(rule, env)) continue;
-        const key = env.session + "|" + env.event;
+        const key = env.session + "|" + rule.id;
         const now = Date.now();
         if (now - (lastShown.get(key) || 0) < DEDUPE_MS) continue;
         lastShown.set(key, now);

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22596,6 +22596,8 @@ const IDLE_MIN_MINUTES = 1;
 const IDLE_MAX_MINUTES = 480;
 const IDLE_DEFAULT_MINUTES = 10;
 const BREAK_ARM_KEY = "mf_break_due";
+const BREAK_SEEN_KEY = "mf_break_seen";
+const AWAY_GAP_MS = 5 * 6e4;
 function clampBreakMinutes(value) {
   if (value === null || value === void 0) return BREAK_DEFAULT_MINUTES;
   if (typeof value === "string" && value.trim() === "") return BREAK_DEFAULT_MINUTES;
@@ -22623,6 +22625,26 @@ function nextArm(now, everyMin, saved) {
     return { at: saved.at, every };
   return armBreak(now, every);
 }
+function wasAway(now, seen) {
+  if (seen === null || seen === void 0 || !isFinite(seen)) return true;
+  const gap = now - seen;
+  return gap < 0 || gap > AWAY_GAP_MS;
+}
+function openArm(now, everyMin, saved, seen, reloaded) {
+  const every = clampBreakMinutes(everyMin);
+  if (!reloaded) return armBreak(now, every);
+  if (wasAway(now, seen)) return armBreak(now, every);
+  return nextArm(now, every, saved);
+}
+function wasReload() {
+  try {
+    const nav = performance.getEntriesByType("navigation")[0];
+    if (!nav || typeof nav.type !== "string") return true;
+    return nav.type === "reload";
+  } catch {
+    return true;
+  }
+}
 function fmtElapsed(ms) {
   const total = Math.max(0, Math.floor(ms / 1e3));
   const m = Math.floor(total / 60);
@@ -22638,6 +22660,22 @@ function loadArm() {
     return v;
   } catch {
     return null;
+  }
+}
+function loadSeen() {
+  try {
+    const raw = localStorage.getItem(BREAK_SEEN_KEY);
+    if (!raw) return null;
+    const n = Number(raw);
+    return isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+function saveSeen(now) {
+  try {
+    localStorage.setItem(BREAK_SEEN_KEY, String(now));
+  } catch {
   }
 }
 function saveArm(arm) {
@@ -23799,7 +23837,7 @@ function attentionItems(instances2) {
     else if (act === "idle" && Number(inst.activity_since) > 0) {
       const idleFor = Date.now() / 1e3 - Number(inst.activity_since);
       const un = ((_a2 = inst.diff_stat || {}) == null ? void 0 : _a2.uncommitted) || {};
-      const unfinished = (Number(un.additions) || 0) + (Number(un.deletions) || 0) > 0 || inst.stage === "committed";
+      const unfinished = (Number(un.additions) || 0) + (Number(un.deletions) || 0) > 0;
       if (idleFor > WEDGE_IDLE_S && unfinished)
         items.push({
           p: 1,
@@ -25186,10 +25224,13 @@ function notifFromEvent(env) {
     case "session.deleted":
       return { text: "deleted", cls: "n-muted" };
     case "session.activity_changed":
-      if (env.new === "idle") return { text: "finished — now idle", cls: "n-done" };
       if (env.new === "clarify") return { text: "needs your input", cls: "n-warn" };
       return null;
-    // working / offline transitions are too noisy
+    case "session.turn_ended": {
+      const secs = Math.round(Number(d.idle_for) || 0);
+      const held = secs >= 90 ? Math.round(secs / 60) + "m" : secs + "s";
+      return { text: secs ? "finished — idle " + held : "finished", cls: "n-done" };
+    }
     case "session.stage_changed":
       return { text: "stage → " + (env.new || ""), cls: "n-info" };
     case "session.budget_exceeded":
@@ -42517,6 +42558,7 @@ function useIdle(ms, enabled) {
   }, [ms, enabled]);
   return idle;
 }
+const SEEN_EVERY_MS = 15e3;
 function logoPoint() {
   const el = document.getElementById("brand-logo");
   if (el) {
@@ -42531,6 +42573,7 @@ function Breaks() {
   const flockOn = useUi((s) => s.idleFlock);
   const flockAfter = useUi((s) => s.idleFlockAfterMin);
   const [dueAt, setDueAt] = reactExports.useState(null);
+  const lastSeen = reactExports.useRef(0);
   const [now, setNow] = reactExports.useState(() => Date.now());
   const [leaving, setLeaving] = reactExports.useState(false);
   const breakFlock = reactExports.useRef(null);
@@ -42541,16 +42584,31 @@ function Breaks() {
       setDueAt(null);
       return;
     }
-    const armed = nextArm(Date.now(), every, loadArm());
+    const t = Date.now();
+    const armed = openArm(t, every, loadArm(), loadSeen(), wasReload());
     saveArm(armed);
+    saveSeen(t);
+    lastSeen.current = t;
     setDueAt(armed.at);
-    setNow(Date.now());
+    setNow(t);
   }, [on, every]);
   reactExports.useEffect(() => {
     if (!on) return;
-    const id = window.setInterval(() => setNow(Date.now()), 1e3);
+    const id = window.setInterval(() => {
+      const t = Date.now();
+      if (wasAway(t, lastSeen.current)) {
+        const armed = armBreak(t, every);
+        saveArm(armed);
+        setDueAt(armed.at);
+      }
+      if (t - lastSeen.current >= SEEN_EVERY_MS) {
+        saveSeen(t);
+        lastSeen.current = t;
+      }
+      setNow(t);
+    }, 1e3);
     return () => window.clearInterval(id);
-  }, [on]);
+  }, [on, every]);
   reactExports.useEffect(() => () => window.clearTimeout(exitTimer.current), []);
   const onBreak = on && dueAt !== null && now >= dueAt;
   const idle = useIdle(flockAfter * 6e4, flockOn && !onBreak);
@@ -42658,7 +42716,7 @@ function BreakScreen({ away, leaving, flockRef, onSnooze, onResume }) {
                 ref: resumeRef,
                 disabled: leaving,
                 onClick: onResume,
-                children: "Resumed work"
+                children: "Resume Working"
               }
             )
           ] })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,23 +137,40 @@ FastAPI app `backend.web.server:app`. Key pieces:
   single-flight slot and freeze that panel's list. Remaining sharp edge: the
   tasks are untracked at lifespan shutdown (fire-and-forget). See
   [web-api.md](web-api.md#assigned-tickets-pr-auto-review--issue-handling).
+- **Per-tick housekeeping** — `_instances_tick` runs two bounded sweeps against
+  the live title list, each swallowing its own exceptions so housekeeping can
+  never fail a tick: `_stage_reset.prune` (the ↺ display pins) and
+  `_prune_session_state` (the per-title probe/rolling state). The second is the
+  backstop for removals that never reach a route — a workspace deleted from
+  Settings, a tombstone converged from another MindFlock — now that dropping a
+  record is no longer a side effect of an offline poll or of `_forget_probes`,
+  both of which destroyed live sessions' work evidence.
 - **The rest of `core/`** — `server.py` keeps only the app assembly, the
   routes, and the always-on background loops; every other helper cluster is a
   focused module: `agent_sessions` (tmux ensure/send/kill for the agent+shell
-  panes), `agent_state` (working/clarify/idle/offline detection), `snapshot`
+  panes), `agent_state` (working/clarify/idle/offline detection — and the
+  *provenance* behind it: every classification layer stamps a per-title rolling
+  record keyed to the tmux incarnation, exposing `state_since` (what
+  `/api/instances`' `activity_since` publishes), `worked_at` ("we watched this
+  agent work in the session running now") and `claim_work()`, the atomic
+  read-and-clear `server._note_turn_boundary` spends to emit
+  `session.turn_ended` exactly once per observed work cycle), `snapshot`
   (per-session JSON descriptors + diff stat), `session_stats` (token/cost
   telemetry + transcript history), `budget` (cost guardrail + input lock),
   `usage_api` (/api/usage provider descriptors), `mobile_access` (tailnet
   URLs/QR/banner), `plain_repo` (base-folder selection), `workspaces` (roots,
   classification, guarded deletion), `recently_closed` (reopen/Ctrl+Z store),
   `uploads` (paste retention), `system_logs` (log tails), `cursor_windows`,
-  `ide_launch`, `ports`, `window_refresh`, `worktree_setup`. Two load-bearing
-  conventions keep this decomposition black-box-equivalent — hold them when
-  extracting more: **(1) no routes in `core/`** — every `APIRouter`/`@app`
-  handler stays in `server.py`; the modules are pure helpers. **(2) re-import
-  for the monkeypatch seam** — a core module calls back through the server
-  namespace (`_server()._foo(...)`) for anything tests monkeypatch, and
-  `server.py` re-imports the module's names, so
+  `ide_launch`, `ports`, `window_refresh`, `worktree_setup`, `stage_reset` (the
+  guided ladder's ↺ display pin — in-memory, pruned against the live titles) and
+  `reopen` (does an intake item still have a workspace on this machine). Both
+  obey convention (1) below: their routes (`/reset-stage`, `/api/intake/reopen`)
+  live in `server.py`. Two load-bearing conventions keep this decomposition
+  black-box-equivalent — hold them when extracting more: **(1) no routes in
+  `core/`** — every `APIRouter`/`@app` handler stays in `server.py`; the modules
+  are pure helpers. **(2) re-import for the monkeypatch seam** — a core module
+  calls back through the server namespace (`_server()._foo(...)`) for anything
+  tests monkeypatch, and `server.py` re-imports the module's names, so
   `monkeypatch.setattr(server, "_foo", …)` works no matter where `_foo` lives.
 - **Startup `PATH` enrichment** (`backend.pathenv`) — the server `lifespan`
   runs `pathenv.ensure_enriched()` (on a worker thread) **once before serving

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -509,7 +509,13 @@ Settable from the UI settings dialog (⚙) and persisted server-side:
   Settings → Notifications) — which session events notify you. Default-on rules
   are opt-*out* (their id lands in `muted_rules`), noisier ones are opt-*in*
   (`enabled_rules`), so a rule added in a later release starts in the state its
-  author intended. One list governs every delivery channel.
+  author intended. One list governs every delivery channel. The ids are stable
+  across releases even when a rule's *meaning* is tightened — `session_idle` is
+  now labelled **"A session finishes its work and stays idle"** and fires on
+  `session.turn_ended` (MindFlock watched the agent work, it has been idle for
+  45 s since, and nothing is queued to wake it), rather than on the activity
+  chip going grey at the end of every assistant turn. An existing opt-in simply
+  gets quieter; **no migration is needed**, by hand or otherwise.
 - **ntfy push** (`notifications.ntfy_enabled` / `_server` / `_topic` / `_token` /
   `_click_url`, Settings → Notifications) — the optional server-side push channel
   that reaches a phone with no browser tab open (see
@@ -527,7 +533,7 @@ The whole `notifications` group as it lands in `settings.json`:
 ```jsonc
 "notifications": {
   "muted_rules": ["pr_closed"],          // default-on rules switched OFF
-  "enabled_rules": ["session_idle"],     // default-off rules switched ON
+  "enabled_rules": ["session_idle"],     // default-off rules switched ON (id is stable)
   "ntfy_enabled": true,
   "ntfy_server": "https://ntfy.sh",      // omitted = the public default
   "ntfy_topic": "mindflock-xTPq…",       // on a public server this IS the credential

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,8 +32,10 @@ CLI (`claude`) and optionally `gh` (PR create/merge only — pushing is plain
 ## Dev build alongside the installed app
 
 The desktop shell can run an **isolated dev copy** next to the installed prod
-app — its own config/logs/window-state, a red **dev**-badged icon, and a
-`MindFlock-DEV` wordmark, while the server (and your sessions) stays shared.
+app — its own config/logs/window-state, a red **dev**-badged icon, a
+`MindFlock-DEV` wordmark and (on Windows) notifications headed `MindFlock-dev`
+rather than by its raw app id, while the server (and your sessions) stays
+shared.
 Turn it on with `MINDFLOCK_DEV=1` or the `--mindflock-dev` flag:
 
 ```bash

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -45,11 +45,21 @@ Core vocabulary (emitted by the server):
 | `session.prompt_sent` | The queue drain loop auto-sends a prompt | `data: {text, remaining, loop}` |
 | `session.queue_changed` | Any prompt-queue edit | `data: {pending, enabled, loop}` |
 | `session.usage_restored` | A provider window reopened for a session that had run out | `data: {resumed}` |
+| `session.turn_ended` | A session's work really is over — observed working, idle ever since, nothing queued | `data: {idle_for}` |
 
 Addon-originated events (see `AppContext.emit`) live under the `addon.`
 namespace, e.g. `addon.notify.ping`. Notable transitions:
 
 - **agent needs you**: `session.activity_changed` with `new == "clarify"`
+- **agent has finished**: `session.turn_ended` — NOT `session.activity_changed`
+  with `new == "idle"`. The activity flip is a chip colour: the CLI's Stop hook
+  fires at the end of *every* assistant turn, so a ten-turn conversation flips
+  it ten times, and a window that has merely been re-opened flips it once
+  without having run anything at all. `session.turn_ended` is the fact worth
+  acting on — it asserts that the agent was observed working in its current tmux
+  incarnation, has been idle continuously for `server._TURN_END_DWELL_S` (45s),
+  and has no queued prompt waiting to wake it. Emitted once per cycle of
+  observed work, so a session that then sits idle all night says it once
 - **PR merged/closed**: `session.stage_changed` with `old == "pr"` (an open PR
   is stage `pr`; merging or closing it moves the stage off `pr`)
 - **out of usage**: `session.activity_changed` with `new == "limit"` — the pane
@@ -326,7 +336,7 @@ test that diffs them:
 |---|---|
 | `_matches(rule, envelope)` | `ruleMatches(rule, env)` |
 | `_fill(template, envelope)` | `fill(template, env)` |
-| `_DEDUPE_SECONDS = 5.0` | `DEDUPE_MS = 5000` |
+| `_DEDUPE_SECONDS = 5.0`, keyed `(session, rule.id)` | `DEDUPE_MS = 5000`, keyed `session + "|" + rule.id` |
 | `aliases.display_name(title, branch)` | `window.mindflock.displayName(title)` |
 
 `{session}` is the twin that bites hardest, because getting it wrong is silent:
@@ -337,6 +347,21 @@ nobody can find is worse than no push. The browser channel asks the SPA
 (`window.mindflock.displayName`, the sidebar's own resolver); the server channel
 runs a hand port of it (`core/aliases.session_label`, pinned against the
 TypeScript original's examples in `tests/unit/test_aliases.py`).
+
+The dedupe key is the **rule id**, not the event name — it was the event name,
+and three rules ride `session.activity_changed`, so whichever matched first
+swallowed the others for 5 s (`usage_limit` eating `needs_input`, both
+default-on) and, because the same key doubles as the browser `Notification`
+`tag`, the later popup also replaced a still-visible earlier one.
+
+**The `session_idle` rule kept its id and changed its event.** It now matches
+`session.turn_ended` with `old`/`new` both `null`, where it used to match
+`session.activity_changed` with `new == "idle"`; its label, title and body
+changed with it ("A session finishes its work and stays idle"). The id is
+deliberately unchanged, so an existing `notifications.enabled_rules` opt-in
+carries straight over and simply gets quieter — there is no settings migration.
+An addon or filter that keyed on the *event name* rather than the rule id does
+need updating.
 
 Any change to rule *semantics* — a new constraint field, different `{…}`
 placeholder handling, a different dedupe key or window — must land in **both**, or

--- a/docs/ingestion-pipeline.md
+++ b/docs/ingestion-pipeline.md
@@ -311,6 +311,28 @@ the session shows up in the grid without a reload. That start takes the row's
 own Agent CLI picker if one was used, then the repo card's, then
 `issue_agent`'s chain above.
 
+## What the sweeps will pick up next
+
+The three panel routes annotate every row with `eligible` by running the *same*
+skip filters the three flows above use (`ticket_start.skip_reasons`,
+`pr_review`, `issue_start`), so eligibility is never a second opinion about what
+the pipeline will do. **Intake → Auto-start**
+([web-ui.md](web-ui.md#intake)) rolls those scattered chips up into one
+oldest-first list — the order the flows themselves draw in — across all three
+sources.
+
+Two exclusions in that roll-up are deliberate, and both are about *work the
+pipeline has already taken*:
+
+- **Items already accepted.** `queued for ingestion (pending)` is a skip
+  *reason*, so an accepted item is no longer `eligible`; it has left the queue
+  and become a session, which is where you watch it.
+- **Items that already have a session.** Ticket eligibility rules these out
+  through the ledger, but PR and issue eligibility only consult the
+  *processed* ledger — so an item started by hand seconds ago can still read as
+  eligible. The roll-up therefore filters `has_session` itself, because calling
+  work that is being done "waiting to start" would be wrong.
+
 ## Cache refreshers
 
 Each `[[workspace.cache]]` entry with a `refresh_command` gets a background

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -164,14 +164,29 @@ launch, MindFlock idempotently merges hook commands into the CLI's hooks
 config; each hook fires and writes a per-session `{state, ts}` JSON marker to
 `~/.mindflock-assistant/.activity-markers/<session>.json`
 (`MINDFLOCK_ACTIVITY_MARKER_DIR` overrides the directory), which the web layer
-trusts over pane inspection. Markers older than 6 h are ignored — an ancient
-marker belongs to a dead run and must not outvote live inspection. Every
-MindFlock-written hook command carries a `# mindflock-activity` tag so a
-re-install recognizes and replaces **only** MindFlock's own entries; user-
-authored hooks are never touched. Hook install is best-effort and can never
-break a launch. (The Claude provider re-exports these primitives — they
-historically lived in `claude.py` — so existing call-sites and tests keep
-working.)
+trusts over pane inspection. Every MindFlock-written hook command carries a
+`# mindflock-activity` tag so a re-install recognizes and replaces **only**
+MindFlock's own entries; user-authored hooks are never touched. Hook install is
+best-effort and can never break a launch. (The Claude provider re-exports these
+primitives — they historically lived in `claude.py` — so existing call-sites and
+tests keep working.)
+
+**A marker has to be both fresh and current.** Age is the first gate: markers
+older than 6 h are ignored outright, and a `working`/`clarify` one older than
+45 s is re-verified against the live pane, while an `idle` one is trusted at any
+age (a Stop hook from two hours ago on a still-running CLI is genuinely idle).
+Age alone is not enough, though — nothing ever deletes a marker file, and it is
+keyed by tmux session name, so a window you closed and re-opened would keep
+reporting the *dead* run's state for as long as its age allowed. So the web
+layer also checks the marker against the **current tmux incarnation**
+(`web/core/agent_state._marker_is_current`): a marker written before the running
+tmux session was created is discarded whatever state it names — a stale `idle`
+would announce a turn that ended before the session existed, and a stale
+`working` would paint a freshly relaunched CLI as busy and stamp it with work
+evidence it never earned. Unknowable inputs still trust the CLI: no creation
+stamp, or an unreadable marker age, and the marker stands. Claude's live
+`claude agents --json` path reports age `0.0` — it is real-time by construction
+— so it always passes.
 
 Two built-in wirings:
 
@@ -215,6 +230,7 @@ natural_codes = [0, 130]         # clean-quit codes (no auto-resume)
 trust_patterns = ["Do you trust"]  # pane substrings that mean a trust prompt
 trust_keystroke = "enter"          # enter | d_enter | y_enter
 idle_pattern = "What next?"        # pane substring meaning "waiting, idle"
+working_patterns = ["(?i)esc to interrupt"]  # status line of a LIVE turn
 
 [activity]                         # opt-in: activity via the CLI's own hooks
 hooks_file = ".mycli/hooks.json"   # repo-local hooks config, merged into at launch
@@ -225,6 +241,20 @@ state = "idle"
 event = "UserPromptSubmit"
 state = "working"
 ```
+
+**Give your CLI a `working_patterns` regex if it shows an interrupt hint.** It
+is the one signal that proves a turn is live *from a single frame*, and that
+makes it load-bearing in two places. It rescues extended thinking, where the
+work runs server-side and the local process blocks on a network read at ~0 CPU,
+looking exactly like an idle prompt. And it is the only "working" evidence
+available on the **first** captured frame of a pane: the classifier no longer
+assumes a never-before-seen pane is busy (see
+[session-engine.md](session-engine.md#layered-activity-classification)), so a
+provider with no `working_patterns` and no usage-limit banner reads `idle` on
+that frame and has to wait for the next poll (~4 s) to be classified from
+movement. The built-ins are all short and version-stable: `esc to interrupt`
+(claude), `esc to cancel`, `esc interrupt`, `(Ctrl+C to interrupt)`, `Waiting
+for LLM`.
 
 The optional `[activity]` table opts a CLI that has its own hooks engine into
 the marker mechanism above: `hooks_file` names the repo-local hooks config

--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -113,6 +113,63 @@ every stored tmux session as a side effect of changing one field.
 - CLI attach (`Attach()`): Ctrl-Q detaches; a resize monitor uses `SIGWINCH` on
   Unix and 250 ms polling on Windows (WSL follows the Unix path).
 
+### Layered activity classification
+
+`working` / `clarify` / `idle` / `limit` / `offline` is decided by
+`web/core/agent_state._agent_activity`, which consults the cheapest
+*authoritative* signal first and only falls back to looking at pixels:
+
+1. **Exit marker** — the agent command ended in this tmux session → `idle`.
+2. **The CLI's own report** — the hook marker (or Claude's live `claude agents
+   --json`), returned as-is; it outvotes what the pane's foreground command
+   looks like. It is gated on age *and* on belonging to the current tmux
+   incarnation, and an `idle` marker is re-checked against the pane for a
+   usage-limit banner, since the hook fires identically whether the turn ended
+   or was cut off (see
+   [providers.md](providers.md#activity-signal-activity_markerspy)).
+3. **Process tree** — a bare shell holds the pane and no non-shell descendant is
+   alive → the agent isn't running → `idle`.
+4. **Pane inspection** — a normalized hash of the captured pane, the pane
+   process's CPU jiffies, the provider's interrupt hint, and the turn-token
+   counter, combined with asymmetric hysteresis so one changed frame can't flip
+   the badge every poll.
+
+**Never guess on a first sighting.** The pane layer used to seed a
+never-before-seen pane as `working` ("a fresh agent usually is"). Two of its
+four signals need two samples — a CPU *rate* and a *climbing* token counter —
+so on frame one only two facts are available, and both are single-frame: a
+usage-limit banner, and the provider's `working_patterns` interrupt hint, which
+means a turn is live right now. A pane showing neither is reported `idle`, with
+no idle-settle clock started, because nothing on that screen says otherwise.
+`clarify` is deliberately not attempted there either: the waiting-prompt match
+requires a *stable* pane, and one frame cannot establish stability — the next
+poll catches it 4 s later.
+
+**The per-title rolling record has a lifecycle, and it is short.** It holds the
+pane hash, the CPU baseline, the hysteresis clocks and the layer-wide
+*provenance* (`reported` / `state_since` / `worked_at`, written on every return
+path, so a session reporting through its CLI's hooks leaves a trail too). It is
+reset:
+
+- when the **tmux incarnation** changes — the record is keyed to tmux's own
+  `session_created`, so a relaunched session starts clean (its `_LIMIT_PROBE`
+  verdict goes with it) while one whose tmux merely hiccuped keeps its history;
+- on the **delete / close / cleanup routes** (`server._forget_session_state`),
+  since titles come straight back and a namesake must not inherit a dead
+  session's state;
+- by a **per-tick sweep** (`server._prune_session_state`) for the removals that
+  never reach a route — a workspace deleted from Settings, a tombstone converged
+  from another MindFlock.
+
+It is explicitly **not** reset on an offline poll (dropping it there guaranteed
+the first-sighting branch the moment the session came back — the phantom
+"running" flash after clicking a closed window), and **not** by the git workflow
+verbs. Commit / push / make-PR / merge call `server._forget_probes`, which drops
+only memoized probe *results* so nobody is served a stale stage; forgetting the
+rolling record there would throw away `worked_at`, and with it the evidence
+behind this session's next "the agent has finished" — pressing **Commit** must
+not erase the fact that the agent worked.
+
 ## Provisioned mode (`session/provisioned.py`)
 
 Opt-in provisioning that turns a session into a **fully-loaded workspace**

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -23,7 +23,9 @@ List all sessions. Each item:
   "stage": "provisioning|agent|precommit|interrupt|committed|pushed|pr|merged",
   "pr_url": "…",              // when a PR exists
   "failed_step": "…",         // when stage == "interrupt" (pre-commit ✗)
+  "stage_reset": false,       // ↺ "back to idle" pin — show the ladder from the start
   "activity": "working|clarify|idle|offline",
+  "activity_since": 1756200000.0,  // epoch the reported activity last changed; 0 = no live reading
   "tokens": 0, "tokens_in": 0, "tokens_cache_read": 0, "tokens_cache_write": 0,
   "tokens_ctx": 0, "tokens_ctx_window": 200000, "tokens_cost": 0.0,
   "tokens_model": "…",
@@ -53,6 +55,17 @@ base (a configured default like `staging`, or one chosen in the dialog the
 server never sees), so a base-scoped lookup would miss the real PR and wedge the
 chip on `pushed`. The base still keys the "is there work to push" (`beyond`)
 test; only the PR lookup drops the base filter.
+`stage_reset` is the **↺ "back to idle"** pin
+(`POST /api/instances/{title}/reset-stage`, below), published *alongside*
+`stage` and never instead of it. The row's `stage` stays exactly what git says,
+so the autopilot driver, the verification-check kicker and every `*_changed`
+event keep reading the same git-derived truth; only the UI's guided ladder
+(chip, primary button, live step) honours the pin. Folding the pin into `stage`
+would let an armed fast-track chain try to commit a clean tree. The pin is
+process memory (never persisted, and pruned when its session goes) and releases
+itself against the **worktree** — a dirty tree or a moved HEAD drops it on the
+next stage read — never against the stage label, since filing a PR flips
+`pushed` → `pr` a beat after it is set.
 `activity` is layered: the provider's own authoritative signal is preferred —
 per-session `{state, ts}` markers written by the CLI's lifecycle hooks, or
 Claude's live `claude agents --json` report (see
@@ -62,6 +75,16 @@ probe memo so two consecutive activity computations never share a snapshot and
 read a zero CPU delta — phantom idle), then the pane-hash heuristic: changing
 = `working`, provider "waiting" patterns = `clarify`, static ≥ 3 s = `idle`,
 no tmux = `offline`.
+
+`activity_since` is the epoch that **reported** activity last changed value
+(`agent_state.state_since`, stamped by every classification layer, not just the
+pane one), so the UI can rank how long a session has been in its current state
+— attention ordering and the sidebar's wedged-session watchdog. It is `0` for a
+session with no live reading at all (offline, never started), and consumers
+should treat `0` as unknown rather than "changed at the epoch". **Re-check any
+consumer against live values**: this field previously read a key nothing had
+ever written, so it answered `0.0` for every session, and anything gated on
+`activity_since > 0` — the wedged-session branch included — had never once run.
 
 `diff_stat` (J3) is the total change the session has produced vs its
 per-session base — committed-beyond-base **plus** uncommitted tracked changes,
@@ -151,6 +174,7 @@ no response whose only content is "gh is not installed".
 | GET | `/api/instances/{title}/branches` | `{branches, current, default}` — the branch list backing the **Make PR** dialog's base picker. `branches` are `origin`'s remote heads (falling back to local heads when origin is unreachable, so it's never blank); `current` is the session's own branch (never a valid PR target); `default` is the pre-selected base (`repository.pr_base_branch` → the session's fork base). 404 unknown title, 409 workspace not ready |
 | POST | `/api/instances/{title}/make-pr` | Opens a PR → `{ok: true, url}` (or `note: "PR already open"`). Three tiers, in order: `gh pr create --base <base> --fill` when `gh` is installed **and** authenticated; else the GitHub REST API with a token from the usual resolution chain; else **`200 {ok: false, compare_url}`** — a prefilled compare URL the UI opens in the browser, plus the remedy sentence "add a GitHub token in Intake → Pull requests, or install the GitHub CLI". A missing `gh` is never an error status. The UI's Make-PR dialog collects `<base>` from the branch picker above (and the frontend remembers the last base per repo — `prBaseByRepo` in `localStorage`); an omitted base falls back to the session's base branch |
 | POST | `/api/instances/{title}/merge-pr` | Merges the branch's PR, same three tiers: `gh pr merge <branch> --merge`; else the REST API with a token; else **`200 {ok: false, pr_url}`** so the UI can send you to the PR page to merge it yourself |
+| POST | `/api/instances/{title}/reset-stage` | ↺ **back to idle** — pins this window's guided ladder back to its start on a clean branch, so the header stops insisting on Push / Make PR / Merge while you keep working on the same branch. **Nothing git-facing happens**: no reset, no revert, no PR close, and the published `stage` is untouched — the pin (`backend/web/core/stage_reset.py`) rides the row as `stage_reset` and only the UI ladder reads it. It releases itself when the worktree moves (dirty tree or new commit), never on the stage label. Also takes down the finished cycle's leftovers: a **halted** fast-track record (a live chain is left strictly alone) and a **stale** verification result (a current failure is never touched — the push gate reads it). → `{ok: true, pinned, dirty, cleared[], row}`, where `row` is the recomputed instance row so the presser's window flips now rather than on the next tick, and `pinned` is `false` on an already-dirty tree (that ladder is at its start already). 404 unknown title, 409 workspace not ready |
 
 ### Assigned tickets, PR auto-review + issue handling
 
@@ -162,6 +186,7 @@ no response whose only content is "gh is not installed".
 | POST | `/api/github/prs/review` | Body `{repo, number, agent?}` — force-start a review session for one open PR (**Begin review** in Intake → Pull requests), bypassing the auto filters, a non-matching base included. `agent` is this launch's coding CLI and outranks the repo card's; blank falls through to the same chain the monitor uses (`github.repo_settings[repo].agent` → `github.agent` → `[mindflock].agent` → the app default). 400 bad `owner/name`/number or an unknown `agent`, 404 no such open PR, 409 a session for it already exists |
 | GET | `/api/github/issues` | Open issues on the issue-handling repos (`github.issue_repos`), each annotated with auto-handling eligibility (`eligible`, `reasons`, `has_session`). PRs filtered out. Powers Intake → **Issues** |
 | POST | `/api/github/issues/start` | Body `{repo, number, agent?}` — force-start a coding session for one open issue on a fresh branch, bypassing the age / already-handled filters. `agent` is this launch's coding CLI, outranking the repo card's (`github.issue_repo_settings[repo].agent` → `github.issue_agent` → `[mindflock].agent` → the app default). 400 bad `owner/name` or number or an unknown `agent`, 404 issue gone, 409 a session for it already exists |
+| POST | `/api/intake/reopen` | Body `{kind}` — `tickets` \| `prs` \| `issues` — plus the same item identity that kind's start route takes (`{source, id}` for a ticket, `{repo, number}` for a PR or issue). Puts a session back on the workspace an earlier run of that item left on this machine instead of starting it over (**Reopen window**). The **server** re-resolves the workspace from the row in the panel's cached listing — never a path the client sends — so a tab left open for an hour cannot name a directory that has since been deleted: `backend/web/core/reopen.py` tries a recently-closed session for the item, then its provisioned clone directory, then a worktree still holding its branch, each gated on a real `.git`. A closed session is restored in full through the undo store (branch, program, prompt, provisioning flags); a workspace whose session was lost to a restart gets a fresh **in-place** session on the directory, in-place because the directory is not MindFlock's to delete. **200** carries the restored session's row, **202** the freshly opened one. 400 unknown `kind` or a payload that doesn't identify an item, 409 the session is already open (or the panel's list no longer holds the row — Refresh it), 410 no workspace for this item is left on this machine |
 
 The three **POST** force-start routes above share one family of *per-launch*
 overrides, each optional and each meaning "just this item, not the whole queue"
@@ -210,7 +235,14 @@ inside the 5-minute stale window, an upstream failure is logged and the last
 known list keeps being served, so a GitHub/provider blip can't empty the panel;
 the flip side is that a persistently failing upstream stays invisible to the
 client for up to 5 minutes. `has_session` is annotated on a per-request copy, so
-it stays live on cache hits.
+it stays live on cache hits. So is `workspace` — the reopenable directory an
+earlier run of the row left behind (`{kind: closed|clone|worktree, path, branch,
+entry_id?}`, absent when there is none), which is what puts **Reopen window** on
+the row. That probe is read-only and best-effort — any failure annotates
+nothing — and is per *pass*, not per row: the recently-closed store is read
+once, each candidate directory is stat'd once, and each repo answers one
+`git worktree list`, all indexed for the whole response. Rows that already have
+a live session are skipped.
 
 ### Verify — checklists for what shipped
 
@@ -337,8 +369,18 @@ usage-limit hold: a hold is armed from the provider's own usage meter **even
 when no limit banner is on the pane** (covering a session that ran out mid-turn
 and rebooted to a fresh idle prompt), and a window that reads spent but carries
 no usable reset time holds on a bounded fallback rather than sending. A meter
-that reads open — or is unavailable — leaves the queue free to send. `GET
-/api/instances` carries a per-session
+that reads open — or is unavailable — leaves the queue free to send.
+
+After MindFlock **itself** reboots a dead agent for a queued run, the drain
+holds for `_QUEUE_BOOT_GRACE` (20 s) whatever the activity probe says. A CLI
+relaunching with a large `--continue` transcript spends that time on a quiet,
+I/O-bound start, and a quiet pane is now correctly read as `idle` — nothing on
+that screen claims work is happening. Typing into a CLI that has not drawn its
+input box loses the prompt, and since the send clears the queue's `armed` flag
+the retry would only come after `_QUEUE_REARM_IDLE` (5 min). The old classifier
+bought roughly this much grace by accident, by assuming a pane it had never seen
+was working; the hold states it instead. `GET /api/instances` carries a
+per-session
 `queue: {pending, enabled, loop}` summary for the UI badge. Each auto-send emits
 `session.prompt_sent`; queue edits emit `session.queue_changed`.
 
@@ -444,7 +486,8 @@ drain-loop pass that nudges sessions parked on a limit screen to carry on
 (`data: {"resumed": <bool>}`, false when `general.resume_on_usage_reset` is
 off). It only ever fires for sessions that had actually run out, so it is the
 "your usage is back" signal; running *out* is `session.activity_changed` with
-`new == "limit"`. The notification-center
+`new == "limit"`. `session.turn_ended` is the one that says an agent has
+**finished** (`data: {"idle_for": <float>}`) — see below. The notification-center
 bell (frontend) curates these into a "what happened while I was away" feed.
 
 `session.activity_changed` transitions **into** `idle`, `clarify`, or `limit`
@@ -453,6 +496,23 @@ single poll can misread a busy pane as idle, and every consumer of this event �
 ntfy pushes, desktop notifications, clarify toasts, shell hooks — would
 otherwise fire on the flicker. A reading that reverts before it settles emits
 nothing at all; transitions back to `working`/`offline` are instant.
+
+That settle is a **flicker** filter and nothing more: it can only suppress a
+reading that reverts. "The agent has finished" is a different question, and
+`session.activity_changed` with `new == "idle"` is the wrong event to answer it
+with — the CLI's Stop hook fires at the end of every assistant turn, so the flip
+happens ten times in a ten-turn conversation, between two prompts of a draining
+queue, and once more for a window that has merely been re-opened (attaching a
+pane relaunches a dead agent, which then parks at an empty prompt). **`session.
+turn_ended`** is the fact that answers it, and it asserts three things at once:
+the agent was *observed working* in its current tmux incarnation, it has been
+idle continuously for `_TURN_END_DWELL_S` (45s), and no queued prompt is waiting
+to wake it. It is emitted once per cycle of observed work — the evidence is
+spent on emit and re-earned by the next `working` reading — so a session left
+idle overnight announces itself once. 45s is chosen to sit above every other
+idle dwell in the app (`_QUEUE_IDLE_SETTLE` 12s, `autopilot.IDLE_SETTLE_S` 30s),
+so the queue drains and a fast-track chain decides the agent is done *before*
+anyone is told the work finished.
 
 For ~30s after the server process starts (including a Settings-triggered
 restart, which re-execs), the `status/activity/stage_changed` diff events are
@@ -652,6 +712,16 @@ browser tab open. It is off until configured, resolves through
 env → `settings.json` → defaults (`MINDFLOCK_NTFY_ENABLED` / `_SERVER` /
 `_TOPIC` / `_TOKEN` / `_CLICK_URL`, where an env-supplied topic is an implicit
 opt-in for headless boxes), and is capped at 60 pushes/hour per process.
+
+Both channels collapse repeats per **(session, rule id)** for 5 s
+(`notify.py::_DEDUPE_SECONDS` / `notify.js::DEDUPE_MS`), not per (session,
+event). Three rules ride `session.activity_changed`, and an event-keyed window
+let whichever fired first swallow the rest — a default-on **ran out of usage**
+push eating a default-on **needs your input** push, and, since the same key is
+also the browser `Notification` tag, replacing its still-visible popup. The
+window is a *flap* collapser and nothing more; it is meaningless at turn
+cadence, which is why `session.turn_ended` is deduped by spending its work
+evidence instead — once per observed work cycle — rather than by a timer.
 
 Two write-path guards worth knowing: the token follows the store's secret
 convention (empty or the `•••set` sentinel keeps the saved one) **and** is

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -304,18 +304,37 @@ session (keyboard-only via a prompt).
 
 ## Notifications (🔔)
 
-The header bell keeps a running feed of notable session events — finished/idle,
+The header bell keeps a running feed of notable session events — finished,
 needs-input, stage changes, cost-over-budget, auto-sent queued prompts — fed by
 the events bus, **including the backlog replayed on connect** so it answers
 "what happened while I was away." An unread badge counts events since you last
 opened it (keyed on timestamp so it survives server restarts); clicking an entry
 focuses that session.
 
+A raw idle transition no longer produces a row at all. The feed used to log
+*finished — now idle* on every activity flip to idle, with no rule gate and no
+dedupe — so it fired at the end of every assistant turn, between two prompts of
+a draining queue, and for a re-opened window whose agent had run nothing. The
+finished row now comes from `session.turn_ended` and says how long the quiet has
+lasted — **finished — idle 45s**, **finished — idle 2m** — because the dwell is
+the part that makes the claim trustworthy. `working`/`offline` flips remain
+chip colours and are still filtered out.
+
 **One rule list, two delivery channels.** Settings → Notifications is split that
 way on purpose: *What triggers a notification* (needs-input, PR merged/closed,
 budget exceeded, pre-commit failed, ran out of usage / usage came back — plus
 the noisy opt-ins) governs **both** channels, and each channel decides only
 where an alert lands.
+
+**"A session finishes its work" is a claim, and it is checked.** The opt-in rule
+fires on `session.turn_ended`, not on the activity chip going grey. The chip
+goes grey at the end of every assistant turn — the CLI's Stop hook cannot tell
+"the work is done" from "this reply is done" — and also for a window you merely
+re-opened, since attaching its pane relaunches a dead agent that then parks at an
+empty prompt. Before the event fires, three things have to be true: MindFlock
+*watched this agent work* in the tmux session that is running now, it has been
+idle for 45 seconds since, and there is no queued prompt about to wake it. Each
+cycle of work announces itself once, however long the session then sits there.
 
 The two usage rules are a pair: **"A session runs out of usage"** fires on the
 activity flip to `limit` (the agent is parked on its CLI's usage-limit screen),
@@ -431,7 +450,17 @@ Authentication section. If the token leaks, regenerate it from Settings →
   about a window you cannot find in the rail is worse than no push.
 - **Attention** — sessions waiting on input badge the tab **title** (`● (n)`)
   *and* the **favicon** (a red dot), so a backgrounded tab is noticeable. The
-  🔔 bell keeps the durable list.
+  🔔 bell keeps the durable list, prioritized: waiting on your answer, then
+  broken (pre-commit / worktree setup), then checks failing, then ready to move.
+- **Wedged-session watchdog** — the lowest-noise entry on that list: a session
+  idle for more than **20 minutes** while still holding **uncommitted** changes
+  reads *idle 25m with unfinished work — possibly stuck*, i.e. an agent that
+  stopped in the middle of something with nobody typing. A `committed` branch
+  does **not** count as unfinished work — git considers it done and the header
+  is merely asking you to push — so committing and walking away is not flagged.
+  This rule only started rendering at all once `activity_since` was populated
+  (see [web-api.md](web-api.md#get-apiinstances)); before that it read a field
+  that was always `0` and never fired.
 - **Undo** — reversible actions (hide, bulk hide) show a *click to undo* toast
   instead of a modal; only truly destructive wipes still confirm.
 - **Hidden sessions stick** — a session you hide stays hidden across reloads
@@ -1320,10 +1349,31 @@ is running it**.
   *Reminder to take a break every `[N]` minutes*, with N editable in place
   (5–480, default 60). When it fires, a card asks you to get up, with the
   murmuration from mindflock.ai flying over your grid.
-  **Snooze 5 min** pushes it back five minutes; **Resumed work** (or
+  **Snooze 5 min** pushes it back five minutes; **Resume Working** (or
   Escape) restarts the whole interval. The clock is wall-clock and survives a
   reload — a refresh is not a way to dodge a break — but changing the interval
-  re-arms it from now. **There is no scrim**: your grid, sidebar and panes stay
+  re-arms it from now.
+
+  **It only runs while the app does.** A deadline on its own keeps counting
+  through a closed window, a shut-down machine and a slept laptop, so whoever
+  came back in the morning was met by a card claiming they had been at the desk
+  all night, its away-clock still climbing. They had not been: time away from
+  the app is time away from the desk, which is the break itself. So the app
+  stamps a heartbeat while it runs (`mf_break_seen`, every 15s), and a gap in it
+  of more than **five minutes** starts the interval over instead of resuming it
+  — on opening, and also mid-run, which is the only thing that notices a machine
+  that slept with the window open (and takes the stale card down with it).
+
+  Opening the app is itself a fresh start: the countdown begins when you sit
+  down, whatever yesterday left behind. That is not a hole in the rule above,
+  because a *refresh* is told apart from an *open* by navigation type rather
+  than by guesswork — F5, the palette's Reload, the reload every tab does when
+  the server restarts, and the API client's reload on a lost session are all
+  `reload` and all keep the deadline; a shell launch or a new tab is `navigate`.
+  The five-minute tolerance is wide on purpose: a hidden tab's timer is
+  throttled to about one tick a minute, and that must not read as an absence.
+
+  **There is no scrim**: your grid, sidebar and panes stay
   exactly as you left them and the flock flies over them, the same treatment the
   idle overlay gets; the card is the only new thing on screen. The overlay still
   swallows the pointer and the keymap stands down with it, so you can watch your

--- a/electron/README.md
+++ b/electron/README.md
@@ -195,6 +195,17 @@ therefore your sessions) stays shared, which is usually what you want:
   `MINDFLOCK_DEV_ICON=/path/to/icon` (`.ico` on Windows; `.png` elsewhere).
 - **`MindFlock-DEV` wordmark** in the title bar.
 - A distinct taskbar/dock identity so it never merges with the prod app.
+- **Notifications headed `MindFlock-dev`** (Windows). A toast is headed by the
+  display name of the Start-menu shortcut registered for the AppUserModelID that
+  raised it — prod gets one from its installer, which is why its notifications
+  read *MindFlock*. Dev has its own AUMID and no installer, so Windows used to
+  print the raw id (*ai.mindflock.desktop.dev*) across the top of every toast.
+  The shell now writes that shortcut itself on a dev run, into
+  `%APPDATA%\Microsoft\Windows\Start Menu\Programs\MindFlock-dev.lnk`,
+  pointing at `electron.exe` with the app dir and `--mindflock-dev` — so it is
+  also a working launcher, and the thing to pin (see below). It is rewritten
+  only when missing or stale, and a Start menu locked down by policy costs you
+  the label, not the app.
 
 Prod is untouched: with neither the env var nor the flag set, every one of
 these is a no-op, so it is safe to ship in the packaged build.
@@ -236,7 +247,10 @@ normal (installed) app pins with its icon but an ad-hoc dev launch may not:
   the running window. The prod app pins cleanly because its installer
   registered a Start-menu shortcut carrying the app's AppUserModelID and icon.
 
-So to pin dev with the red icon, pin a shortcut that (a) targets `electron.exe`
+A dev run already writes one such shortcut — `MindFlock-dev.lnk` in your Start
+menu, for the notification name above — so the quickest path is to right-click
+that and **Pin to taskbar**. Roll your own only if you want it elsewhere or with
+different arguments; it has to be a shortcut that (a) targets `electron.exe`
 **directly** — a `.bat` makes Windows pin `cmd.exe` with cmd's icon instead —
 (b) passes the app dir plus `--mindflock-dev`, and (c) sets its `IconLocation`
 to a `.ico` of the dev badge. For example:

--- a/electron/main.js
+++ b/electron/main.js
@@ -39,11 +39,75 @@ const DEV_ICON = DEV
   ? (process.env.MINDFLOCK_DEV_ICON ||
      path.join(__dirname, process.platform === 'win32' ? 'dev-icon.ico' : 'dev-icon.png'))
   : null
+// The dev shell's own taskbar/toast identity. Kept STABLE: it is what a pinned
+// taskbar button and any already-registered shortcut are keyed on, so renaming
+// it silently orphans both.
+const DEV_AUMID = 'ai.mindflock.desktop.dev'
+// What Windows should PRINT above a dev notification: prod's product name with
+// the suffix this build already wears everywhere else. See ensureDevToastName().
+const DEV_TOAST_NAME = 'MindFlock-dev'
 if (DEV) {
-  app.setAppUserModelId('ai.mindflock.desktop.dev') // own taskbar group + icon
+  app.setAppUserModelId(DEV_AUMID) // own taskbar group + icon
   try {
     app.setPath('userData', path.join(app.getPath('appData'), 'MindFlock (dev)'))
   } catch (e) { /* fall back to the shared dir if this platform disallows it */ }
+}
+
+// Give the dev AUMID a NAME, or Windows prints the id itself.
+//
+// A toast is headed by the display name of the Start-menu shortcut registered
+// for the AUMID that raised it — that is the whole reason the packaged app sets
+// the installer's appId (the NSIS shortcut carries it). Dev sets an AUMID of its
+// own for a separate taskbar group, but nothing had ever written a shortcut for
+// it, so Windows fell back to printing the raw string and every dev notification
+// was headed "ai.mindflock.desktop.dev" instead of a name.
+//
+// So write that shortcut ourselves, once, into the per-user Start menu. It
+// targets electron.exe DIRECTLY with the app dir + the dev flag (the same shape
+// the README's pin-to-taskbar recipe uses — a .bat would make Windows attribute
+// the icon to cmd.exe), which also makes it a working launcher rather than a
+// decoy that exists only to be read.
+//
+// Windows-only, and only in dev: prod already has the installer's shortcut, and
+// no other platform resolves notification identity this way.
+function ensureDevToastName () {
+  if (!DEV || process.platform !== 'win32') return
+  try {
+    const programs = path.join(
+      app.getPath('appData'), 'Microsoft', 'Windows', 'Start Menu', 'Programs'
+    )
+    const link = path.join(programs, DEV_TOAST_NAME + '.lnk')
+    // A shortcut's icon must be an .ico; MINDFLOCK_DEV_ICON may legitimately be
+    // a .png (that override is shared with the window/dock icon, which takes
+    // either), so fall back to the exe rather than writing a broken IconLocation.
+    const icon = DEV_ICON && DEV_ICON.toLowerCase().endsWith('.ico') ? DEV_ICON : process.execPath
+    const want = {
+      target: process.execPath,
+      args: '"' + app.getAppPath() + '" --mindflock-dev',
+      cwd: path.dirname(process.execPath),
+      icon,
+      iconIndex: 0,
+      appUserModelId: DEV_AUMID,
+      description: 'MindFlock dev shell (isolated profile, shared server)'
+    }
+    // Rewrite only when it is missing or has drifted — an electron.exe that
+    // moved, an icon override that changed. Touching the .lnk on every launch
+    // would churn the Start menu's index for nothing.
+    let have = null
+    try { have = shell.readShortcutLink(link) } catch (e) { /* not there yet */ }
+    if (have &&
+        have.target === want.target &&
+        have.args === want.args &&
+        have.icon === want.icon &&
+        have.appUserModelId === want.appUserModelId) return
+    fs.mkdirSync(programs, { recursive: true })
+    shell.writeShortcutLink(link, 'create', want)
+    console.log('[mindflock] dev toast identity registered:', link)
+  } catch (e) {
+    // Cosmetic, and the Start menu can be locked down by policy: a dev run must
+    // still start (with the old raw-id heading) rather than fail over a label.
+    console.warn('[mindflock] could not register the dev toast name:', e && e.message)
+  }
 }
 
 // Log the auto-started server appends to (stdout+stderr), so a startup crash
@@ -1496,6 +1560,9 @@ app.whenReady().then(() => {
   if (DEV && DEV_ICON && process.platform === 'darwin' && app.dock) {
     try { app.dock.setIcon(DEV_ICON) } catch (e) { /* best effort */ }
   }
+  // After logger.init: this one logs whether it took, and a first dev run on a
+  // fresh machine is exactly when that line is worth having in main.log.
+  ensureDevToastName()
   createWindow()
   startUpdateChecks()
 })

--- a/frontend/src/__tests__/breakTimer.test.ts
+++ b/frontend/src/__tests__/breakTimer.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   armBreak,
+  AWAY_GAP_MS,
+  openArm,
+  wasAway,
   BREAK_DEFAULT_MINUTES,
   BREAK_MAX_MINUTES,
   BREAK_MIN_MINUTES,
@@ -133,5 +136,85 @@ describe("fmtElapsed", () => {
 
   it("never shows negative time", () => {
     expect(fmtElapsed(-5000)).toBe("0:00");
+  });
+});
+
+describe("wasAway", () => {
+  it("is false while the heartbeat is recent — the app has been running", () => {
+    expect(wasAway(T, T - 1000)).toBe(false);
+    expect(wasAway(T, T)).toBe(false);
+    // A hidden tab's interval is throttled to about a tick a minute; that must
+    // not read as an absence, which is the whole reason the tolerance is wide.
+    expect(wasAway(T, T - 70_000)).toBe(false);
+    expect(wasAway(T, T - AWAY_GAP_MS)).toBe(false);
+  });
+
+  it("is true once the heartbeat is older than the gap", () => {
+    expect(wasAway(T, T - AWAY_GAP_MS - 1)).toBe(true);
+    expect(wasAway(T, T - 8 * 60 * MIN)).toBe(true); // a night with the lid shut
+  });
+
+  it("is true when there is no heartbeat at all", () => {
+    // Nothing has ever run here, or storage was cleared: unknowable, and the
+    // safe answer to "how long was that?" is to start the interval over.
+    expect(wasAway(T, null)).toBe(true);
+    expect(wasAway(T, undefined)).toBe(true);
+    expect(wasAway(T, NaN)).toBe(true);
+  });
+
+  it("is true for a heartbeat in the FUTURE", () => {
+    // The clock jumped backwards (a timezone fix, an NTP correction). No
+    // elapsed time explains the stamp, so it cannot be trusted as liveness.
+    expect(wasAway(T, T + 60_000)).toBe(true);
+  });
+});
+
+describe("openArm", () => {
+  const saved = { at: T + 20 * MIN, every: 60 };
+
+  it("arms fresh when the APP OPENED, whatever was left behind", () => {
+    // The shell launching, or a new tab. Opening MindFlock is when the
+    // countdown starts — this is the case the whole change exists for.
+    expect(openArm(T, 60, saved, T - 1000, false)).toEqual({ at: T + 60 * MIN, every: 60 });
+    const overdue = { at: T - 5 * 60 * MIN, every: 60 };
+    expect(openArm(T, 60, overdue, T - 1000, false)).toEqual({ at: T + 60 * MIN, every: 60 });
+  });
+
+  it("keeps the deadline on a REFRESH mid-countdown", () => {
+    // Unchanged contract: a reload seconds after the last heartbeat is someone
+    // refreshing a running app, and must not buy them a fresh hour.
+    expect(openArm(T, 60, saved, T - 2000, true)).toEqual(saved);
+  });
+
+  it("keeps an overdue deadline on a refresh mid-countdown", () => {
+    const overdue = { at: T - 3 * MIN, every: 60 };
+    expect(openArm(T, 60, overdue, T - 2000, true)).toEqual(overdue);
+  });
+
+  it("arms fresh when the page reloaded but the app had STOPPED", () => {
+    // Closed for an hour and reopened onto a restored tab, or a slept machine
+    // woken and refreshed: a reload by navigation type, an absence in fact.
+    const overdue = { at: T - 5 * 60 * MIN, every: 60 };
+    expect(openArm(T, 60, overdue, T - 9 * 60 * MIN, true)).toEqual({
+      at: T + 60 * MIN,
+      every: 60,
+    });
+  });
+
+  it("arms fresh on a reload with no heartbeat to judge by", () => {
+    expect(openArm(T, 60, saved, null, true)).toEqual({ at: T + 60 * MIN, every: 60 });
+  });
+
+  it("still re-arms when the interval changed, on every path", () => {
+    const forNinety = { at: T + 80 * MIN, every: 90 };
+    expect(openArm(T, 30, forNinety, T - 1000, true)).toEqual({ at: T + 30 * MIN, every: 30 });
+    expect(openArm(T, 30, forNinety, T - 1000, false)).toEqual({ at: T + 30 * MIN, every: 30 });
+  });
+
+  it("clamps the interval it arms for", () => {
+    expect(openArm(T, 99999, null, null, false)).toEqual({
+      at: T + BREAK_MAX_MINUTES * MIN,
+      every: BREAK_MAX_MINUTES,
+    });
   });
 });

--- a/frontend/src/__tests__/notifications.test.ts
+++ b/frontend/src/__tests__/notifications.test.ts
@@ -1,0 +1,45 @@
+/** The bell feed's curation: which events become a row in "what happened while
+ * you were away", and — more to the point — which do not.
+ *
+ * The bell is the one notification channel with no opt-in gate and no dedupe:
+ * it subscribes to "*" and renders whatever `notifFromEvent` returns. So it was
+ * the channel actually producing the jumpy "finished" the user saw, whether or
+ * not they had ever turned the ntfy/desktop rule on. */
+
+import { describe, it, expect } from "vitest";
+import { notifFromEvent } from "../components/NotificationsBell";
+import type { EventEnvelope } from "../state/queries";
+
+const env = (e: Partial<EventEnvelope>): EventEnvelope => ({
+  event: "",
+  session: "s",
+  seq: 1,
+  ts: 0,
+  old: null,
+  new: null,
+  data: {},
+  ...e,
+});
+
+describe("notifFromEvent", () => {
+  it("ignores a raw idle flip — that is a chip colour, not news", () => {
+    expect(notifFromEvent(env({ event: "session.activity_changed", new: "idle" }))).toBeNull();
+  });
+
+  it("still ignores working and offline", () => {
+    expect(notifFromEvent(env({ event: "session.activity_changed", new: "working" }))).toBeNull();
+    expect(notifFromEvent(env({ event: "session.activity_changed", new: "offline" }))).toBeNull();
+  });
+
+  it("keeps clarify — a question needs answering now", () => {
+    const n = notifFromEvent(env({ event: "session.activity_changed", new: "clarify" }));
+    expect(n?.text).toBe("needs your input");
+    expect(n?.cls).toBe("n-warn");
+  });
+
+  it("reports a real turn boundary as the finish", () => {
+    const n = notifFromEvent(env({ event: "session.turn_ended", data: { idle_for: 46 } }));
+    expect(n?.text).toContain("finished");
+    expect(n?.cls).toBe("n-done");
+  });
+});

--- a/frontend/src/__tests__/ordering.test.ts
+++ b/frontend/src/__tests__/ordering.test.ts
@@ -118,12 +118,13 @@ describe("attentionItems", () => {
     expect(items).toEqual([]);
   });
 
-  it("flags a calm-but-wedged session sitting on unfinished work", () => {
+  it("flags a calm-but-wedged session sitting on uncommitted work", () => {
     const items = attentionItems([
       inst({
         title: "wedged",
         activity: "idle",
-        stage: "committed",
+        stage: "agent",
+        diff_stat: { files: 2, additions: 12, deletions: 3, uncommitted: { files: 2, additions: 12, deletions: 3 } },
         activity_since: Date.now() / 1000 - 2000,
       }),
     ]);
@@ -137,8 +138,26 @@ describe("attentionItems", () => {
       inst({
         title: "fresh",
         activity: "idle",
-        stage: "committed",
+        stage: "agent",
+        diff_stat: { files: 2, additions: 12, deletions: 3, uncommitted: { files: 2, additions: 12, deletions: 3 } },
         activity_since: Date.now() / 1000 - 10,
+      }),
+    ]);
+    expect(items).toEqual([]);
+  });
+
+  it("does not call a committed-and-left session stuck", () => {
+    // git considers a committed branch finished — the header is asking for a
+    // push, not reporting a problem. Counting it meant every session anyone
+    // had committed and walked away from landed on the bell's attention badge
+    // claiming to be wedged. (Live for the first time: activity_since used to
+    // read a key nothing wrote, so this whole branch never rendered.)
+    const items = attentionItems([
+      inst({
+        title: "done",
+        activity: "idle",
+        stage: "committed",
+        activity_since: Date.now() / 1000 - 36000,
       }),
     ]);
     expect(items).toEqual([]);

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -36,7 +36,7 @@ interface Notif {
 }
 
 /** Map a raw event envelope to a notification, or null to ignore the noise. */
-function notifFromEvent(env: EventEnvelope): { text: string; cls: string } | null {
+export function notifFromEvent(env: EventEnvelope): { text: string; cls: string } | null {
   const d = env.data || {};
   switch (env.event) {
     case "session.created":
@@ -50,9 +50,22 @@ function notifFromEvent(env: EventEnvelope): { text: string; cls: string } | nul
     case "session.deleted":
       return { text: "deleted", cls: "n-muted" };
     case "session.activity_changed":
-      if (env.new === "idle") return { text: "finished — now idle", cls: "n-done" };
       if (env.new === "clarify") return { text: "needs your input", cls: "n-warn" };
-      return null; // working / offline transitions are too noisy
+      // idle / working / offline are chip colours, not news. `new === "idle"`
+      // used to render "finished — now idle" here, with no rule gate and no
+      // dedupe — so it logged a row at the end of every assistant turn, between
+      // two prompts of a draining queue, and for a re-opened window whose agent
+      // had run nothing at all. "Finished" is a claim about work, and the event
+      // that can actually make it is session.turn_ended below.
+      return null;
+    case "session.turn_ended": {
+      // Say how long, using the dwell the event carries — the whole claim of
+      // this event is that the quiet lasted, so a bare "finished" throws away
+      // the part that makes it trustworthy.
+      const secs = Math.round(Number((d as { idle_for?: number }).idle_for) || 0);
+      const held = secs >= 90 ? Math.round(secs / 60) + "m" : secs + "s";
+      return { text: secs ? "finished — idle " + held : "finished", cls: "n-done" };
+    }
     case "session.stage_changed":
       return { text: "stage → " + (env.new || ""), cls: "n-info" };
     case "session.budget_exceeded":

--- a/frontend/src/components/breaks/Breaks.tsx
+++ b/frontend/src/components/breaks/Breaks.tsx
@@ -15,6 +15,10 @@
  * The break clock is wall-clock, not "time spent typing": the thing it is
  * counting is how long you have been at the desk, and a session that ran
  * itself for forty minutes while you watched still cost you forty minutes.
+ * What it does NOT count is time the app was not running — a closed window, a
+ * shut-down machine, a slept laptop. That time is the break, so it starts the
+ * interval over rather than presenting a card that has been "counting" all
+ * night (lib/breakTimer: the heartbeat, and openArm's rule table).
  *
  * Both surfaces arrive and leave the same way, and it is a round trip: the
  * flock streams OUT of the MindFlock mark in the top bar when it appears,
@@ -29,9 +33,13 @@ import {
   armBreak,
   fmtElapsed,
   loadArm,
-  nextArm,
+  loadSeen,
+  openArm,
   saveArm,
+  saveSeen,
   snoozeArm,
+  wasAway,
+  wasReload,
   type BreakArm,
 } from "../../lib/breakTimer";
 import type { FlockHandle } from "../../lib/flock";
@@ -42,6 +50,9 @@ import { useIdle } from "./useIdle";
  * rather than assumed, because on macOS the whole cluster is mirrored to the
  * right to clear the traffic lights. The fallback is the top-left corner the
  * mark sits in everywhere else. */
+/** How often the running app stamps the heartbeat. */
+const SEEN_EVERY_MS = 15_000;
+
 function logoPoint(): { x: number; y: number } {
   const el = document.getElementById("brand-logo");
   if (el) {
@@ -58,6 +69,10 @@ export function Breaks() {
   const flockAfter = useUi((s) => s.idleFlockAfterMin);
 
   const [dueAt, setDueAt] = useState<number | null>(null);
+  /** Last heartbeat this window wrote. Kept in a ref as well as in storage so
+   * the per-second check costs nothing: the tick compares against it, and a
+   * value that is suddenly minutes old is the app having been stopped. */
+  const lastSeen = useRef(0);
   const [now, setNow] = useState(() => Date.now());
   /** The break screen is on its way out: birds flying home, scrim fading, and
    * no further presses accepted. */
@@ -65,27 +80,56 @@ export function Breaks() {
   const breakFlock = useRef<FlockHandle | null>(null);
   const exitTimer = useRef(0);
 
-  // Arm at mount and re-arm whenever the setting changes. nextArm() holds the
-  // rule for which of those two a given (on, every) actually is.
+  // Arm at mount and re-arm whenever the setting changes. openArm() holds the
+  // rule for which of those a given (on, every) actually is — including the
+  // difference between this page being refreshed (keep the deadline) and the
+  // app being opened after a night with the machine off (start over).
   useEffect(() => {
     if (!on) {
       saveArm(null);
       setDueAt(null);
       return;
     }
-    const armed = nextArm(Date.now(), every, loadArm());
+    const t = Date.now();
+    const armed = openArm(t, every, loadArm(), loadSeen(), wasReload());
     saveArm(armed);
+    // Stamp the heartbeat before the first tick, so a refresh one second from
+    // now reads a live app rather than an absence.
+    saveSeen(t);
+    lastSeen.current = t;
     setDueAt(armed.at);
-    setNow(Date.now());
+    setNow(t);
   }, [on, every]);
 
   // 1 Hz while reminders are on — cheap, and it is what keeps the away-time
-  // on the card honest without a second timer.
+  // on the card honest without a second timer. It carries the heartbeat too,
+  // so there is still only the one interval.
   useEffect(() => {
     if (!on) return;
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    const id = window.setInterval(() => {
+      const t = Date.now();
+      // A gap here is the machine having slept (or this tab having been frozen)
+      // with the app open — the one case no page load will ever notice, and the
+      // one that produced a card sitting there counting up all night. Time the
+      // app was not running is time away from the desk, which IS the break, so
+      // the interval starts over. If the card was up, this takes it down: the
+      // break it was asking for has been had.
+      if (wasAway(t, lastSeen.current)) {
+        const armed = armBreak(t, every);
+        saveArm(armed);
+        setDueAt(armed.at);
+      }
+      // Written every SEEN_EVERY_MS rather than every tick: one number, but a
+      // localStorage write is a disk write, and 1 Hz of them buys nothing that
+      // a coarser stamp does not (the away rule's tolerance is minutes).
+      if (t - lastSeen.current >= SEEN_EVERY_MS) {
+        saveSeen(t);
+        lastSeen.current = t;
+      }
+      setNow(t);
+    }, 1000);
     return () => window.clearInterval(id);
-  }, [on]);
+  }, [on, every]);
 
   useEffect(() => () => window.clearTimeout(exitTimer.current), []);
 
@@ -238,7 +282,7 @@ function BreakScreen({ away, leaving, flockRef, onSnooze, onResume }: ScreenProp
             disabled={leaving}
             onClick={onResume}
           >
-            Resumed work
+            Resume Working
           </button>
         </div>
       </div>

--- a/frontend/src/components/settings/screens/General.tsx
+++ b/frontend/src/components/settings/screens/General.tsx
@@ -181,7 +181,7 @@ function ReduceMotionRow() {
 }
 
 /** Take a break: a reminder on a timer, with the flock from mindflock.ai flying
- * over your grid. Snooze pushes it back five minutes; "Resumed work" restarts
+ * over your grid. Snooze pushes it back five minutes; "Resume Working" restarts
  * the full interval. Off by default — an app that interrupts you uninvited is a
  * worse app.
  *

--- a/frontend/src/components/sidebar/ordering.ts
+++ b/frontend/src/components/sidebar/ordering.ts
@@ -100,10 +100,18 @@ export function attentionItems(instances: Instance[]): AttentionItem[] {
       items.push({ p: 3, title: inst.title, reason: "pushed — ready for PR" });
     else if (act === "idle" && Number(inst.activity_since) > 0) {
       // Wedged-session watchdog: calm-looking but sitting on unfinished work.
+      //
+      // This branch had never once rendered: `activity_since` read a key nothing
+      // wrote, so it was 0 for every session and the condition was dead. Now that
+      // it is populated, "unfinished" has to mean what the row says. A COMMITTED
+      // branch is not unfinished work — git considers it done and the header is
+      // simply asking you to push — and counting it flagged every session anyone
+      // had committed and walked away from as "possibly stuck", on the bell's
+      // attention badge. Uncommitted output with nobody typing is the real
+      // signal: an agent stopped in the middle of something.
       const idleFor = Date.now() / 1000 - Number(inst.activity_since);
       const un = (inst.diff_stat || ({} as never))?.uncommitted || ({} as { additions?: number; deletions?: number });
-      const unfinished =
-        (Number(un.additions) || 0) + (Number(un.deletions) || 0) > 0 || inst.stage === "committed";
+      const unfinished = (Number(un.additions) || 0) + (Number(un.deletions) || 0) > 0;
       if (idleFor > WEDGE_IDLE_S && unfinished)
         items.push({
           p: 1,

--- a/frontend/src/lib/breakTimer.ts
+++ b/frontend/src/lib/breakTimer.ts
@@ -10,6 +10,18 @@
  *     forever;
  *   - the user changed the interval in Settings → re-arm from now, because a
  *     deadline measured against the old interval means nothing.
+ *
+ * THE CLOCK ONLY RUNS WHILE THE APP DOES. A deadline is wall-clock, so on its
+ * own it keeps counting through a shut-down machine, a closed window and a
+ * slept laptop — and whoever comes back in the morning is met by a card that
+ * claims they have been at the desk for nine hours. They have not: time away
+ * from the app is time away from the desk, which is the break itself. So the
+ * app records that it is running (:data:`BREAK_SEEN_KEY`, a heartbeat), and a
+ * gap in that record re-arms the interval from now instead of resuming it.
+ *
+ * That is deliberately NOT the same as a refresh, which the rules above still
+ * refuse to let you dodge a break with: a reload lands seconds after the last
+ * heartbeat, a reopened app lands minutes or hours after it.
  */
 
 export const BREAK_MIN_MINUTES = 5;
@@ -27,6 +39,17 @@ export const IDLE_MAX_MINUTES = 480;
 export const IDLE_DEFAULT_MINUTES = 10;
 
 export const BREAK_ARM_KEY = "mf_break_due";
+/** Last time the app was known to be running — the heartbeat the away-rule
+ * reads. Its own key rather than a field on the arm: it is written every few
+ * seconds and the arm is not, and a stored deadline must stay readable even if
+ * this one is missing (an older build, cleared storage, a first run). */
+export const BREAK_SEEN_KEY = "mf_break_seen";
+
+/** How long the heartbeat can go silent before the app is assumed to have
+ * stopped counting. Comfortably longer than a hidden tab's throttled timer
+ * (browsers slow a background interval to about one tick a minute, which must
+ * not read as "away") and comfortably shorter than any real absence. */
+export const AWAY_GAP_MS = 5 * 60_000;
 
 export interface BreakArm {
   /** Epoch ms at which the break screen is due. */
@@ -93,6 +116,71 @@ export function nextArm(now: number, everyMin: number, saved: BreakArm | null): 
   return armBreak(now, every);
 }
 
+/** Was the app not running when it should have been counting?
+ *
+ * True for a heartbeat that is missing (nothing has ever run, or storage was
+ * cleared), older than {@link AWAY_GAP_MS}, or in the FUTURE — a clock that
+ * jumped backwards leaves a stamp no elapsed time can explain, and re-arming is
+ * the safe answer to "I cannot tell how long that was".
+ */
+export function wasAway(now: number, seen: number | null | undefined): boolean {
+  if (seen === null || seen === undefined || !isFinite(seen)) return true;
+  const gap = now - seen;
+  return gap < 0 || gap > AWAY_GAP_MS;
+}
+
+/** The clock a freshly loaded page should start with.
+ *
+ * One rule table, because the three ways a page can arrive want three different
+ * answers and only the middle one is obvious:
+ *
+ *   - **The app opened** (the shell launched, or a new tab): a fresh interval.
+ *     Opening MindFlock is the moment the countdown starts — you have just sat
+ *     down, whatever the deadline left behind by yesterday says.
+ *   - **The page reloaded after the app had stopped** (closed for an hour, or a
+ *     slept machine woken and refreshed): also fresh, for the same reason. The
+ *     heartbeat is what tells these apart from…
+ *   - **…a reload mid-countdown** — keep the deadline. This is the case the
+ *     stored arm exists for: a refresh, a server restart or a crash must not
+ *     buy anyone a new hour ({@link nextArm} owns the rest of that rule).
+ */
+export function openArm(
+  now: number,
+  everyMin: number,
+  saved: BreakArm | null,
+  seen: number | null | undefined,
+  reloaded: boolean
+): BreakArm {
+  const every = clampBreakMinutes(everyMin);
+  if (!reloaded) return armBreak(now, every);
+  if (wasAway(now, seen)) return armBreak(now, every);
+  return nextArm(now, every, saved);
+}
+
+/** Did this page arrive by refresh rather than by the app opening?
+ *
+ * The Navigation Timing entry answers it directly: `reload` covers F5, Ctrl+R,
+ * the palette's Reload, `location.reload()` from the API client on a lost
+ * session, and the reload every tab does when the server restarts — every path
+ * the anti-dodge rule was written for. A shell launch, a new tab and a
+ * `loadURL()` are `navigate`, which is the app opening.
+ *
+ * Unreadable (an old browser, a stripped Performance API) answers `true`: the
+ * conservative half is to keep the existing deadline, since the worst outcome
+ * is being asked to take a break slightly early.
+ */
+export function wasReload(): boolean {
+  try {
+    const nav = performance.getEntriesByType("navigation")[0] as
+      | PerformanceNavigationTiming
+      | undefined;
+    if (!nav || typeof nav.type !== "string") return true;
+    return nav.type === "reload";
+  } catch {
+    return true;
+  }
+}
+
 /** m:ss for the "you've been away N" line on the break screen. */
 export function fmtElapsed(ms: number): string {
   const total = Math.max(0, Math.floor(ms / 1000));
@@ -110,6 +198,26 @@ export function loadArm(): BreakArm | null {
     return v;
   } catch {
     return null;
+  }
+}
+
+export function loadSeen(): number | null {
+  try {
+    const raw = localStorage.getItem(BREAK_SEEN_KEY);
+    if (!raw) return null;
+    const n = Number(raw);
+    return isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSeen(now: number) {
+  try {
+    localStorage.setItem(BREAK_SEEN_KEY, String(now));
+  } catch {
+    /* storage unavailable — every load then reads as "away", which re-arms:
+       the same answer this whole rule gives when it cannot tell. */
   }
 }
 

--- a/tests/unit/test_activity_markers.py
+++ b/tests/unit/test_activity_markers.py
@@ -23,6 +23,7 @@ import pytest
 
 from backend.providers import activity_markers as am
 from backend.providers import thread_markers
+from backend.web.core import agent_state
 
 
 @pytest.fixture
@@ -199,3 +200,108 @@ def test_merge_tolerates_corrupt_settings(tmp_path, marker_dir):
     am.merge_activity_hooks(path, _EVENTS, "sess")
     data = json.loads(path.read_text())  # rewritten as valid JSON with our hooks
     assert _tagged(data["hooks"]["Stop"])
+
+
+# --------------------------------------------------------------------------- #
+# A marker belongs to a tmux INCARNATION
+# --------------------------------------------------------------------------- #
+# The marker file is keyed by tmux session name, nothing ever deletes it
+# (`_ensure_agent_session` clears the exit marker and the thread marker, never
+# this one), no provider maps a session-START event to a state, and it only
+# expires after six hours. So re-opening a window that had finished cleanly used
+# to report the DEAD run's "idle" for the seconds the new CLI took to boot —
+# announcing a turn that ended before the session existed.
+#
+# The fix is a provenance check, not an age check: an idle marker is still
+# trusted at any age, as long as it was written by the tmux session that is
+# running now.
+class _MarkerAgeProvider:
+    """A CLI whose hook marker was written ``age`` seconds ago."""
+
+    def __init__(self, age):
+        self._age = age
+
+    def activity_state_age(self, name):
+        return self._age
+
+
+@pytest.fixture()
+def at_now(monkeypatch):
+    """Pin the wall clock ``_marker_is_current`` samples for itself."""
+
+    def _set(t):
+        monkeypatch.setattr(agent_state.time, "time", lambda: t)
+
+    return _set
+
+
+def test_marker_from_this_incarnation_is_current(at_now):
+    # created at t=1000, marker written 30s ago, now t=1100 -> written at 1070,
+    # comfortably after the session started.
+    at_now(1100.0)
+    assert agent_state._marker_is_current(_MarkerAgeProvider(30.0), "s", 1000.0)
+
+
+def test_an_hours_old_marker_on_a_long_lived_session_is_still_current(at_now):
+    # "Trust at any age" has to survive: a Stop hook from two hours ago on a CLI
+    # that has been up all day is genuinely idle.
+    at_now(100000.0)
+    assert agent_state._marker_is_current(_MarkerAgeProvider(7200.0), "s", 1000.0)
+
+
+def test_a_marker_predating_the_tmux_session_is_not_current(at_now):
+    # Session created at t=5000; the marker was written 100s before now=5050,
+    # i.e. at t=4950 — by the run that used to hold this name.
+    at_now(5050.0)
+    assert not agent_state._marker_is_current(_MarkerAgeProvider(100.0), "s", 5000.0)
+
+
+def test_a_live_realtime_signal_always_passes(at_now):
+    # Claude's `agents --json` path reports age 0.0 — real-time by construction,
+    # so it can never predate anything.
+    at_now(5000.0)
+    assert agent_state._marker_is_current(_MarkerAgeProvider(0.0), "s", 5000.0)
+
+
+def test_unknowable_inputs_keep_the_old_behaviour(at_now):
+    # No creation stamp or no marker age means there is nothing to compare, and
+    # the long-standing behaviour is to trust the CLI's own report.
+    at_now(1100.0)
+    assert agent_state._marker_is_current(_MarkerAgeProvider(None), "s", 1000.0)
+    assert agent_state._marker_is_current(_MarkerAgeProvider(30.0), "s", None)
+
+
+def test_the_clock_is_sampled_at_comparison_time(at_now):
+    # The caller's `now` predates the probes between it and this call (a pane
+    # capture, a `claude agents --json` shell-out). Subtracting a freshly
+    # measured age from a stale `now` places the write earlier than it happened
+    # and would reject the FIRST marker of a genuinely fresh session — the one
+    # window the guard was written for. So the clock is read here.
+    at_now(5004.5)  # a poll that began at 5003 and spent 1.5s in probes
+    # Session created at 5000, its first hook fired at 5001 -> age 3.5s.
+    assert agent_state._marker_is_current(_MarkerAgeProvider(3.5), "s", 5000.0)
+
+
+def test_an_unreadable_age_keeps_the_old_behaviour(at_now, monkeypatch):
+    # A provider whose age probe THROWS (a stat on a file that vanished between
+    # the read and the stat, a provider that never implemented it) is the same
+    # situation as one that answers None: no evidence either way, so the CLI's
+    # own report stands. Failing the other way would blank the reading of every
+    # provider with a rough edge in a helper that exists to police one bug.
+    class _Boom:
+        def activity_state_age(self, name):
+            raise OSError("marker vanished")
+
+    at_now(5050.0)
+    assert agent_state._marker_is_current(_Boom(), "s", 5000.0)
+
+
+def test_a_marker_written_in_the_same_instant_counts_as_current(at_now):
+    # The comparison is >=, not >. A hook that fires as part of session startup
+    # writes its marker at (or within a rounding error of) `created`, and
+    # rejecting that would blank the first real reading of every session that
+    # starts fast — the opposite of what the guard is for.
+    at_now(5030.0)
+    assert agent_state._marker_is_current(_MarkerAgeProvider(30.0), "s", 5000.0)
+    # One hundredth of a second the other way is a previous run, and is not.
+    assert not agent_state._marker_is_current(_MarkerAgeProvider(30.01), "s", 5000.0)

--- a/tests/unit/test_activity_resize.py
+++ b/tests/unit/test_activity_resize.py
@@ -248,3 +248,36 @@ def test_permission_prompt_is_not_trust_dismissed(monkeypatch):
     inst, sent, clock = _young_gate_harness(monkeypatch, perm)
     server._agent_activity(inst, "t")
     assert not any("send-keys" in " ".join(a) for a in sent)
+
+
+def test_the_record_survives_an_offline_poll_so_a_resize_still_rebaselines(
+    monkeypatch, harness
+):
+    """The offline poll used to POP the record, which quietly disarmed this
+    whole guard.
+
+    "Clicking a tab must not read as activity" is enforced by comparing the new
+    pane size against the remembered one — and that can only protect a record
+    that still exists. The sequence the user actually performs (a session whose
+    tmux blinked out, clicked to bring it back, which attaches a terminal and
+    resizes the pane) was exactly the one that arrived with nothing remembered
+    and fell into the first-sighting branch.
+    """
+    inst, pane, clock = harness
+    _seed_idle(clock)
+    clock["t"] += 4
+    pane["cpu"] = 400  # a real burst -> working, which is what must survive
+    assert server._agent_activity(inst, "t") == "working"
+
+    dead = types.SimpleNamespace(returncode=1, stdout=b"")
+    live_run = server.subprocess.run  # the harness's tmux stand-in
+    monkeypatch.setattr(server.subprocess, "run", lambda *a, **k: dead)
+    clock["t"] += 4
+    assert server._agent_activity(inst, "t") == "offline"
+    assert "t" in server._ACTIVITY_CACHE, "an absent reading is not an erased history"
+
+    monkeypatch.setattr(server.subprocess, "run", live_run)
+    clock["t"] += 4
+    pane["size"] = "120x30"  # the tab attaching, reflowing the pane
+    pane["text"] = "l1 l2\nl3 l4\nl5 l6\nx\ny\nz\n"
+    assert server._agent_activity(inst, "t") == "working"

--- a/tests/unit/test_addons.py
+++ b/tests/unit/test_addons.py
@@ -187,9 +187,13 @@ def test_notify_default_on_and_opt_in_rules():
     assert rules["needs_input"]["enabled"] is True
     assert rules["session_idle"]["enabled"] is False
     assert rules["precommit_running"]["enabled"] is False
-    # The idle rule fires on activity → idle; pre-commit on stage → precommit.
-    assert rules["session_idle"]["event"] == "session.activity_changed"
-    assert rules["session_idle"]["new"] == "idle"
+    # The idle rule fires on a real turn boundary — NOT on the raw activity
+    # flip, which is a chip colour that changes at the end of every turn;
+    # pre-commit fires on stage → precommit.
+    assert rules["session_idle"]["event"] == "session.turn_ended"
+    # The event IS the whole condition — turn_ended is only ever emitted when
+    # it is true — so the rule constrains neither old nor new.
+    assert rules["session_idle"]["new"] is None
     assert rules["precommit_running"]["new"] == "precommit"
     # Pre-commit failure is default-on and fires on stage → interrupt.
     assert rules["precommit_failed"]["enabled"] is True

--- a/tests/unit/test_cursor_window.py
+++ b/tests/unit/test_cursor_window.py
@@ -618,11 +618,13 @@ def test_agent_activity_offline_when_capture_fails(monkeypatch):
 def test_agent_activity_clarify_on_waiting_prompt_needs_stable_pane(monkeypatch):
     # A numbered selection cursor "❯ 1." is claude's waiting-prompt signal, but
     # it is only trusted once the pane has been STABLE for a poll — the first
-    # sighting (pane just changed) must not read as clarify (A3).
+    # sighting (pane just changed) must not read as clarify (A3). One frame
+    # cannot establish stability, so the first sighting reports the quiet
+    # verdict, 'idle', and never a guess.
     pane = _tall("Some output\n❯ 1. Yes\n  2. No")
     monkeypatch.setattr(server.subprocess, "run", _fake_tmux(pane))
     inst = _FakeInst(program="claude")
-    assert server._agent_activity(inst, "mysess") == "working"
+    assert server._agent_activity(inst, "mysess") == "idle"
     assert server._agent_activity(inst, "mysess") == "clarify"
 
 
@@ -630,19 +632,20 @@ def test_agent_activity_clarify_on_phrase_pattern(monkeypatch):
     pane = _tall("Do you want to proceed?\nNo, and tell Claude what to do differently")
     monkeypatch.setattr(server.subprocess, "run", _fake_tmux(pane))
     inst = _FakeInst(program="claude")
-    assert server._agent_activity(inst, "mysess") == "working"  # first sight
+    assert server._agent_activity(inst, "mysess") == "idle"  # first sight
     assert server._agent_activity(inst, "mysess") == "clarify"  # stable pane
 
 
 def test_agent_activity_limit_on_usage_limit_banner(monkeypatch):
     # A usage-limit SCREEN is reported as its own 'limit' state, outranking the
-    # '❯ 1.' selection menu a limit screen also shows. Like clarify, it needs a
-    # STABLE pane first (so a genuinely working turn / scrolling output is never
-    # misread), so the first sighting is 'working' and the stable poll is 'limit'.
+    # '❯ 1.' selection menu a limit screen also shows. Unlike clarify it does
+    # NOT need a stable pane: the banner is a single-frame fact and
+    # `is_limit_screen` is the high-precision match, so it is one of the two
+    # verdicts a first sighting is allowed to reach.
     pane = _tall("Claude usage limit reached · resets 3am\n❯ 1. Wait\n  2. Switch")
     monkeypatch.setattr(server.subprocess, "run", _fake_tmux(pane))
     inst = _FakeInst(program="claude")
-    assert server._agent_activity(inst, "mysess") == "working"  # first sight
+    assert server._agent_activity(inst, "mysess") == "limit"  # first sight
     assert server._agent_activity(inst, "mysess") == "limit"  # stable pane
 
 
@@ -662,32 +665,61 @@ def test_agent_activity_not_limit_on_stray_rate_limit_text(monkeypatch):
 
 def test_agent_activity_no_clarify_while_pane_scrolls(monkeypatch):
     # A numbered list scrolling by mid-generation contains "❯ 1." but the pane
-    # keeps changing -> never clarify, stays working.
+    # keeps changing -> never clarify. With no /proc CPU to read (this mock has
+    # no pane pid) the hash fallback needs _ACTIVITY_CONFIRM_POLLS changed polls
+    # before it will say "working", so the run reads idle, idle, working,
+    # working — the point being that no frame is ever mistaken for a question.
     frames = iter([_tall("❯ 1. option\nframe-%d" % i) for i in range(5)])
     monkeypatch.setattr(server.subprocess, "run", _fake_tmux(lambda: next(frames)))
     inst = _FakeInst(program="claude")
-    for _ in range(4):
-        assert server._agent_activity(inst, "scrolls") == "working"
+    seen = [server._agent_activity(inst, "scrolls") for _ in range(4)]
+    assert "clarify" not in seen
+    assert seen[-1] == "working"
 
 
-def test_agent_activity_working_on_first_capture(monkeypatch):
-    # No waiting prompt + not seen before -> "working" (pane just observed).
+def test_agent_activity_idle_on_first_capture_of_a_quiet_pane(monkeypatch):
+    # A pane never seen before, showing neither a limit banner nor the
+    # provider's interrupt hint, is reported IDLE. It used to be reported
+    # "working" on the theory that a fresh agent usually is — the phantom
+    # behind "I click an offline session and it goes running and then idle",
+    # since the record is rebuilt from scratch every time a session's tmux
+    # comes back. Nothing about this frame says work is happening, so nothing
+    # claims it is.
     monkeypatch.setattr(
         server.subprocess, "run", _fake_tmux(_tall("streaming tokens..."))
     )
     inst = _FakeInst(program="claude")
-    assert server._agent_activity(inst, "sess-A") == "working"
+    assert server._agent_activity(inst, "sess-A") == "idle"
     # Cache recorded the observation.
     assert "sess-A" in server._ACTIVITY_CACHE
+    # …and recorded that no work has been witnessed, so nothing downstream can
+    # claim a turn ended here (server._note_turn_boundary).
+    assert server._agent_state.worked_at("sess-A") is None
+
+
+def test_agent_activity_working_on_first_capture_with_interrupt_hint(monkeypatch):
+    # The other half: an interrupt hint IS single-frame proof of a live turn,
+    # so a first sighting may reach "working" — and stamps the work evidence.
+    monkeypatch.setattr(
+        server.subprocess, "run", _fake_tmux(_tall("⠋ Thinking… (esc to interrupt)"))
+    )
+    inst = _FakeInst(program="claude")
+    assert server._agent_activity(inst, "sess-A2") == "working"
+    assert server._agent_state.worked_at("sess-A2") is not None
 
 
 def test_agent_activity_working_when_pane_changes(monkeypatch):
     inst = _FakeInst(program="claude")
     state = {"pane": _tall("frame-1")}
     monkeypatch.setattr(server.subprocess, "run", _fake_tmux(lambda: state["pane"]))
-    assert server._agent_activity(inst, "sess-B") == "working"
-    # A different pane hash -> still "working" (working is sticky on change).
+    assert server._agent_activity(inst, "sess-B") == "idle"  # quiet first frame
+    # A changing pane flips to working after _ACTIVITY_CONFIRM_POLLS changed
+    # polls, and is sticky from there.
     state["pane"] = _tall("frame-2")
+    assert server._agent_activity(inst, "sess-B") == "idle"  # 1 change
+    state["pane"] = _tall("frame-3")
+    assert server._agent_activity(inst, "sess-B") == "working"  # 2 changes
+    state["pane"] = _tall("frame-4")
     assert server._agent_activity(inst, "sess-B") == "working"
 
 
@@ -700,12 +732,11 @@ def test_agent_activity_idle_when_static_beyond_threshold(monkeypatch):
     clock = {"t": 1000.0}
     monkeypatch.setattr(server.time, "time", lambda: clock["t"])
 
-    # First observation: working, timer starts at t=1000.
-    assert server._agent_activity(inst, "sess-C") == "working"
-    # Same pane, but less than idle-after later -> still working.
+    # A static screen with no proof of work reads idle from the first frame and
+    # stays there — there is no phantom "working" to wait out any more.
+    assert server._agent_activity(inst, "sess-C") == "idle"
     clock["t"] = 1000.0 + server._ACTIVITY_IDLE_AFTER - 0.5
-    assert server._agent_activity(inst, "sess-C") == "working"
-    # Same pane, now beyond the idle threshold -> idle.
+    assert server._agent_activity(inst, "sess-C") == "idle"
     clock["t"] = 1000.0 + server._ACTIVITY_IDLE_AFTER + 0.1
     assert server._agent_activity(inst, "sess-C") == "idle"
 
@@ -719,7 +750,7 @@ def test_agent_activity_single_changed_frame_keeps_idle(monkeypatch):
     clock = {"t": 1000.0}
     monkeypatch.setattr(server.time, "time", lambda: clock["t"])
 
-    server._agent_activity(inst, "sess-D")  # seed (working)
+    server._agent_activity(inst, "sess-D")  # seed (idle: a quiet first frame)
     clock["t"] += server._ACTIVITY_IDLE_AFTER + 1
     assert server._agent_activity(inst, "sess-D") == "idle"  # settled idle
     state["pane"] = _tall("screen-b")
@@ -743,7 +774,7 @@ def test_agent_activity_bottom_line_churn_is_ignored(monkeypatch):
     monkeypatch.setattr(server.subprocess, "run", _fake_tmux(pane))
     clock = {"t": 1000.0}
     monkeypatch.setattr(server.time, "time", lambda: clock["t"])
-    assert server._agent_activity(inst, "sess-E") == "working"  # seed
+    assert server._agent_activity(inst, "sess-E") == "idle"  # seed
     clock["t"] += server._ACTIVITY_IDLE_AFTER + 1
     assert server._agent_activity(inst, "sess-E") == "idle"
     clock["t"] += 4
@@ -789,7 +820,7 @@ def test_agent_activity_climbing_token_counter_is_working(monkeypatch):
     monkeypatch.setattr(server.subprocess, "run", _fake_tmux(pane))
     clock = {"t": 1000.0}
     monkeypatch.setattr(server.time, "time", lambda: clock["t"])
-    assert server._agent_activity(inst, "sess-tok") == "working"  # seed (5.0k)
+    assert server._agent_activity(inst, "sess-tok") == "idle"  # seed (5.0k)
     # Counter flat past the idle window -> idle (climb is the signal, not mere
     # presence of a number).
     clock["t"] += server._ACTIVITY_IDLE_AFTER + 2
@@ -819,6 +850,149 @@ def test_agent_activity_waiting_prompt_beats_stale_interrupt_hint(monkeypatch):
     assert server._agent_activity(inst, "sess-clar") == "working"  # seed
     # Stable pane on the next poll -> the waiting prompt wins over the hint.
     assert server._agent_activity(inst, "sess-clar") == "clarify"
+
+
+class _MarkedProvider:
+    """A CLI reporting through its hook marker, with a controllable age."""
+
+    def __init__(self, state, age):
+        self.state, self.age = state, age
+
+    def activity_state(self, name):
+        return self.state
+
+    def activity_state_age(self, name):
+        return self.age
+
+    def record_thread(self, *a, **k):
+        return None
+
+    def waiting_prompt_patterns(self):
+        return []
+
+    def working_pane_patterns(self):
+        return (r"esc to interrupt",)  # Claude's own, so the pane can speak
+
+    def progress_token_pattern(self):
+        return None
+
+
+def test_idle_marker_from_a_previous_incarnation_is_ignored(monkeypatch):
+    # Re-opening a window relaunches its CLI (`_ensure_agent_session`), and the
+    # activity marker — keyed by tmux session name, cleared by nobody, good for
+    # six hours — still holds the DEAD run's "idle". Trusting it announced a
+    # turn that had ended before this session existed. tmux's own
+    # `session_created` retires it.
+    monkeypatch.setattr(server.time, "time", lambda: 1000.0)
+    # tmux session created at t=100; the marker was written 950s ago, i.e. at
+    # t=50 — half a minute before this incarnation started.
+    monkeypatch.setattr(
+        server.providers, "resolve", lambda prog: _MarkedProvider("idle", 950.0)
+    )
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        _fake_tmux(_tall("⠋ Thinking… (esc to interrupt)"), created=100.0),
+    )
+    inst = _FakeInst(program="claude")
+    # Layer 1 declines, so the live pane decides — and the pane says a turn is
+    # running right now.
+    assert server._agent_activity(inst, "sess-reborn") == "working"
+
+
+def test_idle_marker_from_this_incarnation_is_still_trusted_at_any_age(monkeypatch):
+    # The property the guard must not break: a Stop hook from an hour ago on a
+    # CLI that has been up all day is genuinely idle, whatever the pane shows.
+    monkeypatch.setattr(server.time, "time", lambda: 100000.0)
+    monkeypatch.setattr(
+        server.providers, "resolve", lambda prog: _MarkedProvider("idle", 3600.0)
+    )
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        _fake_tmux(_tall("⠋ Thinking… (esc to interrupt)"), created=100.0),
+    )
+    inst = _FakeInst(program="claude")
+    assert server._agent_activity(inst, "sess-oldbutmine") == "idle"
+
+
+class _PatternlessProvider(_MarkedProvider):
+    """A CLI that declares no working_pane_patterns — the common shape of a
+    provider nobody has configured in Settings → Providers."""
+
+    def __init__(self):
+        super().__init__(None, None)
+
+    def working_pane_patterns(self):
+        return ()
+
+
+def test_a_provider_with_no_working_patterns_reads_idle_on_a_first_sighting(
+    monkeypatch,
+):
+    """The load-bearing consequence of dropping the first-sighting guess.
+
+    Two of the four work signals need two samples (a CPU rate, a climbing token
+    counter), so on frame one only the limit banner and the provider's own
+    interrupt hint can speak. A provider that declares no interrupt hint has
+    nothing to say — and reads idle on a pane that is, for all this frame
+    proves, parked. That is the correct answer and also the whole reason
+    working_patterns is now worth configuring: for the queue, `_QUEUE_BOOT_GRACE`
+    is what covers the gap.
+    """
+    monkeypatch.setattr(
+        server.providers, "resolve", lambda prog: _PatternlessProvider()
+    )
+    # The very text Claude's own pattern would have caught.
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        _fake_tmux(_tall("⠋ Thinking… (esc to interrupt)")),
+    )
+    inst = _FakeInst(program="whatever")
+    assert server._agent_activity(inst, "sess-nopat") == "idle"
+    assert server._agent_state.worked_at("sess-nopat") is None
+
+
+def test_a_quiet_first_sighting_never_decays_into_a_working_idle_pair(monkeypatch):
+    """A first sighting with no proof of work leaves ``busy_at`` UNSET.
+
+    The hysteresis further down reads ``rec["busy_at"] or rec["changed"] or
+    now``. Seeding busy_at with "now" instead would have started an idle-settle
+    clock on a session nobody had seen work — reporting working for
+    _ACTIVITY_IDLE_AFTER seconds and then idle, which is precisely the
+    working->idle pair the notification layer must never be handed.
+    """
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "time", lambda: clock["t"])
+    monkeypatch.setattr(server.subprocess, "run", _fake_tmux(_tall("$ ")))
+    inst = _FakeInst(program="claude")
+    assert server._agent_activity(inst, "sess-quiet") == "idle"
+    assert server._ACTIVITY_CACHE["sess-quiet"]["busy_at"] is None
+    # Poll it for a minute: same pane, nothing to report, nothing reported.
+    for _ in range(15):
+        clock["t"] += 4
+        assert server._agent_activity(inst, "sess-quiet") == "idle"
+    assert server._agent_state.worked_at("sess-quiet") is None
+
+
+def test_a_first_sighting_of_a_limit_screen_is_reported_as_limit(monkeypatch):
+    """The single-frame verdict that is NOT idle, on the layer below the hook
+    marker: a reopened window parked on its cap must say so at once, because
+    `usage_limit` is a default-ON rule and the answer "idle" would instead let
+    the turn-end machinery arm on a run the cap had cut short."""
+    monkeypatch.setattr(
+        server.providers, "resolve", lambda prog: _PatternlessProvider()
+    )
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        _fake_tmux(_tall("Claude usage limit reached · resets 3am")),
+    )
+    inst = _FakeInst(program="whatever")
+    assert server._agent_activity(inst, "sess-cap") == "limit"
+    # And a limit is not work: nothing to announce the end of.
+    assert server._agent_state.worked_at("sess-cap") is None
 
 
 def test_agent_activity_exit_marker_wins(monkeypatch):
@@ -887,7 +1061,8 @@ _PS_SHELLS_ONLY = "  100     1 systemd\n 4242  4000 bash\n 4250  4242 sh\n"
 
 def test_agent_activity_wrapper_shell_with_claude_child_not_idle(monkeypatch):
     # fg is bash (the launcher wrapper) but claude is alive underneath -> falls
-    # through to pane inspection (first sighting => working), NOT idle.
+    # through to pane inspection, which sees the interrupt hint => working,
+    # NOT the bare-shell "idle" Layer 2 would have returned.
     monkeypatch.setattr(
         server.subprocess,
         "run",
@@ -910,7 +1085,7 @@ def test_agent_activity_wrapper_shell_clarify_flows_through(monkeypatch):
         _fake_tmux(pane, fg="bash", pid="4242", ps=_PS_WITH_CLAUDE),
     )
     inst = _FakeInst(program="claude")
-    assert server._agent_activity(inst, "sess-wrap2") == "working"  # first sight
+    assert server._agent_activity(inst, "sess-wrap2") == "idle"  # first sight
     server._PID_TREE_CACHE.clear()
     assert server._agent_activity(inst, "sess-wrap2") == "clarify"  # stable pane
 

--- a/tests/unit/test_dev_toast_identity.py
+++ b/tests/unit/test_dev_toast_identity.py
@@ -1,0 +1,113 @@
+"""The dev shell's notifications are headed by a NAME, not by its AUMID.
+
+Windows heads a toast with the display name of the Start-menu shortcut
+registered for the AppUserModelID that raised it. The packaged app gets one from
+its NSIS installer, which is why prod notifications read "MindFlock". Dev sets an
+AUMID of its own (a separate taskbar group and icon) and nothing ever wrote a
+shortcut for it, so Windows fell back to printing the raw id and every dev
+notification was headed ``ai.mindflock.desktop.dev``.
+
+``electron/main.js`` now writes that shortcut itself. Nothing here can watch a
+real toast, so what is pinned is the wiring that decides what one says: the name,
+the id it is registered against, and the two properties that make the shortcut
+work as a launcher rather than a decoy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_MAIN_JS = Path(__file__).resolve().parents[2] / "electron" / "main.js"
+
+
+def _js() -> str:
+    return _MAIN_JS.read_text(encoding="utf-8")
+
+
+def _fn(js: str) -> str:
+    """Just the body of ``ensureDevToastName``, so an assertion about it cannot
+    be satisfied by a coincidence elsewhere in a 1600-line main.js."""
+    fn = js[js.index("function ensureDevToastName") :]
+    return fn[: fn.index("\n}\n")]
+
+
+def test_the_name_windows_prints_is_prod_s_plus_a_suffix():
+    """ "Like prod, with -dev at the end" is the whole requirement."""
+    js = _js()
+    assert "const DEV_TOAST_NAME = 'MindFlock-dev'" in js
+    # The .lnk is named after it, because the FILENAME is what Windows shows.
+    assert "DEV_TOAST_NAME + '.lnk'" in js
+
+
+def test_the_shortcut_is_registered_against_the_dev_aumid():
+    """A shortcut carrying any other id names nothing: the toast is attributed
+    by the AUMID the process set on itself, so the two must be one constant."""
+    js = _js()
+    assert "const DEV_AUMID = 'ai.mindflock.desktop.dev'" in js
+    assert "app.setAppUserModelId(DEV_AUMID)" in js
+    fn = _fn(js)
+    assert "appUserModelId: DEV_AUMID" in fn
+
+
+def test_it_lands_in_the_start_menu_and_targets_the_exe():
+    """Windows only resolves the name from a Start-menu shortcut, and it must
+    target electron.exe directly — a .bat would attribute icon and identity to
+    cmd.exe (the same reason the README's pin-to-taskbar recipe says so)."""
+    fn = _fn(_js())
+    assert "'Start Menu', 'Programs'" in fn
+    assert "target: process.execPath" in fn
+    assert "--mindflock-dev" in fn, "the shortcut must launch a DEV shell, not prod"
+
+
+def test_prod_and_every_other_platform_are_untouched():
+    """Prod already has the installer's shortcut, and no other OS resolves
+    notification identity this way — so the whole thing is inert elsewhere."""
+    fn = _fn(_js())
+    assert "if (!DEV || process.platform !== 'win32') return" in fn
+
+
+def test_a_locked_down_start_menu_cannot_stop_the_app():
+    """It is a label. Policy can forbid writing there, and a dev run that
+    refused to start over a cosmetic .lnk would be a far worse bug."""
+    fn = _fn(_js())
+    assert "try {" in fn and "catch (e)" in fn
+
+
+def test_the_shortcut_is_not_rewritten_on_every_launch():
+    """Only when missing or drifted — an .lnk rewritten every start churns the
+    Start menu's index for nothing."""
+    fn = _fn(_js())
+    assert "readShortcutLink" in fn
+    assert "have.appUserModelId === want.appUserModelId" in fn
+
+
+def test_a_png_icon_override_does_not_become_a_broken_shortcut():
+    """``MINDFLOCK_DEV_ICON`` is shared with the window/dock icon, which takes a
+    .png happily. A shortcut's IconLocation does not: pointing one at a .png
+    yields a blank tile, which is worse than the exe's own icon. So the override
+    is used verbatim only when it is an .ico, and otherwise falls back."""
+    fn = _fn(_js())
+    assert "endsWith('.ico')" in fn
+    assert "? DEV_ICON : process.execPath" in fn
+
+
+def test_a_drifted_shortcut_is_rewritten_whichever_field_moved():
+    """ "Only when missing or stale" is only true if staleness is checked
+    against everything that can move. electron.exe relocates on an upgrade, the
+    app dir moves with a checkout, the icon override changes — each one alone
+    leaves a shortcut that names or launches the wrong thing."""
+    fn = _fn(_js())
+    for field in ("target", "args", "icon", "appUserModelId"):
+        assert "have.%s === want.%s" % (field, field) in fn, field
+    assert "writeShortcutLink(link, 'create', want)" in fn
+
+
+def test_it_runs_where_its_own_log_line_is_readable():
+    """A first dev run on a fresh machine is exactly when "did the shortcut get
+    written?" is worth knowing, and the answer only reaches main.log if the call
+    happens after the logger is up."""
+    js = _js()
+    ready = js[js.index("app.whenReady().then(") :]
+    ready = ready[: ready.index("startUpdateChecks()")]
+    assert "ensureDevToastName()" in ready
+    assert ready.index("logger.init") < ready.index("ensureDevToastName()")

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import stat
 import time
 
@@ -101,6 +102,7 @@ def test_event_names_vocabulary_is_complete():
         "session.prompt_sent",
         "session.queue_changed",
         "session.usage_restored",
+        "session.turn_ended",
         "session.autopilot_changed",
         "session.pushed",
         "session.test_plan_ready",
@@ -109,6 +111,29 @@ def test_event_names_vocabulary_is_complete():
         "session.test_plan_gave_up",
         "session.test_plan_due",
     }
+
+
+def test_the_turn_boundary_event_is_documented_for_extension_authors():
+    """``docs/extensions.md`` is the contract an addon/hook author codes
+    against, and this event exists precisely so nobody keys "the agent is done"
+    off the raw idle flip. A row nobody can find leaves them writing the bug
+    the event was added to fix, so the doc has to carry both halves: the
+    vocabulary row and the recipe that steers them away from the old signal.
+    """
+    from pathlib import Path
+
+    doc = (Path(__file__).resolve().parents[2] / "docs" / "extensions.md").read_text(
+        encoding="utf-8"
+    )
+    rows = [ln for ln in doc.splitlines() if ln.startswith("| `session.")]
+    documented = {
+        name for ln in rows for name in re.findall(r"`(session\.[a-z_]+)`", ln)
+    }
+    assert "session.turn_ended" in documented
+    assert "session.turn_ended" in EVENT_NAMES
+    # The recipe list, where "agent has finished" is spelled out — including
+    # which event it is NOT.
+    assert "**agent has finished**: `session.turn_ended`" in doc
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_frontend_breaks.py
+++ b/tests/unit/test_frontend_breaks.py
@@ -15,6 +15,7 @@ can do is pin the contract into the shipped bundle:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -42,10 +43,10 @@ def _css() -> str:
 def test_break_screen_ships_with_both_of_its_answers():
     js = _js()
     assert 'id: "break-screen"' in js or '"break-screen"' in js
-    # Snooze pushes it back; "Resumed work" restarts the whole interval. A
+    # Snooze pushes it back; "Resume Working" restarts the whole interval. A
     # break screen with only one way out is a trap, not a reminder.
     assert "Snooze 5 min" in js
-    assert "Resumed work" in js
+    assert "Resume Working" in js
 
 
 def test_break_settings_row_sits_in_general_with_an_interval():
@@ -56,6 +57,86 @@ def test_break_settings_row_sits_in_general_with_an_interval():
     # The two localStorage keys the setting persists under.
     assert "mf_break_on" in js
     assert "mf_break_every" in js
+
+
+def test_the_break_clock_only_runs_while_the_app_does():
+    """A deadline is wall-clock, so on its own it counts through a shut-down
+    machine and hands whoever opens the app in the morning a card that has been
+    "counting" all night. The heartbeat is what tells an absence from a refresh,
+    so both halves have to reach the bundle: the stamp, and the gap rule that
+    reads it — including the mid-run check, the only thing that notices a laptop
+    that slept with the window open."""
+    js = _js()
+    assert "mf_break_seen" in js
+    assert "wasAway" in js
+    # Mid-run, not only at mount: the tick re-arms and takes the stale card down.
+    tick = js[js.index("function Breaks(") : js.index("function Breaks(") + 4000]
+    assert "wasAway(" in tick, "a sleeping machine is only ever caught by the tick"
+
+
+def test_opening_the_app_starts_the_clock_but_a_refresh_does_not():
+    """The rule the whole thing turns on: an open is a fresh interval, a reload
+    keeps its deadline. They are told apart by navigation type rather than by
+    guesswork, so the literal the browser answers with has to be the one the
+    bundle compares against."""
+    js = _js()
+    assert (
+        'getEntriesByType("navigation")' in js or "getEntriesByType('navigation')" in js
+    )
+    at = js.index("function wasReload")
+    block = js[at : at + 500]
+    assert '"reload"' in block or "'reload'" in block
+
+
+def _bundled_const(js: str, name: str) -> float:
+    """The numeric value of a top-level ``const`` in the built bundle.
+
+    Read as a value rather than matched as a literal because the bundler
+    rewrites the source spelling: ``15_000`` ships as ``15e3`` and
+    ``5 * 60_000`` as ``5 * 6e4``. Both are valid Python arithmetic, and the
+    expression is checked to be nothing else before it is evaluated.
+    """
+    head = "const %s = " % name
+    at = js.index(head) + len(head)
+    expr = js[at : js.index(";", at)]
+    assert re.fullmatch(r"[\d.eE+*\s]+", expr), expr
+    return float(eval(expr, {"__builtins__": {}}))  # noqa: S307 — see above
+
+
+def test_the_heartbeat_is_written_coarsely_and_the_gap_is_measured_in_minutes():
+    """Two numbers hold the away rule up, and each fails a different way.
+
+    The stamp is a localStorage write, i.e. a disk write, so 1 Hz of them buys
+    nothing the away rule's minute-scale tolerance can use. The gap has to sit
+    ABOVE a hidden tab's throttled interval — browsers slow a background timer
+    to roughly one tick a minute, and a throttled tab is not an absent app —
+    and below any real absence.
+    """
+    js = _js()
+    assert _bundled_const(js, "SEEN_EVERY_MS") == 15_000
+    gap = _bundled_const(js, "AWAY_GAP_MS")
+    assert gap >= 2 * 60_000, "a throttled background tab must not read as away"
+    assert gap <= 15 * 60_000, "an absence this long is not worth missing"
+    # And the stamp has to be frequent enough that the gap can never be an
+    # artefact of the writer's own cadence.
+    assert _bundled_const(js, "SEEN_EVERY_MS") < gap / 4
+
+
+def test_the_settings_copy_and_the_button_say_the_same_thing():
+    """The Settings row documents what the button does; a rename that lands in
+    only one of the two describes a control that no longer exists."""
+    src = (
+        _ROOT
+        / "frontend"
+        / "src"
+        / "components"
+        / "settings"
+        / "screens"
+        / "General.tsx"
+    ).read_text(encoding="utf-8")
+    assert '"Resume Working"' in src or "Resume Working" in src
+    assert "Resumed work" not in src
+    assert "Resumed work" not in _js()
 
 
 def test_break_screen_counts_as_a_modal_for_the_keymap():

--- a/tests/unit/test_frontend_notifications.py
+++ b/tests/unit/test_frontend_notifications.py
@@ -36,11 +36,58 @@ def test_app_js_notification_wiring():
         "session.prompt_sent",
         "session.activity_changed",
         "session.stage_changed",
+        # "the agent has finished" comes from the turn-boundary event, never
+        # from the raw idle flip — that one fires at the end of every assistant
+        # turn and for a window that has merely been re-opened.
+        "session.turn_ended",
     ):
         assert kind in js, kind
+    assert "finished — now idle" not in js
 
 
 def test_style_css_has_notification_rules():
     css = client.get("/style.css").text
     for sel in ("#notif-btn", ".notif-badge", ".notif-pop", ".notif-item"):
         assert sel in css, sel
+
+
+def test_bell_renders_the_dwell_the_turn_boundary_carries():
+    """The event's whole claim is that the quiet LASTED; a bare "finished"
+    throws away the part that makes it trustworthy. And the row keeps the
+    ``n-done`` class the bell's attention styling and badge counting key on."""
+    js = client.get("/app.js").text
+    at = js.index('case "session.turn_ended"')
+    block = js[at : at + 400]
+    assert "idle_for" in block
+    assert "n-done" in block
+    # Minutes past a point, so a session left alone all afternoon does not
+    # report "finished — idle 9412s".
+    assert "/ 60" in block
+
+
+def test_the_browser_channel_dedupes_per_RULE_like_the_server_does():
+    """Same bug, same fix, in the channel where it also swapped a POPUP.
+
+    The key is reused as the Notification ``tag``, so an event-keyed window did
+    not merely swallow the second rule's push — the browser replaced the first
+    rule's still-visible popup with it.
+    """
+    js = client.get("/addons/notify.js").text
+    assert 'const key = env.session + "|" + rule.id;' in js
+    assert "tag: key" in js or "tag:key" in js
+
+
+def test_the_two_channels_collapse_a_flap_over_the_same_window():
+    """A mirrored constant with a comment saying so is a constant that drifts.
+
+    Both channels dedupe the same (session, rule) pair; if only one of them
+    widened, a flapping transition would push twice on the phone and once in
+    the browser (or the reverse), which reads as a bug in whichever the user
+    happens to be looking at.
+    """
+    from backend.web.addons import notify as notify_addon
+
+    js = client.get("/addons/notify.js").text
+    at = js.index("const DEDUPE_MS")
+    ms = int(js[at : js.index("\n", at)].split("=")[1].strip().rstrip(";"))
+    assert ms == notify_addon._DEDUPE_SECONDS * 1000

--- a/tests/unit/test_intake_reopen.py
+++ b/tests/unit/test_intake_reopen.py
@@ -471,3 +471,46 @@ class TestFrontendWiring:
     def test_the_stylesheet_ships_the_demoted_start(self):
         css = client.get("/style.css").text
         assert ".ik-start-again" in css
+
+
+# --------------------------------------------------------------------------- #
+# The docs. Reopen is described in web-ui.md; web-api.md documented no
+# /api/intake/* route at all, so an API reader would have concluded it did not
+# exist. Both are guarded here, in one place, for the same reason the panels
+# share their row rendering: the two must not disagree about what exists.
+# --------------------------------------------------------------------------- #
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _doc(name: str) -> str:
+    return (_ROOT / "docs" / name).read_text(encoding="utf-8")
+
+
+class TestDocs:
+    def test_web_ui_names_the_route_the_module_and_the_two_refusals(self):
+        text = _doc("web-ui.md")
+        assert "POST /api/intake/reopen" in text
+        assert "backend/web/core/reopen.py" in text
+        # The identity-not-a-path rule is the reason the refusals exist at all.
+        assert "never a path from the client" in text
+        assert "**410**" in text and "**409**" in text
+        assert (_ROOT / "backend" / "web" / "core" / "reopen.py").exists()
+
+    def test_web_ui_names_the_resolution_order_it_promises(self):
+        text = _doc("web-ui.md")
+        # Most-informative first, and `.git`-gated — a half-deleted workspace
+        # must not be offered.
+        for phrase in ("recently-closed session", "provisioned clone directory"):
+            assert phrase in text, phrase
+        assert "worktree" in text and "`.git`" in text
+
+    def test_web_api_documents_the_route_it_used_to_omit(self):
+        text = _doc("web-api.md")
+        rows = [ln for ln in text.splitlines() if "/api/intake/reopen" in ln]
+        assert rows, "web-api.md never mentions POST /api/intake/reopen"
+        row = rows[0]
+        # The status codes are the contract a client codes against.
+        for code in ("400", "409", "410"):
+            assert code in row, code
+        # ...and `workspace`, the row annotation that puts the button there.
+        assert "`workspace`" in text

--- a/tests/unit/test_intake_surface.py
+++ b/tests/unit/test_intake_surface.py
@@ -1098,3 +1098,52 @@ def test_every_intake_work_list_ships_its_filter():
     # is what makes Ctrl+F and "Escape clears, then closes" the same everywhere.
     assert "dlg-filter" in js
     assert client.get("/style.css").text.count(".pr-open-toolbar .dlg-filter") >= 1
+
+
+# --------------------------------------------------------------------------- #
+# The Auto-start tab — the cross-source roll-up of "what starts next without
+# me". Its contract is a shared rule (one module behind both the tab body and
+# the strip badge, so the count and the list cannot disagree) and one
+# three-value chip vocabulary, whichever switch is really involved. Both are now
+# documented, which makes the names load-bearing.
+# --------------------------------------------------------------------------- #
+_ROOT = Path(__file__).resolve().parents[2]
+_INTAKE_SRC = _ROOT / "frontend" / "src" / "components" / "intake"
+
+
+class TestAutoStartTabIsDocumented:
+    def test_the_docs_name_the_tab_its_key_and_its_one_vocabulary(self):
+        text = (_ROOT / "docs" / "web-ui.md").read_text(encoding="utf-8")
+        assert "`autostart`" in text
+        assert "**Auto-start**" in text
+        # Three values, and only three: an earlier cut leaked the plumbing into
+        # the labels ("ingestion paused" beside "switched off").
+        for chip in ("auto-start on", "auto-start off", "not set up"):
+            assert chip in text, chip
+        # The difference between the switches belongs in the sentence under the
+        # heading, which names the one to flip.
+        assert "Automated ingestion" in text
+        assert "Automated PR review" in text
+        assert "Automated issue handling" in text
+
+    def test_the_modules_the_docs_cite_exist(self):
+        text = (_ROOT / "docs" / "web-ui.md").read_text(encoding="utf-8")
+        assert "intake/queue.ts" in text
+        assert "components/intake/kit.tsx" in text
+        assert (_INTAKE_SRC / "queue.ts").exists()
+        assert (_INTAKE_SRC / "kit.tsx").exists()
+
+    def test_the_tab_and_its_badge_really_share_the_one_rule(self):
+        """The doc's claim — "the count and the list cannot disagree" — is only
+        true while both read `queue.ts`."""
+        dialog = (_INTAKE_SRC / "IntakeDialog.tsx").read_text(encoding="utf-8")
+        assert 'from "./queue"' in dialog
+        assert '"autostart"' in dialog
+        assert 'from "./queue"' in (_INTAKE_SRC / "QueueTab.tsx").read_text(
+            encoding="utf-8"
+        )
+
+    def test_the_bundle_ships_the_fourth_tab(self):
+        js = client.get("/app.js").text
+        assert "Auto-start" in js
+        assert "autostart" in js

--- a/tests/unit/test_needs_rebase.py
+++ b/tests/unit/test_needs_rebase.py
@@ -118,14 +118,47 @@ def test_snapshot_carries_activity_since(monkeypatch):
     monkeypatch.setitem(server.ENGINE.instances, inst.Title, inst)
     # Stub the live probe so it can't overwrite the seeded cache record.
     monkeypatch.setattr(server, "_agent_activity", lambda i, t: "idle")
+    # ``state_since`` is the key every layer of _agent_activity writes through
+    # agent_state._verdict. This test used to seed ``changed_epoch``, a key
+    # nothing has ever written — which is exactly how the field stayed dead in
+    # production while its test went on passing.
     monkeypatch.setitem(
         server._ACTIVITY_CACHE,
         inst.Title,
-        {"hash": "", "changed_epoch": 1234.5, "state": "idle", "streak": 0},
+        {"hash": "", "state_since": 1234.5, "reported": "idle", "streak": 0},
     )
     snap = server._build_instances_snapshot()
     mine = [d for d in snap if d["title"] == inst.Title]
     assert mine and mine[0]["activity_since"] == 1234.5
+
+
+def test_activity_since_is_zero_for_a_session_with_no_reading(monkeypatch):
+    """0 is the "unknown" the frontend gates on — an offline session, or one the
+    poll has not classified yet, must not look like it changed state at the
+    epoch. The wedge rule reads ``Number(activity_since) > 0`` for exactly this,
+    and would otherwise call every unseen session stuck since 1970."""
+    inst = _FakeInst("", title="act-none")
+    monkeypatch.setitem(server.ENGINE.instances, inst.Title, inst)
+    monkeypatch.setattr(server, "_agent_activity", lambda i, t: "offline")
+    server._ACTIVITY_CACHE.pop(inst.Title, None)
+    snap = server._build_instances_snapshot()
+    mine = [d for d in snap if d["title"] == inst.Title]
+    assert mine and mine[0]["activity_since"] == 0.0
+
+
+def test_the_cheap_snapshot_publishes_activity_since_too(monkeypatch):
+    """The two snapshot builders are one payload as far as a client is
+    concerned. The cheap path (a session too new/paused to probe) carried the
+    same dead ``changed_epoch`` read, so a row could lose the field simply by
+    being served from the other branch."""
+    inst = _FakeInst("", title="act-cheap")
+    monkeypatch.setitem(
+        server._ACTIVITY_CACHE,
+        inst.Title,
+        {"hash": "", "state_since": 4321.0, "reported": "idle"},
+    )
+    d = server._session_snapshot_cheap(inst, {})
+    assert d["activity_since"] == 4321.0
 
 
 # --------------------------------------------------------------------------- #
@@ -152,3 +185,18 @@ def test_app_js_has_wedge_watchdog_rule():
     assert "WEDGE_IDLE_S" in js
     assert "activity_since" in js
     assert "possibly stuck" in js
+
+
+def test_a_committed_and_walked_away_session_is_not_called_stuck():
+    """This branch had never once rendered — ``activity_since`` read a key
+    nothing wrote, so it was 0 for every session. Now that it is live, what it
+    calls "unfinished work" has to be true: a COMMITTED branch is finished as
+    far as git is concerned (the header is asking for a push, not reporting a
+    problem), and counting it would put every session anyone committed and
+    walked away from on the bell's attention badge, claiming to be wedged.
+    """
+    js = client.get("/app.js").text
+    at = js.index("const unfinished = ")
+    rule = js[at : js.index(";", at)]
+    assert "un.additions" in rule and "un.deletions" in rule
+    assert "committed" not in rule

--- a/tests/unit/test_ntfy.py
+++ b/tests/unit/test_ntfy.py
@@ -603,12 +603,117 @@ def test_dispatch_respects_a_muted_rule(pushes):
 def test_dispatch_honours_an_opted_in_rule(pushes):
     """Default-off rules push only once the user turns them on."""
     S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
-    idle = {**_clarify(), "new": "idle"}
-    _addon()._on_event(idle)
+    done = {
+        "event": "session.turn_ended",
+        "session": "s1",
+        "old": None,
+        "new": None,
+        "data": {"idle_for": 46.0},
+    }
+    _addon()._on_event(done)
     assert pushes == []
     client.post("/api/notify/rules/session_idle", json={"enabled": True})
-    _addon()._on_event(idle)
+    _addon()._on_event(done)
     assert len(pushes) == 1 and pushes[0]["priority"] == 2  # ambient: no buzz
+
+
+def test_raw_idle_never_pushes_even_when_opted_in(pushes):
+    """The chip going grey is not a notification.
+
+    ``session.activity_changed new="idle"`` fires at the end of every assistant
+    turn, between two prompts of a draining queue, and for a window that merely
+    re-opened. Opting into "a session finishes" must not subscribe you to that;
+    only ``session.turn_ended`` carries the claim.
+    """
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    client.post("/api/notify/rules/session_idle", json={"enabled": True})
+    _addon()._on_event({**_clarify(), "new": "idle"})
+    assert pushes == []
+
+
+def _turn_ended(session="alpha", idle_for=46.0) -> dict:
+    return {
+        "seq": 2,
+        "event": "session.turn_ended",
+        "session": session,
+        "old": None,
+        "new": None,
+        "ts": 0.0,
+        "data": {"idle_for": idle_for},
+    }
+
+
+def test_the_finished_push_says_what_it_now_means(pushes):
+    """The rule's whole claim changed, so its words did too: not "is idle" (a
+    chip colour) but "has finished" (a turn that ended, quietly, with nothing
+    queued behind it)."""
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    client.post("/api/notify/rules/session_idle", json={"enabled": True})
+    _addon()._on_event(_turn_ended())
+    (push,) = pushes
+    assert push["title"] == "alpha has finished"
+    assert "nothing queued" in push["message"]
+    assert push["tags"] == ["zzz"]
+
+
+def test_an_existing_opt_in_carries_over_with_no_migration(pushes):
+    """The id is unchanged ON PURPOSE. A settings file written before the
+    retarget lists ``session_idle`` in ``enabled_rules``; after it, that same
+    string has to keep meaning "tell me when a session finishes" — a renamed id
+    would have silently switched every existing opt-in back off."""
+    S.update_settings(
+        notifications={
+            "ntfy_enabled": True,
+            "ntfy_topic": "t1",
+            "enabled_rules": ["session_idle"],  # written by the OLD build
+        }
+    )
+    assert "session_idle" in {r["id"] for r in notify_addon._enabled_rules()}
+    _addon()._on_event(_turn_ended())
+    assert len(pushes) == 1
+    # And the resolved config the browser channel reads agrees.
+    rules = {r["id"]: r for r in client.get("/api/notify/config").json()["rules"]}
+    assert rules["session_idle"]["enabled"] is True
+    assert rules["session_idle"]["event"] == "session.turn_ended"
+
+
+def test_dedupe_is_per_RULE_not_per_EVENT(pushes):
+    """Three rules ride ``session.activity_changed``.
+
+    Keyed by event name, the first match inside the 5s window swallowed the
+    rest — so a session that hit its usage cap and then asked a question got the
+    cap push and NOT the question, though both are default-on and only one of
+    them can be acted on. (In the browser channel the same key is the
+    Notification ``tag``, so the later rule's popup also replaced a still-visible
+    earlier one.)
+    """
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    addon = _addon()
+    addon._on_event({**_clarify(), "new": "limit"})
+    addon._on_event(_clarify())  # same session, same event, within the window
+    assert [p["title"] for p in pushes] == [
+        "alpha ran out of usage",
+        "alpha needs your input",
+    ]
+    # The window still collapses a flap of the SAME rule, which is all it is for.
+    addon._on_event(_clarify())
+    assert len(pushes) == 2
+
+
+def test_the_flap_window_is_not_what_dedupes_a_finished_session(pushes, monkeypatch):
+    """``turn_ended`` is already once-per-work-cycle at the source (the emitter
+    spends the session's work evidence), so the 5s window has no opinion about
+    it — and must not acquire one, or a genuine second run finishing inside a
+    long-lived process would go unannounced."""
+    S.update_settings(notifications={"ntfy_enabled": True, "ntfy_topic": "t1"})
+    client.post("/api/notify/rules/session_idle", json={"enabled": True})
+    addon = _addon()
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(notify_addon.time, "monotonic", lambda: clock["t"])
+    addon._on_event(_turn_ended())
+    clock["t"] += notify_addon._DEDUPE_SECONDS + 1  # a second run, later
+    addon._on_event(_turn_ended())
+    assert len(pushes) == 2
 
 
 def test_dispatch_dedupes_a_flapping_transition(pushes):

--- a/tests/unit/test_prompt_queue.py
+++ b/tests/unit/test_prompt_queue.py
@@ -479,6 +479,45 @@ def test_drain_waits_for_idle_to_settle(drain, monkeypatch):
     assert pq.list_queue("d1") == []
 
 
+def test_a_just_rebooted_agent_is_not_typed_into(drain, monkeypatch):
+    """After MindFlock relaunches a dead agent, hold the queue regardless of
+    what the activity probe says.
+
+    A CLI restarting with a large ``--continue`` transcript spends its first
+    seconds quiet and I/O-bound, and a quiet pane is — correctly — read as idle
+    now that the classifier stops guessing that an unseen pane is working. But
+    typing into a CLI that has not drawn its input box loses the prompt, and the
+    send clears ``armed``, so the retry only comes after _QUEUE_REARM_IDLE (five
+    minutes). The old guess bought roughly this grace by accident; this states
+    it.
+    """
+    import time as _t
+
+    server, sent = drain
+    clock = {"now": 1_000_000.0}
+    monkeypatch.setattr(_t, "time", lambda: clock["now"])
+    monkeypatch.setattr(server, "_agent_activity", lambda i, t: "idle")
+    # A reboot we just performed, and an idle dwell that is long since satisfied
+    # — so the grace is the only thing that can hold this prompt back.
+    server._QUEUE_STATE["d1"] = {
+        "armed": True,
+        "sent_at": 0.0,
+        "rebooted_at": clock["now"],
+        "idle_since": 1.0,
+    }
+    pq.enqueue("d1", "task one")
+
+    server._drain_one_queue("d1")
+    assert sent == []
+    clock["now"] += server._QUEUE_BOOT_GRACE - 1
+    server._drain_one_queue("d1")
+    assert sent == [], "the CLI has not drawn its prompt yet"
+
+    clock["now"] += 2  # past the grace
+    server._drain_one_queue("d1")
+    assert sent == ["task one"]
+
+
 def test_drain_resets_settle_when_agent_reworks(drain, monkeypatch):
     """A brief working blip mid-dwell resets the timer: the prompt must not slip
     through on stale idle-since accumulated across a working stretch."""

--- a/tests/unit/test_stage_reset.py
+++ b/tests/unit/test_stage_reset.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -289,3 +290,45 @@ def test_route_clears_a_stale_check_but_not_one_that_matches_head(routed, wt):
     _code, body = _reset("r1")
     assert body["cleared"] == []
     assert (wts.check_status(str(wt)) or {}).get("state") == "failed"
+
+
+# --------------------------------------------------------------------------- #
+# The docs. The stage/stage_reset split is the whole safety argument, and it is
+# now public prose, which makes it contractual: these guard the names a reader
+# would go looking for (and the two docs against drifting apart again).
+# --------------------------------------------------------------------------- #
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _doc(name: str) -> str:
+    return (_ROOT / "docs" / name).read_text(encoding="utf-8")
+
+
+def test_web_ui_docs_name_the_route_the_row_field_and_the_module():
+    text = _doc("web-ui.md")
+    assert "POST /api/instances/{title}/reset-stage" in text
+    assert "stage_reset" in text
+    assert "backend/web/core/stage_reset.py" in text
+    # The prose cites a path, so the path is part of the contract: splitting the
+    # module has to break a test rather than quietly rot the sentence.
+    assert (_ROOT / "backend" / "web" / "core" / "stage_reset.py").exists()
+
+
+def test_web_ui_docs_hold_the_two_invariants_the_pin_is_safe_because_of():
+    text = _doc("web-ui.md")
+    # (1) the pin is published ALONGSIDE the git-derived stage, never instead of
+    # it — folding it in would let an armed fast-track chain commit a clean tree;
+    assert "does **not** touch the published `stage`" in text
+    # (2) release is keyed on the worktree, because filing a PR flips the label
+    # `pushed` -> `pr` a beat after the press.
+    assert "never against the stage label" in text
+    assert "one-shot action, not a toggle" in text
+
+
+def test_web_api_docs_carry_the_route_and_the_row_field_too():
+    """web-api.md is where an API reader looks; it documented neither."""
+    text = _doc("web-api.md")
+    assert '"stage_reset"' in text  # in the GET /api/instances row shape
+    row = [ln for ln in text.splitlines() if "/api/instances/{title}/reset-stage" in ln]
+    assert row, "the guided-workflow table never mentions /reset-stage"
+    assert any("`stage` is untouched" in ln for ln in row)

--- a/tests/unit/test_turn_boundary.py
+++ b/tests/unit/test_turn_boundary.py
@@ -1,0 +1,656 @@
+"""Turn boundaries: when MindFlock is allowed to say "your agent has finished".
+
+The complaint these pin down: *"we go from the offline state and I click it, we
+go to running for a moment and then idle so it always triggers"*, and *"very
+short periods of idleness trigger the notification"*.
+
+Three separate facts had been collapsed into one event. ``activity_changed
+new="idle"`` is a chip colour — it fires at the end of every assistant turn, on
+a session that merely booted to a bare prompt, between two prompts of a
+draining queue, and for a window that was just re-opened. ``session.turn_ended``
+is the notification-grade fact, and it asserts all three of: the agent was
+observed working in THIS tmux incarnation, it has been idle continuously since,
+and nothing is queued to wake it back up.
+
+Split across two levels: the state layer's provenance (does the record know the
+agent worked?) and the emit layer's gate (does that provenance, plus a dwell,
+plus an empty queue, produce the event?).
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from backend.web import server
+from backend.web.core import agent_state
+from backend.web.core import events as events_mod
+from backend.web.core.events import EventBus
+
+
+# --------------------------------------------------------------------------- #
+# The state layer: incarnation-scoped provenance
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _clean_record():
+    agent_state._ACTIVITY_CACHE.pop("s", None)
+    agent_state._LIMIT_PROBE.pop("s", None)
+    yield
+    agent_state._ACTIVITY_CACHE.pop("s", None)
+    agent_state._LIMIT_PROBE.pop("s", None)
+
+
+def test_working_stamps_work_evidence_and_idle_does_not():
+    rec = agent_state._activity_record("s", 100.0)
+    assert agent_state.worked_at("s") is None
+    agent_state._verdict(rec, "idle", 1000.0)
+    assert agent_state.worked_at("s") is None, "a quiet session has no work behind it"
+    agent_state._verdict(rec, "working", 1010.0)
+    assert agent_state.worked_at("s") == 1010.0
+    agent_state._verdict(rec, "idle", 1020.0)
+    assert agent_state.worked_at("s") == 1010.0, "idling does not erase the evidence"
+
+
+def test_clarify_alone_is_not_work():
+    # A trust/MCP gate on a brand-new session reports 'clarify' before the agent
+    # has been handed anything to do. That must not arm a turn-end.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "clarify", 1000.0)
+    assert agent_state.worked_at("s") is None
+
+
+def test_state_since_tracks_the_reported_value():
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+    assert agent_state.state_since("s") == 1000.0
+    agent_state._verdict(rec, "working", 1004.0)  # unchanged: clock does not move
+    assert agent_state.state_since("s") == 1000.0
+    agent_state._verdict(rec, "idle", 1008.0)
+    assert agent_state.state_since("s") == 1008.0
+
+
+def test_a_new_tmux_incarnation_resets_the_record():
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+    rec["hash"] = "deadbeef"
+    agent_state._LIMIT_PROBE["s"] = {"at": 1000.0, "limit": True}
+    # Same session_created -> the record is the same object, history intact.
+    assert agent_state._activity_record("s", 100.0) is rec
+    assert agent_state.worked_at("s") == 1000.0
+    # A different session_created is a different agent process: its work, its
+    # pane baseline and its limit verdict all belonged to something that no
+    # longer exists.
+    fresh = agent_state._activity_record("s", 200.0)
+    assert agent_state.worked_at("s") is None
+    assert fresh.get("hash") is None
+    assert "s" not in agent_state._LIMIT_PROBE
+
+
+def test_a_stampless_first_sighting_is_not_kept():
+    # `tmux display-message` can fail while `has-session` succeeds, so
+    # `_pane_meta` answers all-None and there is no incarnation to file a
+    # reading under. Such a record is a throwaway: keeping it would leave the
+    # next real stamp to either adopt a dead run's history or discard it, and
+    # discarding it a poll earlier is the same answer without the ambiguity.
+    rec = agent_state._activity_record("s", None)
+    agent_state._verdict(rec, "working", 1000.0)
+    assert "s" not in agent_state._ACTIVITY_CACHE
+    assert agent_state.worked_at("s") is None
+
+
+def test_limit_spends_the_work_evidence():
+    # A turn the usage cap cut short is not a turn that finished. The reading
+    # only says "limit" while the banner is on the pane, so without dropping the
+    # evidence here the session announces "has finished" the moment the pane
+    # redraws — for work that was abandoned mid-thought.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+    assert agent_state.worked_at("s") == 1000.0
+    agent_state._verdict(rec, "limit", 1010.0)
+    assert agent_state.worked_at("s") is None
+    agent_state._verdict(rec, "idle", 1020.0)
+    assert agent_state.worked_at("s") is None, "a redrawn prompt must not re-arm it"
+    # A resume re-earns it, so the genuine ending still announces.
+    agent_state._verdict(rec, "working", 1030.0)
+    assert agent_state.worked_at("s") == 1030.0
+
+
+def test_claim_work_is_once_only():
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+    assert agent_state.claim_work("s") == 1000.0
+    assert agent_state.claim_work("s") is None
+    assert agent_state.claim_work("never-seen") is None
+
+
+def test_a_record_with_no_stamp_adopts_one_rather_than_resetting():
+    # Hand-seeded records (tests, and the very first sighting) must not be
+    # treated as a stale incarnation.
+    agent_state._ACTIVITY_CACHE["s"] = {"worked_at": 999.0}
+    rec = agent_state._activity_record("s", 100.0)
+    assert rec["created"] == 100.0
+    assert agent_state.worked_at("s") == 999.0
+
+
+def test_offline_no_longer_wipes_the_record():
+    # The pop that used to live here is what guaranteed the phantom: a session
+    # whose tmux was briefly gone came back with no history at all, straight
+    # into the pane layer's first-sighting branch.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["tmux", "has-session"]:
+            return types.SimpleNamespace(returncode=1, stdout=b"")
+        pytest.fail("nothing else should run for a dead session: %r" % (cmd,))
+
+    inst = types.SimpleNamespace(
+        Title="s", Program="claude", Status="running", Started=lambda: True
+    )
+    import unittest.mock as mock
+
+    with mock.patch.object(server.subprocess, "run", fake_run):
+        with mock.patch.object(server.tmux, "to_mindflock_tmux_name", lambda t: t):
+            assert server._agent_activity(inst, "s") == "offline"
+    assert agent_state.worked_at("s") == 1000.0
+    assert "s" in agent_state._ACTIVITY_CACHE
+
+
+# --------------------------------------------------------------------------- #
+# The emit layer: dwell + provenance + queue
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def bus(monkeypatch):
+    b = EventBus()
+    monkeypatch.setattr(events_mod, "BUS", b)
+    server._EVENT_SNAPSHOT.clear()
+    # The boot quiet window swallows everything for 30s after process start,
+    # which in a test run is always.
+    monkeypatch.setattr(server, "_in_boot_quiet", lambda: False)
+    monkeypatch.setattr(server._prompt_queue, "peek_next", lambda title: None)
+    # 0.0 keeps the settle's two-sighting semantics (first call parks the
+    # candidate, second adopts it) without any test having to sleep. The dwell
+    # under test here is the one ABOVE the settle, not the settle itself.
+    monkeypatch.setattr(server, "_ACTIVITY_SETTLE_SECONDS", 0.0)
+    # Work evidence that is always there to be claimed, so each test below
+    # exercises the gate it names rather than the once-per-cycle claim (which
+    # has its own test up in the state-layer section).
+    monkeypatch.setattr(server._agent_state, "claim_work", lambda t: 5.0)
+    yield b
+    server._EVENT_SNAPSHOT.clear()
+
+
+def _ended(got):
+    return [e for e in got if e["event"] == "session.turn_ended"]
+
+
+def _tick(title, activity="idle"):
+    server._emit_state_changes(title, "running", activity, "agent")
+
+
+def test_turn_ended_needs_observed_work(bus, monkeypatch):
+    """THE OFFLINE-CLICK FIX.
+
+    Clicking a session whose tmux has died relaunches its CLI, so the fresh
+    incarnation parks at an empty prompt and reads idle. No amount of sitting
+    there may produce "your agent has finished" — it never started.
+    """
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: None)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    _tick("phantom", "offline")
+    for _ in range(10):
+        _tick("phantom", "idle")
+    assert _ended(got) == []
+    # …and the raw chip event still went out, so the UI is not blinded.
+    assert [e["new"] for e in got if e["event"] == "session.activity_changed"] == [
+        "idle"
+    ]
+
+
+def test_turn_ended_emits_once_per_work_cycle(bus, monkeypatch):
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    worked = {"at": 5.0}
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: worked["at"])
+
+    def _claim(t):
+        got, worked["at"] = worked["at"], None
+        return got
+
+    monkeypatch.setattr(server._agent_state, "claim_work", _claim)
+    _tick("s1", "working")
+    _tick("s1", "idle")  # parks the settle candidate
+    _tick("s1", "idle")  # settles -> activity_changed, and the dwell is 0
+    assert len(_ended(got)) == 1
+    assert _ended(got)[0]["session"] == "s1"
+    # Spending the evidence is the dedupe: it stays idle, it stays quiet.
+    for _ in range(5):
+        _tick("s1", "idle")
+    assert len(_ended(got)) == 1
+
+
+def test_a_short_idle_never_announces(bus, monkeypatch):
+    """THE SHORT-IDLE FIX: the gap between two turns is not a finished session."""
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    _tick("s2", "working")
+    clock["t"] += 4
+    _tick("s2", "idle")
+    clock["t"] += 4
+    _tick("s2", "idle")  # settles the chip
+    assert [e["new"] for e in got if e["event"] == "session.activity_changed"] == [
+        "idle"
+    ]
+    # A whole half-minute of quiet — the Stop hook fires here after EVERY turn —
+    # and still nothing claims the work is over.
+    for _ in range(7):
+        clock["t"] += 4
+        _tick("s2", "idle")
+    assert _ended(got) == []
+    # Past the dwell, it finally is.
+    clock["t"] += server._TURN_END_DWELL_S
+    _tick("s2", "idle")
+    assert len(_ended(got)) == 1
+
+
+def test_work_resuming_restarts_the_dwell(bus, monkeypatch):
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    _tick("s3", "working")
+    clock["t"] += 4
+    _tick("s3", "idle")
+    clock["t"] += 4
+    _tick("s3", "idle")  # chip settles; dwell starts here
+    clock["t"] += server._TURN_END_DWELL_S - 5
+    _tick("s3", "working")  # the agent picked something up again
+    clock["t"] += 4
+    _tick("s3", "idle")
+    clock["t"] += 4
+    _tick("s3", "idle")
+    clock["t"] += server._TURN_END_DWELL_S - 5  # would have been enough before
+    _tick("s3", "idle")
+    assert _ended(got) == []
+
+
+def test_fresh_work_evidence_holds_the_announcement(bus, monkeypatch):
+    """The dwell is asked of the EVIDENCE's clock too, not just the chip's.
+
+    The drain and the autopilot driver both probe activity UNCACHED on their own
+    5s cadences and never feed a snapshot, so a session idle for ten minutes
+    that picks up a queued prompt can have second-old work evidence while the
+    tickers still serve "idle" out of the 2.5s probe memo. Without this gate the
+    announcement lands at the moment the agent STARTED a turn.
+    """
+    got = []
+    bus.subscribe(got.append)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(server.time, "time", lambda: clock["t"])
+    # The chip has said idle for ten minutes…
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    _tick("s7", "working")
+    clock["t"] += 4
+    _tick("s7", "idle")
+    clock["t"] += 600
+    _tick("s7", "idle")
+    # …but the agent was seen working one second ago by an uncached probe.
+    fresh = clock["t"] - 1.0
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: fresh)
+    _tick("s7", "idle")
+    assert _ended(got) == []
+    # Once BOTH clocks agree the quiet has held, it announces.
+    clock["t"] += server._TURN_END_DWELL_S + 1
+    _tick("s7", "idle")
+    assert len(_ended(got)) == 1
+
+
+def test_a_queued_run_is_not_a_finished_run(bus, monkeypatch):
+    # The drain feeds the next prompt once idle has held _QUEUE_IDLE_SETTLE.
+    # Announcing "finished" in that gap is how a ten-prompt queue produced ten
+    # notifications.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(
+        server._prompt_queue, "peek_next", lambda title: {"id": "1", "text": "next"}
+    )
+    _tick("s4", "working")
+    for _ in range(5):
+        _tick("s4", "idle")
+    assert _ended(got) == []
+
+
+def test_limit_is_not_a_turn_ending(bus, monkeypatch):
+    # A turn the account's usage cap cut short is not a turn that finished; the
+    # default-on usage_limit rule is what speaks for that.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    _tick("s5", "working")
+    for _ in range(5):
+        _tick("s5", "limit")
+    assert _ended(got) == []
+
+
+def test_boot_quiet_covers_turn_ends_too(bus, monkeypatch):
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server, "_in_boot_quiet", lambda: True)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    _tick("s6", "working")
+    for _ in range(5):
+        _tick("s6", "idle")
+    assert _ended(got) == []
+
+
+def test_dwell_exceeds_every_other_idle_settle_in_the_app():
+    """The ordering these numbers have to keep, pinned so a future tweak of any
+    one of them cannot silently invert it.
+
+    The queue drains, and autopilot decides the agent is done, BEFORE anyone is
+    told the work finished. Announcing first would mean telling the user a
+    session was over and then watching it start typing again.
+    """
+    from backend.web.core import autopilot
+
+    assert server._TURN_END_DWELL_S > server._QUEUE_IDLE_SETTLE
+    assert server._TURN_END_DWELL_S > autopilot.IDLE_SETTLE_S
+    # And it must dwarf the flicker filter, which answers a different question
+    # ("did two probes agree?") and cannot answer this one.
+    assert server._TURN_END_DWELL_S > server._ACTIVITY_SETTLE_SECONDS * 10
+
+
+def test_clarify_after_work_keeps_the_EARLIER_stamp():
+    # `clarify` is not work, and it is not "no work either" — it must leave the
+    # evidence exactly as it found it. Refreshing it here would restart the
+    # dwell every time a permission prompt redrew, and clearing it would lose a
+    # genuine turn to a mid-turn confirmation.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "clarify", 1200.0)
+    assert agent_state.worked_at("s") == 1000.0
+    agent_state._verdict(rec, "idle", 1210.0)
+    assert agent_state.worked_at("s") == 1000.0
+
+
+def test_a_garbage_incarnation_stamp_does_not_retire_the_record():
+    # `_pane_meta` parses tmux's own output; a truncated or mangled line yields
+    # something that is not a number. Unparseable is UNKNOWN, and unknown must
+    # not read as "a different session" — that would discard a live run's
+    # history on a single bad poll.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+    for junk in ("not-a-number", object(), [1, 2]):
+        assert agent_state._activity_record("s", junk) is rec
+        assert agent_state.worked_at("s") == 1000.0
+    assert rec["created"] == 100.0
+
+
+def test_working_and_offline_readings_never_announce(bus, monkeypatch):
+    """Only a SETTLED idle is a candidate. ``limit`` has its own test above;
+    these are the other two the gate has to refuse."""
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    _tick("s8", "working")
+    for _ in range(5):
+        _tick("s8", "working")
+    assert _ended(got) == []
+    # A session whose tmux went away mid-turn has not finished it — it has
+    # stopped being observable, which is a different sentence.
+    for _ in range(5):
+        _tick("s8", "offline")
+    assert _ended(got) == []
+
+
+def test_the_dwell_runs_from_what_users_were_TOLD(bus, monkeypatch):
+    """``activity_at`` stamps the ANNOUNCED value, not the raw reading.
+
+    The settle can hold an idle back for seconds before anyone hears about it.
+    Measuring the dwell from the reading would spend that hold twice — once
+    suppressing the flicker, once counting toward the announcement — and the
+    "it has been quiet for 45 seconds" claim would be short by however long the
+    settle took.
+    """
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server, "_ACTIVITY_SETTLE_SECONDS", 3.0)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+
+    _tick("s9", "working")  # first sighting: seeds the snapshot
+    assert server._EVENT_SNAPSHOT["s9"]["activity_at"] == 1000.0
+    clock["t"] = 1002.0
+    _tick("s9", "working")  # unchanged -> the stamp is carried, not refreshed
+    assert server._EVENT_SNAPSHOT["s9"]["activity_at"] == 1000.0
+
+    clock["t"] = 1010.0
+    _tick("s9", "idle")  # parked behind the settle: still announcing "working"
+    assert server._EVENT_SNAPSHOT["s9"]["activity"] == "working"
+    assert server._EVENT_SNAPSHOT["s9"]["activity_at"] == 1000.0
+    clock["t"] = 1012.0
+    _tick("s9", "idle")  # inside the settle window: still nothing announced
+    assert server._EVENT_SNAPSHOT["s9"]["activity_at"] == 1000.0
+
+    clock["t"] = 1014.0
+    _tick("s9", "idle")  # settled -> announced HERE, not at 1010
+    assert server._EVENT_SNAPSHOT["s9"]["activity"] == "idle"
+    assert server._EVENT_SNAPSHOT["s9"]["activity_at"] == 1014.0
+
+    clock["t"] = 1014.0 + server._TURN_END_DWELL_S - 0.5
+    _tick("s9", "idle")
+    assert _ended(got) == [], "the settle's four seconds are not the user's"
+    clock["t"] = 1014.0 + server._TURN_END_DWELL_S + 0.5
+    _tick("s9", "idle")
+    assert len(_ended(got)) == 1
+    assert _ended(got)[0]["data"]["idle_for"] == pytest.approx(
+        server._TURN_END_DWELL_S + 0.5, abs=0.1
+    )
+
+
+def test_two_ticks_racing_announce_exactly_once(monkeypatch):
+    """``claim_work`` is the permission to speak, and it is atomic.
+
+    Two unsynchronised 4s tickers plus an on-demand ``_republish_session`` all
+    run this gate. A plain read-then-clear lets two of them satisfy the dwell in
+    the same instant — and the duplicate would be invisible on the phone (the
+    per-channel dedupe eats it) and perfectly visible in the bell, whose rows
+    are keyed by event seq.
+    """
+    import threading
+
+    b = EventBus()
+    monkeypatch.setattr(events_mod, "BUS", b)
+    got = []
+    b.subscribe(got.append)
+    monkeypatch.setattr(server, "_in_boot_quiet", lambda: False)
+    monkeypatch.setattr(server._prompt_queue, "peek_next", lambda title: None)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    # The REAL claim, deliberately: this test is about that function's atomicity.
+    agent_state._ACTIVITY_CACHE["race"] = {
+        "created": 1.0,
+        "reported": "idle",
+        "state_since": 0.0,
+        "worked_at": 5.0,
+    }
+    snap = {"activity": "idle", "activity_at": 0.0}
+    ready = threading.Barrier(8)
+
+    def _go():
+        ready.wait()
+        server._note_turn_boundary("race", snap, 10_000.0)
+
+    threads = [threading.Thread(target=_go) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(_ended(got)) == 1
+    agent_state._ACTIVITY_CACHE.pop("race", None)
+
+
+def test_a_failing_probe_never_breaks_the_tick(bus, monkeypatch):
+    """A notification is the least important thing in the loop it rides."""
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+
+    def _boom(*a, **kw):
+        raise RuntimeError("queue store is unreadable")
+
+    monkeypatch.setattr(server._prompt_queue, "peek_next", _boom)
+    _tick("s10", "working")
+    _tick("s10", "idle")
+    _tick("s10", "idle")  # the tick completes...
+    assert _ended(got) == []  # ...and simply says nothing
+    # The same for the emit itself: the bus is the last thing to go wrong here.
+    monkeypatch.setattr(server._prompt_queue, "peek_next", lambda title: None)
+    monkeypatch.setattr(bus, "emit", _boom)
+    server._note_turn_boundary("s10", {"activity": "idle", "activity_at": 0.0}, 1e9)
+
+
+# --------------------------------------------------------------------------- #
+# The record's lifetime: what may forget it, and what may not
+# --------------------------------------------------------------------------- #
+_LIVE = "keep-me"
+_GONE = "left-us"
+
+
+@pytest.fixture()
+def seeded_state():
+    """Rolling state for two sessions, in every dict that carries any."""
+
+    def _seed(title, worked=1000.0):
+        server._ACTIVITY_CACHE[title] = {
+            "created": 1.0,
+            "reported": "idle",
+            "state_since": 900.0,
+            "worked_at": worked,
+            "hash": "abc",
+        }
+        server._LIMIT_PROBE[title] = {"at": 1.0, "limit": True}
+        server._TRUST_DISMISS_AT[title] = 1.0
+        # This one alone is keyed by TMUX SESSION NAME, not by title.
+        server._THREAD_RECORD_AT[server.tmux.to_mindflock_tmux_name(title)] = 1.0
+
+    _seed(_LIVE)
+    _seed(_GONE)
+    yield _seed
+    for title in (_LIVE, _GONE):
+        for _d in (
+            server._ACTIVITY_CACHE,
+            server._LIMIT_PROBE,
+            server._TRUST_DISMISS_AT,
+        ):
+            _d.pop(title, None)
+        server._THREAD_RECORD_AT.pop(server.tmux.to_mindflock_tmux_name(title), None)
+
+
+def test_pressing_commit_keeps_the_work_evidence(seeded_state):
+    """THE REGRESSION THE SPLIT EXISTS TO PREVENT.
+
+    Commit / Push / Make-PR / merge all call ``_forget_probes`` to drop a
+    2.5s-old stage. When that also popped the rolling record, pressing Commit
+    at the end of a run destroyed the very evidence the turn-end announcement
+    is built on — so the sessions a user was most likely to be watching were
+    exactly the ones that never told them they were done.
+    """
+    with server._PROBE_CACHE_LOCK:
+        server._PROBE_CACHE[("stage", _LIVE)] = (0.0, {"stage": "agent"})
+    server._forget_probes(_LIVE)
+    # The memoized result is gone (that IS the point of the call)…
+    with server._PROBE_CACHE_LOCK:
+        assert ("stage", _LIVE) not in server._PROBE_CACHE
+    # …and the session's history is untouched.
+    assert server._agent_state.worked_at(_LIVE) == 1000.0
+    assert server._agent_state.state_since(_LIVE) == 900.0
+    assert _LIVE in server._LIMIT_PROBE
+
+
+def test_deleting_a_session_forgets_it_entirely(seeded_state):
+    """Titles are reused — ``untitled-2`` comes straight back — so a namesake
+    must not inherit the dead session's pane hash, limit verdict or history."""
+    name = server.tmux.to_mindflock_tmux_name(_GONE)
+    assert name != _GONE, "the translation is the whole point of the last line"
+    server._forget_session_state(_GONE)
+    assert _GONE not in server._ACTIVITY_CACHE
+    assert _GONE not in server._LIMIT_PROBE
+    assert _GONE not in server._TRUST_DISMISS_AT
+    assert name not in server._THREAD_RECORD_AT
+    # Its neighbour is untouched.
+    assert server._agent_state.worked_at(_LIVE) == 1000.0
+    assert server.tmux.to_mindflock_tmux_name(_LIVE) in server._THREAD_RECORD_AT
+
+
+def test_the_teardown_routes_forget_the_whole_record_not_just_the_probes():
+    """Which of the two functions each caller gets is the entire fix, and it is
+    invisible at runtime until a user presses the wrong button — so pin it."""
+    import inspect
+
+    for route in (
+        server.delete_instance,
+        server.instance_cleanup,
+        server.close_instance,
+    ):
+        src = inspect.getsource(route)
+        assert "_forget_session_state(title)" in src, route.__name__
+    # And the workflow verbs must NOT: they only want fresh probes.
+    assert "_forget_probes" in inspect.getsource(server._forget_session_state)
+
+
+def test_prune_drops_departed_sessions_and_keeps_the_flock(seeded_state):
+    server._prune_session_state([_LIVE])
+    assert _GONE not in server._ACTIVITY_CACHE
+    assert _GONE not in server._LIMIT_PROBE
+    assert _GONE not in server._TRUST_DISMISS_AT
+    assert server.tmux.to_mindflock_tmux_name(_GONE) not in server._THREAD_RECORD_AT
+    assert server._agent_state.worked_at(_LIVE) == 1000.0
+    assert server.tmux.to_mindflock_tmux_name(_LIVE) in server._THREAD_RECORD_AT
+
+
+def test_the_tick_sweeps_a_session_that_left_without_a_route(monkeypatch, seeded_state):
+    """A workspace deleted from Settings, or a tombstone converged from another
+    MindFlock on the same state file, pops the instance without passing through
+    a teardown route. Nothing else would ever drop its state."""
+    monkeypatch.setattr(server, "_build_instances_snapshot", lambda: [])
+    monkeypatch.setattr(server._events, "set_sessions_snapshot", lambda out: None)
+    # Per the suite's rule about the REAL engine: replace the mapping, never
+    # mutate the live one.
+    monkeypatch.setattr(server.ENGINE, "instances", {_LIVE: object()})
+    server._instances_tick()
+    assert _GONE not in server._ACTIVITY_CACHE
+    assert _LIVE in server._ACTIVITY_CACHE
+
+
+def test_republishing_a_session_keeps_its_work_evidence(monkeypatch, seeded_state):
+    """``_republish_session`` runs right after commit/push/PR — the same moments
+    ``_forget_probes`` fires. It must not lose the record either."""
+    monkeypatch.setattr(server.ENGINE, "instances", {_LIVE: object()})
+    monkeypatch.setattr(
+        server,
+        "_session_snapshot",
+        lambda inst, queues: {
+            "status": "running",
+            "activity": "idle",
+            "stage": "agent",
+        },
+    )
+    monkeypatch.setattr(server._events, "patch_session_snapshot", lambda t, d: None)
+    assert server._republish_session(_LIVE) is not None
+    assert server._agent_state.worked_at(_LIVE) == 1000.0


### PR DESCRIPTION
- Introduced `session.turn_ended` event to accurately signal when a session's work is genuinely complete, ensuring it only fires after the agent has been observed working, has been idle for 45 seconds, and has no queued prompts.
- Updated notification rules to reflect this change, improving clarity for users by distinguishing between idle states and actual completion of work.
- Fixed issues with the break clock to ensure it only counts active time, resetting appropriately when the app is reopened or when significant gaps in activity are detected.
- Improved documentation to clarify the new event and its implications for user notifications and session management.

This update enhances user experience by reducing noise from unnecessary notifications and ensuring accurate tracking of session states.
