### PR TITLE
Enhance session management and notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The dev shell's notifications get their icon back.** A dev toast came up
+  headed *MindFlock-dev* and badged with the blank white document tile — the one
+  Windows draws when it cannot read the icon it was pointed at. The `.ico` was
+  fine; the *path* was not. A shortcut's `IconLocation` is resolved by the
+  Windows shell, later, in whatever process happens to be drawing a tile — and
+  on the supported Windows shape the checkout lives on a WSL share, which the
+  shell's icon extraction will not read. The window and taskbar icons were right
+  all along, because Electron loads those itself with an ordinary file read,
+  which is exactly why only the toast looked broken.
+
+  The dev shortcut now keeps a copy of its icon on the local disk, in the dev
+  profile beside the rest of the throwaway dev state, and points at that. It is
+  byte-compared rather than rewritten, so changing `MINDFLOCK_DEV_ICON` is
+  picked up and leaving it alone costs nothing; a checkout on a local drive
+  keeps using its own file. The shortcut already on disk repairs itself on the
+  next dev run.
+
 - **"Your agent has finished" is now a claim MindFlock can back up.** The idle
   notification fired on the wrong fact. A session's chip goes grey when its CLI
   reports a turn ended, and a coding CLI reports that at the end of *every*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Notifications carry the session's rail slot: "[3] sitecheck-bot7 has
+  finished."** The sidebar numbers its first nine rows, and those numbers are
+  how people locate a window — so the desktop notification, the bell feed, and
+  the in-app toasts now lead with the same number the rail shows at that
+  moment (drag order and the live filter applied, resolved client-side at
+  render time, because the order is per-browser state the server never sees).
+  Rows past the ninth, filtered-out sessions, and phone pushes — which have no
+  rail to agree with — carry no number rather than a wrong one. Extension
+  pages get the same resolver as `window.mindflock.slotNumber(title)`.
+
+### Changed
+
+- **The whole window state flow got significantly tighter — where the evidence
+  earns it.** "Your agent has finished" used to take ~55 seconds from the last
+  keystroke of a turn, for every agent, in every situation: a flat 45-second
+  dwell chosen as a blanket over three different hazards (a human typing a
+  follow-up, a queued prompt in flight, a fast-track chain mid-step), plus the
+  activity settle and a poll tick. Each of those hazards is now checked
+  *exactly*, so the padding survives only where the evidence is weak.
+
+  A hook CLI's finished run (Claude, Codex) now announces in **~15 seconds**;
+  a pane CLI's in ~35; the CPU backstop keeps the full 45. The chip — and the
+  default-on "needs your input" push — react within **one tick** when the
+  CLI's own hook reported the state, because a hook marker cannot misread a
+  frame the way a pane capture can (the 3s settle stays for pane-derived
+  readings, and for "ran out of usage", whose banner detection is a pane fact
+  whatever triggered it). Queued prompts go out one drain pass sooner on a
+  hook-reported idle. The exact gates that replaced the padding: recent human
+  input (the terminals, /send, send-now — and tmux's own client activity, so a
+  conversation held in a raw tmux attach doesn't buzz per turn), a send-grace
+  covering the window where the last queued prompt is typed but not yet picked
+  up (previously covered only by the blanket — announcing there was possible
+  before this release), and fast-track's own record, bounded by its driver
+  lease so a wedged chain cannot mute a session forever.
+
+  The turn's END also got a harder look at *why* it ended: the working→idle
+  hook transition now forces a fresh usage-limit probe (a miss never refreshes
+  the probe throttle), closing a window where a turn cut short by the cap
+  could be announced as finished — including the variant where the banner left
+  the screen before the throttled re-check ever saw it, which no amount of
+  dwell used to fix. And the pane layer's proven-busy bookkeeping is cleared
+  by every non-working reading, so a busy run can no longer straddle an agent
+  death or a relaunch and re-arm off stale evidence.
+
 ### Fixed
+
+- **Sessions no longer read "idle" while their agent is visibly working.** The
+  activity hooks MindFlock installs into a repo's `.claude/settings.local.json`
+  resolved their marker *directory* at install time — baked in as an absolute
+  path — while resolving the session name at fire time. One sandboxed install
+  poisoned the well: a Verify run executes with `HOME` redirected into a
+  scratchpad, and when its MindFlock instance re-pinned the SHARED repo's
+  hooks file, every cohabiting session's hooks began writing markers into a
+  dead sandbox under /tmp. The chips froze on whatever the last pre-poison
+  reading was — "idle", for a session that then worked for fifteen straight
+  minutes — and the resume-thread binding drifted the same way, so the live
+  `claude agents --json` signal (which knew the truth: `busy`) was consulted
+  under a dead conversation id and answered nothing. Both directories are now
+  resolved *inside the firing hook*, from the CLI's own environment: a
+  sandboxed CLI writes to its sandbox, a real one to the real home, no matter
+  who installed the hooks or where.
+
+- **Archived Shortcut work no longer fills the Tickets panel.** A workflow state
+  showing three stories in Shortcut listed ten in MindFlock, and the extra seven
+  could not be found in Shortcut at all — because Shortcut hides them. Six were
+  archived stories, which `/stories/search` returns and boards do not; the
+  seventh was a live story under an archived epic, which disappears from the
+  board with the epic it belongs to. Both are now filtered out of every Shortcut
+  listing.
+
+  The panel was the visible half. The same search feeds the ingestion pipeline,
+  so a story archived while it sat in the configured ingest state could still be
+  picked up and worked — archiving it being, presumably, how you meant to stop
+  that. The epic lookup is one extra call per search, skipped entirely when no
+  story carries an epic, and best-effort: if it fails you get the old, wider
+  listing rather than an empty one.
 
 - **The dev shell's notifications get their icon back.** A dev toast came up
   headed *MindFlock-dev* and badged with the blank white document tile — the one
@@ -60,6 +137,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   usage cap cut short does not count — it did not finish, so the evidence is
   dropped rather than left armed to claim "done" the moment the banner scrolls
   off the pane.
+
+  One more way to hallucinate a work cycle turned up after that, and it needed
+  no mouse click: a session parked untouched for nineteen hours announced
+  "finished". Its own auto-updater burned a single four-second poll's worth of
+  CPU, which the classifier reads as **working** — a busy process tree is how it
+  tells a thinking agent from a parked one — and twelve seconds later it was
+  idle again with a full work cycle behind it. A `/clear`, a garbage collection
+  pause, a stray compile: all of them look the same from outside. So "watched
+  that agent work" now means **corroborated**, not merely *looked busy*. The
+  CLI's own report counts, at any duration — a hook fires because a prompt was
+  submitted or a tool ran. So does the interrupt hint on the pane, which is
+  there *because* a turn is running, and which covers a long turn whose marker
+  goes stale mid-thought. A busy process tree on its own no longer does: it
+  still turns the chip green, and it no longer earns the right to interrupt you.
+  This is not a Claude-only rule. Codex reports through hooks the same way;
+  aider, antigravity, cline, goose and opencode have no hooks, so their status
+  line is the signal — and because a regex against someone else's UI can simply
+  be wrong, those keep a backstop: twenty unbroken seconds of CPU still counts,
+  which no spike lasts. The two CLIs that report for themselves get no backstop,
+  since a spike on a parked session of exactly that kind is the bug being fixed.
+  A test pins which provider sits on which rung, so a CLI that quietly stops
+  matching its own hint shows up as a failure rather than as silence.
 
   Everything that has to stay fast stayed fast. **Needs your input** and **ran
   out of usage** still fire on the instant signal — those are "come here now",

--- a/README.md
+++ b/README.md
@@ -690,9 +690,11 @@ feeds:
 The quietest of the opt-ins is **"a session finishes its work"**, and it means
 it. It does not fire when the chip goes grey — a coding CLI reports a turn ended
 at the end of *every* reply, so that would buzz once per exchange. MindFlock
-sends it only once it has watched that agent actually work, seen it stay idle
-for 45 seconds since, and confirmed nothing is queued to wake it back up: once
-per stretch of real work, however long the session then sits there.
+sends it only once it has watched that agent actually work — corroborated by
+the CLI's own hooks or its status line, not just a CPU blip — seen it stay
+idle since (12–45 seconds, shorter the stronger the evidence), and confirmed
+nothing is queued to wake it back up: once per stretch of real work, however
+long the session then sits there.
 
 To set it up: install the free ntfy app, then in Settings → Notifications →
 **Phone push (ntfy)** hit **Generate** for a random topic, scan the QR into the

--- a/backend/providers/activity_markers.py
+++ b/backend/providers/activity_markers.py
@@ -114,12 +114,12 @@ def read_activity_marker_age(session_name: str) -> Optional[float]:
     return (time.time() - entry[1]) if entry else None
 
 
-def hook_command(state: str, marker_dir, record_thread: bool = True) -> str:
+def hook_command(state: str, marker_dir=None, record_thread: bool = True) -> str:
     """The command a CLI hook runs to record ``state``.
 
     Resolves the *live* tmux session at fire-time (``tmux display-message
     #{session_name}`` — or ``MINDFLOCK_SESSION_NAME`` when the CLI exports it)
-    and writes ``<marker_dir>/<session>.json`` — instead of baking a fixed
+    and writes ``<marker dir>/<session>.json`` — instead of baking a fixed
     per-session path. This is essential when several sessions share one working
     directory (in-place sessions on the same repo): they share one hooks config
     file, so a fixed path would route every session's events into whichever
@@ -127,6 +127,19 @@ def hook_command(state: str, marker_dir, record_thread: bool = True) -> str:
     session that actually fired it. If the session can't be resolved (hook
     running outside tmux), it no-ops (exit 0) and the web layer falls back to
     CPU/pane inspection.
+
+    The MARKER DIRECTORY is resolved at fire-time too, from the hook's own
+    environment (``MINDFLOCK_ACTIVITY_MARKER_DIR``, else the real
+    ``~/.mindflock-assistant/.activity-markers``) — never baked in at install
+    time. The install-time value was a live incident: a Verify session runs
+    its sandboxed MindFlock with ``HOME`` redirected into a scratchpad, and
+    when that instance re-pinned the SHARED repo's hooks file it embedded the
+    sandbox's absolute path — after which every cohabiting session's hooks
+    quietly wrote markers into a dead sandbox, their chips frozen on the last
+    pre-poison reading ("idle" while visibly working). Resolving in the
+    firing CLI's env gives each world its own markers: a sandboxed CLI writes
+    into its sandbox, a real one into the real home, whoever installed last.
+    ``marker_dir`` is accepted and ignored (kept for caller/test signatures).
 
     When ``record_thread`` is True (Claude), the hook also persists the payload's
     ``session_id`` as this window's resume-thread marker — the id
@@ -136,8 +149,6 @@ def hook_command(state: str, marker_dir, record_thread: bool = True) -> str:
     clobbering that with a differently-shaped id.
     """
     import json
-
-    from . import thread_markers
 
     lines = [
         "import json,sys,subprocess,os,time,re",
@@ -157,7 +168,9 @@ def hook_command(state: str, marker_dir, record_thread: bool = True) -> str:
         "if not s:",
         "    raise SystemExit(0)",
         "s=re.sub(r'[^A-Za-z0-9_.-]','_',s)",
-        "d=%s" % json.dumps(str(marker_dir)),
+        "d=os.environ.get('MINDFLOCK_ACTIVITY_MARKER_DIR') or "
+        "os.path.join(os.path.expanduser('~'),"
+        "'.mindflock-assistant','.activity-markers')",
         "os.makedirs(d,exist_ok=True)",
         "open(os.path.join(d,s+'.json'),'w').write("
         "json.dumps({'state':%s,'ts':int(time.time())}))" % json.dumps(state),
@@ -166,7 +179,9 @@ def hook_command(state: str, marker_dir, record_thread: bool = True) -> str:
         lines += [
             "sid=str(p.get('session_id') or '')",
             "if sid:",
-            "    td=%s" % json.dumps(str(thread_markers.marker_dir())),
+            "    td=os.environ.get('MINDFLOCK_THREAD_MARKER_DIR') or "
+            "os.path.join(os.path.expanduser('~'),"
+            "'.mindflock-assistant','.thread-markers')",
             "    os.makedirs(td,exist_ok=True)",
             "    open(os.path.join(td,s+'.thread'),'w').write(sid)",
         ]
@@ -174,7 +189,7 @@ def hook_command(state: str, marker_dir, record_thread: bool = True) -> str:
     return "python3 -c %s || true %s" % (shlex.quote(code), _HOOK_TAG)
 
 
-def notification_hook_command(marker_dir) -> str:
+def notification_hook_command(marker_dir=None) -> str:
     """The command a Notification hook runs — records ``clarify`` only for
     notifications that genuinely need the user (permission / plan / question).
 
@@ -212,11 +227,12 @@ def notification_hook_command(marker_dir) -> str:
         "if not s:\n"
         "    sys.exit(0)\n"
         "s=re.sub(r'[^A-Za-z0-9_.-]','_',s)\n"
-        "md=%s\n"
+        "md=os.environ.get('MINDFLOCK_ACTIVITY_MARKER_DIR') or "
+        "os.path.join(os.path.expanduser('~'),"
+        "'.mindflock-assistant','.activity-markers')\n"
         "os.makedirs(md, exist_ok=True)\n"
         "open(os.path.join(md,s+'.json'), \"w\").write("
         'json.dumps({"state": "clarify", "ts": int(time.time())}))\n'
-        % (json.dumps(str(marker_dir)),)
     )
     return "python3 -c %s || true %s" % (shlex.quote(code), _HOOK_TAG)
 
@@ -402,7 +418,6 @@ def merge_activity_hooks(
     import json
     from pathlib import Path
 
-    md = marker_dir()
     settings_path = Path(settings_path)
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -421,9 +436,9 @@ def merge_activity_hooks(
             entries = []
         entries = [e for e in entries if not is_mindflock_hook_entry(e)]
         if notification_event is not None and event == notification_event:
-            cmd = notification_hook_command(md)
+            cmd = notification_hook_command()
         else:
-            cmd = hook_command(state, md, record_thread=record_thread)
+            cmd = hook_command(state, record_thread=record_thread)
         entries.append({"hooks": [{"type": "command", "command": cmd}]})
         hooks[event] = entries
     settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -342,6 +342,18 @@ class BaseProvider:
         """
         return None
 
+    def reports_activity(self) -> bool:
+        """Whether this CLI announces its own state at all (hooks installed by
+        :meth:`install_activity_hooks`, or a live query).
+
+        NOT the same question as ``activity_state(...) is None``, which is also
+        what a CLI that DOES report says while its marker is merely stale. The
+        web layer needs the CAPABILITY: a session whose CLI can speak for itself
+        must never have a turn-end ANNOUNCEMENT built out of pane guesswork —
+        see ``agent_state._verdict``'s ``arms`` argument. Default: no.
+        """
+        return False
+
     def activity_state_age(self, session_name: str) -> Optional[float]:
         """Seconds since :meth:`activity_state` was last refreshed, or None.
 

--- a/backend/providers/claude.py
+++ b/backend/providers/claude.py
@@ -374,6 +374,11 @@ class ClaudeProvider(BaseProvider):
         return r"([\d.,]+\s*[kmKM]?)\s*tokens"
 
     # --- activity signal ---------------------------------------------------- #
+    def reports_activity(self) -> bool:
+        # Every launch path re-pins the hooks (see install_activity_hooks), and
+        # `claude agents --json` answers live where the binary supports it.
+        return True
+
     def activity_state(self, session_name: str) -> Optional[str]:
         # Prefer Claude Code's own real-time report from `claude agents --json`
         # (never stale — it reflects the live session, including a long think

--- a/backend/providers/generic.py
+++ b/backend/providers/generic.py
@@ -192,6 +192,11 @@ class GenericProvider(BaseProvider):
         except Exception:  # noqa: BLE001 — never break a launch over hook install
             return
 
+    def reports_activity(self) -> bool:
+        # Configured hooks are the whole capability here: without them this CLI
+        # never writes a marker and pane inspection is all there is.
+        return bool(self.cfg.activity_hooks_file)
+
     def activity_state(self, session_name: str) -> Optional[str]:
         # Only trust a marker when this CLI actually writes one (hooks declared);
         # otherwise no signal, so the web layer uses pane inspection unchanged.

--- a/backend/ticket_ingestion/providers/shortcut.py
+++ b/backend/ticket_ingestion/providers/shortcut.py
@@ -146,7 +146,17 @@ class ShortcutProvider(TicketProvider):
         return t
 
     async def _search_stories(self, body: dict) -> list:
-        """One POST /stories/search call, returning the raw story list."""
+        """One POST /stories/search call, returning the raw story list —
+        archived stories excluded.
+
+        ``/stories/search`` returns archived stories, which Shortcut's own
+        boards hide. Listing them puts rows in the panel that cannot be found
+        in Shortcut (six of the ten in one "Unscheduled" bucket, on the
+        author's workspace) and, worse, leaves the backfill scanner free to
+        start work on a story that was archived precisely to stop it.
+        ``archived`` is absent from hand-built payloads in tests; missing reads
+        as live, which is the safe direction — it only ever lists more.
+        """
         url = f"{_SHORTCUT_API_BASE}/stories/search"
         async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
             async with session.post(url, json=body, headers=self._headers()) as resp:
@@ -156,7 +166,56 @@ class ShortcutProvider(TicketProvider):
                         f"Shortcut API returned {resp.status}: {text[:200]}"
                     )
                 data = await resp.json()
-        return data if isinstance(data, list) else []
+        if not isinstance(data, list):
+            return []
+        return [s for s in data if not (isinstance(s, dict) and s.get("archived"))]
+
+    async def _archived_epic_ids(self) -> set:
+        """The ids of archived epics.
+
+        Archiving an epic takes its stories off Shortcut's boards without
+        touching each story's own ``archived`` flag, so the story-level filter
+        above is not the whole rule — a live story under a long-finished epic
+        is just as invisible in Shortcut as an archived one.
+
+        One extra call per search, and best-effort: a failure costs the filter,
+        never the tickets. Deliberately NOT cached on the adapter —
+        :class:`BackfillScanner` and :class:`PipelineOrchestrator` each hold one
+        for the life of the process, so a set cached here would never notice an
+        epic being un-archived and would hide those stories forever.
+        """
+        url = f"{_SHORTCUT_API_BASE}/epics?includes_description=false"
+        try:
+            async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
+                async with session.get(url, headers=self._headers()) as resp:
+                    if resp.status != 200:
+                        return set()
+                    data = await resp.json()
+        except Exception as err:  # noqa: BLE001 — network / token
+            _logger.warning("Could not resolve archived Shortcut epics: %s", err)
+            return set()
+        return {
+            e["id"]
+            for e in (data if isinstance(data, list) else [])
+            if isinstance(e, dict) and e.get("archived") and e.get("id") is not None
+        }
+
+    async def _drop_archived_epic_stories(self, rows: list) -> list:
+        """``rows`` minus the stories belonging to an archived epic.
+
+        Skips the ``/epics`` call entirely when no row carries an ``epic_id``,
+        so the common case (and every test with hand-built stories) costs
+        nothing."""
+        if not any(isinstance(r, dict) and r.get("epic_id") for r in rows):
+            return rows
+        archived = await self._archived_epic_ids()
+        if not archived:
+            return rows
+        return [
+            r
+            for r in rows
+            if not (isinstance(r, dict) and r.get("epic_id") in archived)
+        ]
 
     def _ingest_state_ids(self) -> list[int]:
         """The configured ingest filter as Shortcut state ids. One or several
@@ -196,6 +255,7 @@ class ShortcutProvider(TicketProvider):
                     continue
                 seen_ids.add(sid)
                 data.append(item)
+        data = await self._drop_archived_epic_stories(data)
         # /stories/search returns StorySlim (no description). Hydrate each by id.
         slim = [story_from_api_response(item, self.cfg.api_token) for item in data]
         full: list[Ticket] = []
@@ -238,6 +298,7 @@ class ShortcutProvider(TicketProvider):
                     data.append(item)
         else:
             data = await self._search_stories({"owner_id": self.cfg.member_id})
+        data = await self._drop_archived_epic_stories(data)
         # Workflow-state id -> display name (bucket). Best-effort: an error
         # here degrades to unlabeled buckets, never an empty panel.
         try:

--- a/backend/web/core/agent_state.py
+++ b/backend/web/core/agent_state.py
@@ -123,11 +123,19 @@ def _session_find_prompt(inst, prefix: str) -> Optional[str]:
 #
 # * **pane-inspection bookkeeping**, written only by :func:`_pane_hash_activity`
 #   and meaningful only to it — ``hash`` / ``changed`` / ``state`` / ``streak``
-#   / ``size`` / ``cpu`` / ``cpu_at`` / ``busy_at`` / ``tokens``. ``state`` is
-#   *that layer's* running verdict, not the session's.
+#   / ``size`` / ``cpu`` / ``cpu_at`` / ``busy_at`` / ``tokens`` /
+#   ``hard_since`` / ``proof``. ``state`` is *that layer's* running verdict, not
+#   the session's; ``hard_since`` is when its current run of proven-busy polls
+#   began and ``proof`` is what proved it — ``"status"`` for the provider's own
+#   live-turn status line (Claude's ``esc to interrupt``, a climbing token
+#   counter), ``"cpu"`` for a busy process tree and nothing else. Both are None
+#   between runs. The pair is what decides whether pane inspection may arm a
+#   turn-end announcement; see :func:`_agent_activity`.
 # * **layer-wide provenance**, written by :func:`_verdict` on EVERY return path
 #   of :func:`_agent_activity` — ``created`` / ``reported`` / ``state_since`` /
-#   ``worked_at``. Before these existed only the pane path wrote anything, so a
+#   ``worked_at`` / ``source`` (which layer produced the current reading —
+#   "marker" / "exit" / "proc" / "trust" / "pane") / ``worked_evidence`` (what
+#   corroborated the armed work — "marker" / "status" / "cpu"). Before these existed only the pane path wrote anything, so a
 #   session reporting through its CLI's hooks (the common Claude case) left no
 #   trail at all: ``activity_since`` was dead for exactly those sessions, and
 #   nothing downstream could tell "this agent worked and then stopped" from
@@ -138,6 +146,12 @@ _ACTIVITY_IDLE_AFTER = (
     8.0  # static-pane seconds before working -> idle (2x the UI's 4s poll)
 )
 _ACTIVITY_CONFIRM_POLLS = 2  # consecutive changed polls before idle -> working
+# How long a CPU-ONLY ``working`` run must last before it may ARM a turn-end
+# announcement (see :func:`_verdict`). The backstop for a CLI that does not
+# report its own state, whose only other signal is a status-line regex that may
+# simply be wrong. Well clear of the ~12s a single spike holds the state through
+# `_ACTIVITY_IDLE_AFTER`, and far below any turn worth being told about.
+_CPU_ONLY_ARMS_AFTER_S = 20.0
 _ACTIVITY_NOISE_LINES = (
     2  # bottom pane lines ignored by the hash (cursor/spinner churn)
 )
@@ -194,6 +208,7 @@ def _activity_record(title: str, created) -> dict:
             "reported": None,
             "state_since": 0.0,
             "worked_at": None,
+            "source": "",
         }
         if stamp is not None:
             _ACTIVITY_CACHE[title] = rec
@@ -212,6 +227,7 @@ def _activity_record(title: str, created) -> dict:
         rec.setdefault("reported", None)
         rec.setdefault("state_since", 0.0)
         rec.setdefault("worked_at", None)
+        rec.setdefault("source", "")
         return rec
     if rec.get("created") is None:
         # An EXISTING record with no stamp is a hand-seeded one (tests, and
@@ -219,6 +235,7 @@ def _activity_record(title: str, created) -> dict:
         rec.setdefault("reported", None)
         rec.setdefault("state_since", 0.0)
         rec.setdefault("worked_at", None)
+        rec.setdefault("source", "")
         rec["created"] = stamp
         return rec
     if rec["created"] != stamp:
@@ -229,13 +246,21 @@ def _activity_record(title: str, created) -> dict:
         # process as usage-limited (and 'usage_limit' is a default-ON rule).
         rec.clear()
         rec.update(
-            {"created": stamp, "reported": None, "state_since": 0.0, "worked_at": None}
+            {
+                "created": stamp,
+                "reported": None,
+                "state_since": 0.0,
+                "worked_at": None,
+                "source": "",
+            }
         )
         _LIMIT_PROBE.pop(title, None)
     return rec
 
 
-def _verdict(rec: Optional[dict], value: str, now: float) -> str:
+def _verdict(
+    rec: Optional[dict], value: str, now: float, arms: bool = False, source: str = ""
+) -> str:
     """Record ``value`` as this session's reading and return it.
 
     THE SINGLE EXIT POINT for every layer of :func:`_agent_activity`, so
@@ -250,40 +275,157 @@ def _verdict(rec: Optional[dict], value: str, now: float) -> str:
     session that boots to a bare prompt reports ``idle`` forever. Neither is a
     turn, and neither may arm one.
 
-    ``limit`` actively DROPS it. A turn the account's cap cut short is not a
-    turn that finished, and the reading only says ``limit`` while the banner is
-    on the pane — press a key, or let the throttled re-check expire against a
-    redrawn prompt, and the session reads plain idle again with the cut-short
-    turn's evidence still armed, ready to report "has finished" on work that
-    was abandoned mid-thought. Autopilot drops its own idle dwell on a limit for
-    exactly this reason. A resume re-earns the evidence on the next ``working``.
+    ``arms`` is the second half of that sentence, and every ``working`` reading
+    now has to earn it. A reading is enough to paint the chip; it is not by
+    itself enough to interrupt a human with "your agent finished". The caller
+    passes True only where the reading CORROBORATES work:
+
+    * the CLI's own report (a fresh hook marker / live agent query) — always;
+      a hook fires because a prompt was submitted or a tool ran;
+    * the provider's live-turn status line (Claude's ``esc to interrupt``, a
+      climbing token counter), which is on the pane BECAUSE a turn is running —
+      so it arms even where the CLI's own marker went stale mid-turn;
+    * a busy process tree and nothing else, but ONLY for a CLI that cannot
+      report for itself, and only after `_CPU_ONLY_ARMS_AFTER_S` of unbroken
+      busy polls. See :func:`_agent_activity`, which decides all three.
+
+    Everything else reports its state and arms nothing. The case that forced
+    this: a parked Claude session whose pane burned one 4s poll above
+    `_CPU_ACTIVE_JIFFIES_PER_S` (its own auto-updater, a `/clear`, GC) read as
+    ``working`` for ~12s — long enough to clear the announce path's flicker
+    settle — and 45s later announced a turn that never happened. Its transcript
+    had not been written to in 19 hours. Duration thresholds cannot separate
+    that from a short real turn; provenance can.
+
+    ``source`` names WHICH layer produced the reading — ``"marker"`` (the CLI's
+    own hook marker / live query, including the idle/limit reclassifications
+    built on it), ``"exit"`` (the launch wrapper's exit marker), ``"proc"``
+    (bare shell, no agent process), ``"trust"`` (the startup trust-gate
+    auto-answer), ``"pane"`` (live-pane inspection). It is recorded with the
+    value so downstream consumers can weigh the reading by where it came from:
+    the announce path's settle skip and the queue drain's fast tier both key on
+    :func:`reading_is_authoritative`, and the turn-end dwell tiers key on
+    ``worked_evidence`` — stamped here alongside ``worked_at`` as "marker" for
+    the CLI's own word and otherwise as the pane layer's own ``proof``
+    ("status" / "cpu"), so the announcement can be as fast as its evidence is
+    strong.
+
+    ``limit`` actively DROPS the evidence. A turn the account's cap cut short is
+    not a turn that finished, and the reading only says ``limit`` while the
+    banner is on the pane — press a key, or let the throttled re-check expire
+    against a redrawn prompt, and the session reads plain idle again with the
+    cut-short turn's evidence still armed, ready to report "has finished" on
+    work that was abandoned mid-thought. Autopilot drops its own idle dwell on a
+    limit for exactly this reason. A resume re-earns the evidence on the next
+    armed ``working``.
     """
     if rec is None:
         return value
     if rec.get("reported") != value:
         rec["reported"] = value
         rec["state_since"] = now
+    rec["source"] = source
+    # The (value, source) pair as ONE store, because it is read as one fact:
+    # `reported` and `source` are written back-to-back with no lock while the
+    # drain, autopilot and both tickers all call this concurrently, and two
+    # interleaved calls can leave one caller's value paired with the other's
+    # source — which would let a pane-derived clarify borrow marker authority
+    # for up to a poll. :func:`reading_is_authoritative` reads only this tuple.
+    rec["reading"] = (value, source)
     if value == "working":
-        rec["worked_at"] = now
-    elif value == "limit":
-        rec["worked_at"] = None
+        if arms:
+            # Evidence label BEFORE the timestamp: `_note_turn_boundary` reads
+            # them in the opposite order (evidence, then worked_at), so any
+            # interleaving pairs an old label with an old stamp, or a fresh
+            # stamp with either label — and a fresh stamp always fails the
+            # dwell, which is the conservative outcome. The dangerous pairing
+            # (old stamp judged by a new, faster label) needs the reader to see
+            # the new label before the new stamp, which these two orderings
+            # jointly rule out.
+            rec["worked_evidence"] = (
+                "marker" if source == "marker" else (rec.get("proof") or "cpu")
+            )
+            rec["worked_at"] = now
+    else:
+        # Any non-working reading ends the pane layer's proven-busy run,
+        # WHATEVER layer delivered it. These used to be cleared only by the
+        # pane path's own idle transition, so an idle delivered by the exit
+        # marker (the CLI died), a Stop hook, or the process-tree probe left
+        # `hard_since`/`proof` frozen — and a relaunch into the SAME tmux
+        # session then armed on its first startup-CPU poll, the 20s unbroken
+        # run "satisfied" by a stamp from a run that ended hours earlier.
+        # A limit or clarify interrupts the run just as thoroughly as idle.
+        rec["hard_since"] = None
+        rec["proof"] = None
+        if value == "limit":
+            rec["worked_at"] = None
     return value
 
 
 def worked_at(title: str) -> Optional[float]:
-    """Epoch this session was last OBSERVED working in its current tmux
+    """Epoch this session was last CORROBORATED working in its current tmux
     incarnation, or None — the provenance behind ``session.turn_ended``.
 
-    None means one of three things, and all three are "there is no turn to
-    announce": the session has never been seen working, its tmux session was
-    relaunched since (:func:`_activity_record` resets the record), or a turn
-    end has already been announced for the work we saw (:func:`claim_work`).
+    Corroborated, not merely reported: only readings passed to :func:`_verdict`
+    with ``arms=True`` stamp this. A pane that momentarily looks busy moves the
+    badge and leaves no evidence behind.
+
+    None means one of four things, and all four are "there is no turn to
+    announce": the session has never been seen working, nothing has corroborated
+    the work it appeared to do, its tmux session was relaunched since
+    (:func:`_activity_record` resets the record), or a turn end has already been
+    announced for the work we saw (:func:`claim_work`).
 
     A read, for gating. The announcement itself must go through
     :func:`claim_work`, which is the same question asked atomically.
     """
     val = (_ACTIVITY_CACHE.get(title) or {}).get("worked_at")
     return float(val) if isinstance(val, (int, float)) else None
+
+
+#: Reading sources whose word is the CLI's own (or the definitive record of its
+#: death) rather than an inference from what the pane looks like. These are the
+#: sources that may skip the announce path's flicker settle and take the queue
+#: drain's fast tier: a hook marker cannot flicker — it changes only when the
+#: CLI fires a hook — and an exit marker is written exactly once, by the launch
+#: wrapper, when the agent command ends. "proc" is deliberately absent: the
+#: process-tree probe can misread transiently (a ps race, a missing pane pid),
+#: which is precisely the failure the settle exists to absorb.
+_AUTHORITATIVE_SOURCES = frozenset({"marker", "exit"})
+
+
+def reading_is_authoritative(title: str, value: str) -> bool:
+    """Whether ``title``'s CURRENT recorded reading is ``value`` AND came from
+    an authoritative source (:data:`_AUTHORITATIVE_SOURCES`).
+
+    Both halves matter. The value comparison guards the memo skew the server
+    documents in ``_note_turn_boundary``: the tickers serve activity out of a
+    2.5s probe memo while the queue drain and autopilot make UNCACHED calls on
+    their own cadences, so at any instant the rolling record can describe a
+    NEWER reading than the value a caller holds. Claiming authority for a value
+    the record no longer reports would let a consumer skip its safety net on
+    the strength of a different reading entirely — so a mismatch answers False,
+    which every consumer treats as "take the slow, guarded path".
+    """
+    reading = (_ACTIVITY_CACHE.get(title) or {}).get("reading") or ()
+    return (
+        len(reading) == 2
+        and reading[0] == value
+        and reading[1] in _AUTHORITATIVE_SOURCES
+    )
+
+
+def work_evidence(title: str) -> str:
+    """What corroborated this session's ``worked_at`` evidence: ``"marker"``
+    (the CLI's own report), ``"status"`` (the provider's live-turn status
+    line), ``"cpu"`` (the sustained-CPU backstop), or ``""`` (no armed
+    evidence recorded). The turn-end announcement picks its dwell tier from
+    this — the stronger the evidence, the less time it needs to buy
+    confidence. Left in place by :func:`claim_work` on purpose: it describes
+    the last armed cycle, and it is only ever read next to ``worked_at``.
+    """
+    val = (_ACTIVITY_CACHE.get(title) or {}).get("worked_evidence")
+    return str(val) if isinstance(val, str) else ""
 
 
 #: Guards the read-and-clear in :func:`claim_work`. Nothing else needs it —
@@ -793,7 +935,7 @@ def _marker_is_current(provider, name: str, created) -> bool:
         return True
 
 
-def _idle_or_limit(srv, title: str, name: str, provider) -> str:
+def _idle_or_limit(srv, title: str, name: str, provider, force: bool = False) -> str:
     """``"limit"`` when a session that LOOKS idle is really parked on a
     usage-limit screen, else ``"idle"``.
 
@@ -807,12 +949,47 @@ def _idle_or_limit(srv, title: str, name: str, provider) -> str:
 
     Throttled to one capture per :data:`_LIMIT_RECHECK_S` per session, because
     the marker path exists precisely to avoid a pane capture on every poll.
+
+    ``force`` bypasses the throttle for one capture. The caller passes it on
+    the working→idle marker TRANSITION — the first idle reading after a turn —
+    because that is exactly where the throttle used to open a blind window: a
+    cached "no banner" verdict taken before the turn started was served for up
+    to 15s after a limit cut the turn short, and if the banner left the pane
+    inside that window (a keypress, the prompt redrawing at reset time) the
+    limit was never observed at all — the cut-short turn's work evidence
+    stayed armed and a "has finished" went out for abandoned work. Probing
+    fresh at the moment the turn ends closes the window at the moment it
+    opens. Cost: one forced capture per caller that observes the transition —
+    the first _verdict flips ``reported`` to idle, so steady-state polls never
+    re-force, but the uncached drain/autopilot probes and any memo-missing
+    poller landing inside the first capture's window each force their own
+    (bounded by caller count, a handful at worst).
     Never raises."""
     now = time.time()
     rec = _LIMIT_PROBE.get(title)
-    if rec is None or now - float(rec.get("at") or 0.0) >= _LIMIT_RECHECK_S:
-        rec = {"at": now, "limit": _limit_on_pane(srv, name, provider)}
-        _LIMIT_PROBE[title] = rec
+    stale = rec is None or now - float(rec.get("at") or 0.0) >= _LIMIT_RECHECK_S
+    if force or stale:
+        if _limit_on_pane(srv, name, provider):
+            # "Banner seen" always wins and always caches — the safe direction.
+            _LIMIT_PROBE[title] = {"at": now, "limit": True}
+            return "limit"
+        if stale:
+            _LIMIT_PROBE[title] = {"at": now, "limit": False}
+        else:
+            # A FORCED miss must not buy the throttle a fresh 15s: the one
+            # forced capture can race the CLI's banner paint (the Stop-hook
+            # marker write and the redraw are independent) or fail outright
+            # (_limit_on_pane answers False on any capture error), and the
+            # fast marker-tier dwell (12s) expires INSIDE the throttle window
+            # — announcing a limit-cut turn as finished before any re-probe
+            # could catch it. Zeroing the stamp makes the NEXT poll re-probe
+            # at tick cadence instead: one extra capture per turn end, and a
+            # late-painted banner is seen ~4s later, well inside every dwell.
+            # Never clobber a concurrent capture that DID see the banner.
+            cur = _LIMIT_PROBE.get(title)
+            if not (cur and cur.get("limit")):
+                _LIMIT_PROBE[title] = {"at": 0.0, "limit": False}
+        return "idle"
     return "limit" if rec.get("limit") else "idle"
 
 
@@ -909,6 +1086,12 @@ def _pane_hash_activity(
                 # below falls back to `changed`, which is now — so a pane that
                 # stays quiet simply stays idle.
                 "busy_at": now if state == "working" else None,
+                # Same evidence, different question: busy_at runs the idle
+                # hysteresis, hard_since runs the announce gate.
+                "hard_since": now if state == "working" else None,
+                # The only single-frame route to "working" here is the
+                # provider's own interrupt hint, which is turn-specific proof.
+                "proof": "status" if state == "working" else None,
                 # Baseline the turn-token counter now so the NEXT poll can
                 # already tell a climb (work) from a flat counter (idle).
                 "tokens": tokens,
@@ -968,6 +1151,15 @@ def _pane_hash_activity(
             rec["changed"] = now
             rec["streak"] = 0
             rec["state"] = "working"
+            if not rec.get("hard_since"):
+                rec["hard_since"] = now
+            # A busy process tree says SOMETHING is running, not that a turn is:
+            # an auto-updater, a `/clear`, a GC pause and a compile all cross
+            # this line. The status line, when the provider has one, says which.
+            if status_working:
+                rec["proof"] = "status"
+            elif not rec.get("proof"):
+                rec["proof"] = "cpu"
             return "working"
         # CPU quiet. On a STABLE pane, a usage-limit SCREEN or a visible
         # waiting-prompt means the agent has parked. The limit banner is checked
@@ -994,6 +1186,9 @@ def _pane_hash_activity(
             rec["changed"] = now
             rec["streak"] = 0
             rec["state"] = "working"
+            if not rec.get("hard_since"):
+                rec["hard_since"] = now
+            rec["proof"] = "status"
             return "working"
         # NO pane-change promotion here, deliberately. On this branch CPU is the
         # authoritative signal and a changing pane is noise: an idle Claude
@@ -1012,6 +1207,11 @@ def _pane_hash_activity(
         if now - busy_at >= _ACTIVITY_IDLE_AFTER:
             rec["streak"] = 0
             rec["state"] = "idle"
+            # The run of proven-busy polls is over. The next one starts its own
+            # clock and earns its own proof, so two spikes either side of a lull
+            # never add up to a turn.
+            rec["hard_since"] = None
+            rec["proof"] = None
         return rec.get("state", "idle")
 
     # Fallback (no /proc CPU, e.g. macOS): pane-hash hysteresis. A usage-limit
@@ -1035,16 +1235,27 @@ def _pane_hash_activity(
         rec["changed"] = now
         rec["streak"] = 0
         rec["state"] = "working"
+        if not rec.get("hard_since"):
+            rec["hard_since"] = now
+        rec["proof"] = "status"
         return "working"
     if changed:
         rec["changed"] = now
         rec["streak"] = rec.get("streak", 0) + 1
         if rec.get("state") != "working" and rec["streak"] >= _ACTIVITY_CONFIRM_POLLS:
             rec["state"] = "working"
+            if not rec.get("hard_since"):
+                rec["hard_since"] = now
+            # "The text keeps moving" is the weakest evidence there is; it ranks
+            # with CPU, never above it.
+            if not rec.get("proof"):
+                rec["proof"] = "cpu"
     else:
         rec["streak"] = 0
         if now - rec.get("changed", now) >= _ACTIVITY_IDLE_AFTER:
             rec["state"] = "idle"
+            rec["hard_since"] = None
+            rec["proof"] = None
     return rec.get("state", "idle")
 
 
@@ -1122,10 +1333,10 @@ def _agent_activity(inst, title: str) -> str:
         # on a freshly-created session BEFORE any hook-marker short-circuit
         # below, so a seeded (PR/ticket) prompt can't sit parked behind it.
         if _startup_trust_gate_clarify(srv, inst, title, name, created):
-            return _verdict(rec, "clarify", now)
+            return _verdict(rec, "clarify", now, source="trust")
         # Layer 0: the agent command ENDED (exit marker written this session).
         if srv._agent_exited(name, created):
-            return _verdict(rec, "idle", now)
+            return _verdict(rec, "idle", now, source="exit")
         # Layer 1: the CLI's own report (Claude Code hook marker).
         provider = providers.resolve(getattr(inst, "Program", "") or "")
         # Bind this window to its own conversation id while it runs (throttled)
@@ -1146,9 +1357,28 @@ def _agent_activity(inst, title: str) -> str:
             # WITHIN THIS INCARNATION (see :func:`_marker_is_current`).
             # WHY it ended is another question: a turn the account's usage limit
             # cut short fires the same hook as a completed one, so the pane is
-            # checked (throttled) before this idle is passed on. See
-            # :func:`_idle_or_limit`.
-            return _verdict(rec, _idle_or_limit(srv, title, name, provider), now)
+            # checked before this idle is passed on. The check is throttled in
+            # steady state and FORCED fresh on the working→idle transition —
+            # ``rec["reported"]`` still holds the previous verdict here, since
+            # _verdict runs after _idle_or_limit — because the first idle after
+            # a turn is exactly where a cached pre-turn "no banner" verdict
+            # used to hide a limit that cut the turn short (and, if the banner
+            # then left the pane inside the throttle window, hide it forever).
+            # See :func:`_idle_or_limit`.
+            reading = rec.get("reading") or ()
+            ended_a_turn = (
+                len(reading) == 2
+                and reading[0] in ("working", "clarify")
+                # A trust-gate clarify precedes any turn — a fresh session
+                # resolving its gate to idle ended nothing worth a capture.
+                and reading[1] != "trust"
+            )
+            return _verdict(
+                rec,
+                _idle_or_limit(srv, title, name, provider, force=ended_a_turn),
+                now,
+                source="marker",
+            )
         if marked in ("working", "clarify"):
             # working/clarify markers only refresh on hook events (tool call,
             # prompt submit, notification). A long thinking/generating stretch
@@ -1167,8 +1397,12 @@ def _agent_activity(inst, title: str) -> str:
                 # treats it as a human gate and the queue stalls behind a menu
                 # that never clears on its own, even after the window reopens.
                 if marked == "clarify" and _limit_on_pane(srv, name, provider):
-                    return _verdict(rec, "limit", now)
-                return _verdict(rec, marked, now)
+                    return _verdict(rec, "limit", now, source="marker")
+                # The CLI said so itself, so this is the one reading allowed to
+                # arm a turn-end announcement — at any duration. A hook fires
+                # because a prompt was submitted or a tool ran; there is no
+                # cosmetic redraw or background CPU burst behind it.
+                return _verdict(rec, marked, now, arms=True, source="marker")
         # Layer 2: a bare shell holds the pane AND nothing but shells lives
         # under it -> the agent isn't running, whatever the pane looks like.
         if (
@@ -1176,16 +1410,50 @@ def _agent_activity(inst, title: str) -> str:
             and fg.lower() in _BARE_SHELLS
             and not srv._pane_has_agent_process(pane_pid)
         ):
-            return _verdict(rec, "idle", now)
+            return _verdict(rec, "idle", now, source="proc")
         # Layers 3-4: live-pane inspection (CPU rate + status-line proof under
         # asymmetric hysteresis, with a pane-hash fallback where /proc CPU is
         # unavailable). Kept in its own helper so the layered dispatch above
         # reads as a sequence of authoritative-first probes.
-        return _verdict(
-            rec,
-            _pane_hash_activity(srv, inst, title, name, provider, pane_pid, pane_size),
-            now,
+        pane_state = _pane_hash_activity(
+            srv, inst, title, name, provider, pane_pid, pane_size
         )
+        # What the pane looks like is enough to paint the chip. Whether it may
+        # also announce that a TURN ENDED depends on what proved it busy:
+        #
+        # * The provider's own live-turn status line (Claude's ``esc to
+        #   interrupt``, a climbing token counter) is turn-specific proof — it
+        #   is on screen because a turn is running — so it arms, hooks or no
+        #   hooks. That is the case where a CLI reports for itself but its
+        #   marker went stale mid-turn.
+        # * CPU alone does not. A busy process tree means something is running,
+        #   not that a turn is: a parked Claude session's own auto-updater
+        #   crossed `_CPU_ACTIVE_JIFFIES_PER_S` for ONE 4s poll, read as
+        #   ``working`` for ~12s — past the announce path's flicker settle — and
+        #   45s later announced a turn its transcript shows never happened.
+        # * A CLI that does NOT report for itself keeps a CPU backstop, because
+        #   a status-line regex is all such a provider has and a regex can be
+        #   wrong — its CLI reworded the hint, or nobody filled one in. Losing
+        #   the announcement entirely to a bad pattern is worse than the spike
+        #   it protects against, so an UNBROKEN busy run of
+        #   `_CPU_ONLY_ARMS_AFTER_S` arms there. No backstop where the CLI does
+        #   report (Claude, Codex): those have two independent signals already,
+        #   and the phantom this whole ladder exists to kill was one of theirs.
+        arms = False
+        if pane_state == "working" and rec:
+            if rec.get("proof") == "status":
+                arms = True
+            elif marked is None or not provider.reports_activity():
+                # The backstop is denied only to a CLI whose hooks are actually
+                # SPEAKING (``marked`` non-None this poll — fresh or stale, the
+                # marker machinery works). ``reports_activity`` alone is a
+                # config declaration: a codex build without the hooks engine,
+                # or a hook install that failed silently, still declares True —
+                # and denying such a session the backstop leaves it with one
+                # regex as its only route to a turn-end, forever.
+                since = rec.get("hard_since")
+                arms = bool(since) and (now - float(since)) >= _CPU_ONLY_ARMS_AFTER_S
+        return _verdict(rec, pane_state, now, arms=arms, source="pane")
     except Exception:  # noqa: BLE001
         return "offline"
 

--- a/backend/web/core/terminal.py
+++ b/backend/web/core/terminal.py
@@ -261,10 +261,20 @@ def spawn_tail(path, lines: int = 500, dimensions=(24, 80)):
     )
 
 
-async def pump_pty(ws: WebSocket, proc, allow_input: bool = True) -> None:
+async def pump_pty(
+    ws: WebSocket, proc, allow_input: bool = True, on_input=None
+) -> None:
     """Bridge a PtyProcess to a websocket: PTY output -> ws, ws input -> PTY,
     resize control frames -> ioctl. ``allow_input=False`` makes it read-only
-    (used for the log stream)."""
+    (used for the log stream).
+
+    ``on_input`` (optional, no-arg) is called for every HUMAN input frame —
+    keystrokes and synthesized scroll alike, but never resize control frames,
+    which fire on layout changes with nobody at the keyboard. The server's
+    session terminals pass a presence stamp through it (a person typing in a
+    window is a person who does not need a push about that window); callers
+    with no interest in presence (the assistant pane, the log stream) pass
+    nothing. Best-effort: a failing callback must not break the pump."""
     loop = asyncio.get_running_loop()
     out_q: "asyncio.Queue[Optional[bytes]]" = asyncio.Queue()
     fd = proc.fd
@@ -305,6 +315,11 @@ async def pump_pty(ws: WebSocket, proc, allow_input: bool = True) -> None:
             b = msg.get("bytes")
             if b is not None:
                 if allow_input:
+                    if on_input is not None:
+                        try:
+                            on_input()
+                        except Exception:  # noqa: BLE001
+                            pass
                     os.write(fd, b)
                 continue
             t = msg.get("text")
@@ -319,6 +334,11 @@ async def pump_pty(ws: WebSocket, proc, allow_input: bool = True) -> None:
                     except Exception:  # noqa: BLE001
                         pass
                 elif allow_input:
+                    if on_input is not None:
+                        try:
+                            on_input()
+                        except Exception:  # noqa: BLE001
+                            pass
                     os.write(fd, t.encode("utf-8"))
     except WebSocketDisconnect:
         pass

--- a/backend/web/server.py
+++ b/backend/web/server.py
@@ -769,6 +769,29 @@ def _emit_state_changes(title: str, status: str, activity: str, stage: str) -> N
             prev is not None
             and activity != prev.get("activity")
             and activity in _SETTLE_ACTIVITIES
+            # An AUTHORITATIVE idle/clarify skips the settle. The 3s parking
+            # exists for pane-derived MISREADS — a scrolling menu matched as a
+            # waiting prompt, a redraw matched as idle — and a hook marker
+            # cannot misread a frame: it changes only when the CLI fires a
+            # hook. Holding it 3s+a tick was pure latency on the chip and on
+            # the default-on "needs your input" push. Deliberately NOT
+            # "limit": both marker-branch limit reclassifications are really
+            # pane facts (a capture matched against the limit patterns — see
+            # _idle_or_limit / _limit_on_pane), and a single frame CAN misread
+            # those (scrollback in copy-mode, agent output quoting a banner),
+            # so the default-on "ran out of usage" push keeps its two-sighting
+            # guard. What a marker CAN legitimately do is flip idle→working at
+            # a chained turn boundary (Stop then an immediate
+            # UserPromptSubmit); the skip lets that pair through where the
+            # settle sometimes swallowed it — an extra chip flick per chained
+            # turn, accepted for the latency. The check binds source to THIS
+            # value atomically (see reading_is_authoritative) so a stale
+            # memoized reading can never borrow a newer reading's authority —
+            # any mismatch takes the settle, the guarded path.
+            and not (
+                activity in ("idle", "clarify")
+                and _agent_state.reading_is_authoritative(title, activity)
+            )
         ):
             pending = prev.get("pending_activity")
             if pending is None or pending[0] != activity:
@@ -835,26 +858,128 @@ def _emit_state_changes(title: str, status: str, activity: str, stage: str) -> N
 # has been continuously idle since, and nothing is queued to wake it back up.
 # Every "the agent is done" channel keys on THIS; nothing keys on the raw idle.
 #
-# Why 45s, given the whole pipeline already debounces:
-#   * `_ACTIVITY_SETTLE_SECONDS` (3.0) is a FLICKER filter — it can only
-#     suppress a reading that reverts, and a session parked at its prompt never
-#     reverts. It is structurally incapable of answering this question.
-#   * It must exceed the inter-turn gap of an interactive conversation. A human
-#     reading a long answer and typing a follow-up is 10-30s, and the Stop hook
-#     fires in that gap every single time.
-#   * It must exceed the prompt queue's whole send path — `_QUEUE_IDLE_SETTLE`
-#     (12.0) + a 5s drain pass + `_QUEUE_SEND_COOLDOWN` (8.0) — so an
-#     unattended queued run never announces "finished" between two prompts. The
-#     queue check below makes that exact rather than a race; the number is the
-#     belt to its braces.
-#   * It must exceed autopilot's own idle settle (autopilot.IDLE_SETTLE_S, 30.0)
-#     so the order is always "the chain decided the agent was done, THEN we said
-#     so" — never the reverse.
-#   * It must be large against the 4s tick so two unsynchronised tickers plus an
-#     on-demand `_republish_session` shift the answer by ~±9%, not ±25%.
-# The cost of being wrong is 45s of latency on a "your agent is done" push. The
-# alternative was a buzz per turn.
+# The dwell is TIERED by how the work evidence was corroborated
+# (``agent_state.work_evidence``), because the dwell only has to buy the
+# confidence the evidence itself lacks. It used to be a flat 45s chosen as a
+# blanket over three hazards — a human typing a follow-up, the queue's send
+# path, autopilot's own settle — each of which is now checked EXACTLY by its
+# own gate below (recent human keystrokes, the drain's sent_at grace, the
+# autopilot record's state), so the time-padding survives only where the
+# evidence is weak:
+#
+#   * "marker" (the CLI's own hook report) — 12s. The Stop hook is
+#     authoritative that the turn ended; the working→idle transition also
+#     forces a FRESH limit-screen probe (see agent_state._idle_or_limit), so
+#     the old 15s probe-cache blind window no longer bounds this tier. 12s is
+#     three 4s ticks: enough that two unsynchronised tickers plus an on-demand
+#     `_republish_session` shift the answer by a tick, not by half the dwell,
+#     and enough to ride out hook-chained auto-continues (a Stop followed
+#     immediately by a UserPromptSubmit reads working again within a tick).
+#   * "status" (the provider's live-turn status line) — 25s. The turn-END
+#     detection here is itself pane-based (`_ACTIVITY_IDLE_AFTER` of static
+#     pane before idle is even reported), so the dwell carries more of the
+#     burden than it does for a hook CLI.
+#   * "cpu" (the sustained-CPU backstop), or no recorded evidence — 45s,
+#     unchanged. The weakest tier stays the slowest; that is the deal the
+#     backstop was admitted on.
+#
+# What the dwell deliberately no longer covers, because the exact gates do:
+#   * the inter-turn gap of an INTERACTIVE conversation — `_HUMAN_HOLD_S`
+#     holds the announcement while keystrokes have recently reached this
+#     session (terminal, /send, send-now, voice, mobile compose);
+#   * the queue's pop→visible-working window — `_QUEUE_SEND_GRACE_S` holds
+#     while a just-sent prompt has not yet been seen working (peek_next reads
+#     None the instant the last prompt is POPPED, which is at tmux-typing
+#     time, not at pickup time);
+#   * fast-track — held exactly while the session's autopilot record says
+#     state == "running", so the order is always "the chain decided the agent
+#     was done, THEN we said so", at any dwell.
+# `_ACTIVITY_SETTLE_SECONDS` (3.0) is a FLICKER filter — it can only suppress
+# a reading that reverts, and a session parked at its prompt never reverts. It
+# is structurally incapable of answering this question at any tier.
 _TURN_END_DWELL_S = 45.0
+_TURN_END_DWELL_MARKER_S = 12.0
+_TURN_END_DWELL_STATUS_S = 25.0
+#: Dwell per work-evidence tier; unknown/absent evidence gets the slow lane.
+_TURN_END_DWELLS = {
+    "marker": _TURN_END_DWELL_MARKER_S,
+    "status": _TURN_END_DWELL_STATUS_S,
+}
+
+# Hold "has finished" while a human has recently typed into this session — a
+# person mid-composition is about to start the next turn, and a person typing
+# in the window does not need a push about the window. Stamped by
+# `_note_human_input` from every human input path (both terminal websockets,
+# /send, queue send-now; voice dictation and the mobile composer ride the
+# terminal socket) and never by automation (queue drain, limit auto-resume and
+# the trust-gate dismissal all go through `tmux send-keys`, which touches none
+# of those paths). Presence only tunes TIMING: the hard gates above it
+# guarantee the announcement's sentence is true, so a missed stamp (a user
+# typing into tmux directly, outside the web UI) merely announces sooner, and
+# an over-eager stamp (scroll wheels ride the same socket) merely announces
+# later.
+_HUMAN_HOLD_S = 45.0
+#: Ignore terminal input for this long after a websocket attaches: tmux probes
+#: a newly attached client and xterm.js auto-answers through the same data
+#: path as keystrokes, so attach/reconnect bursts are not presence.
+_ATTACH_PROBE_GRACE_S = 2.0
+_HUMAN_INPUT_AT: Dict[str, float] = {}
+
+
+def _note_human_input(title: str) -> None:
+    """Record that a human just put input into ``title``'s window."""
+    _HUMAN_INPUT_AT[title] = time.time()
+
+
+def _tmux_client_input_recent(title: str, within: float) -> bool:
+    """Whether any tmux client attached to ``title``'s session saw input in
+    the last ``within`` seconds — the presence signal for people the web
+    surfaces cannot see: a Windows Terminal tab, a raw ``tmux attach``, SSH.
+    Their keystrokes never cross a MindFlock route, so without this the
+    presence gate would buzz a direct-tmux conversation once per turn.
+
+    Asked only at announce time (one ``list-clients`` per announce-eligible
+    tick, after every cheaper gate has passed), never on the poll path.
+    Over-counts in one known way: the web terminal is itself an attached
+    client, and its terminal emulator answers tmux's attach-time device
+    probes as client input — so a reconnect storm (wifi blip, laptop wake)
+    reads as presence and defers announcements up to ``within``. That errs
+    the direction this whole pipeline errs: late, never wrong. Best-effort:
+    any failure reads as "nobody there" and the announcement proceeds.
+    """
+    try:
+        name = tmux.to_mindflock_tmux_name(title)
+        cp = _run_capped(
+            ["tmux", "list-clients", "-t", name, "-F", "#{client_activity}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        if cp.returncode != 0:
+            return False
+        now = time.time()
+        for tok in cp.stdout.decode("utf-8", "replace").split():
+            try:
+                if now - float(tok) < within:
+                    return True
+            except ValueError:
+                continue
+    except Exception:  # noqa: BLE001 — presence is a courtesy, never a gate
+        pass
+    return False
+
+
+# Hold "has finished" while a queued prompt is in flight: `record_sent` POPS
+# the item the moment tmux typing succeeds, so `peek_next` reads None seconds
+# to minutes before the agent visibly starts the turn (or never, for a send
+# that didn't take). The drain's own record carries the exact facts — `armed`
+# flips back True only when the drain OBSERVES working, and `sent_at` stamps
+# the send — so the gate is "sent, not yet seen working, recently": precise
+# where the old flat dwell was a blanket. Past the grace with the agent never
+# seen working, the send is presumed lost (the drain's own recovery for that
+# is `_QUEUE_REARM_IDLE`) and the announcement falls through, exactly as the
+# flat 45s used to behave.
+_QUEUE_SEND_GRACE_S = 60.0
 
 
 def _note_turn_boundary(title: str, snap: dict, now: float) -> None:
@@ -862,23 +987,39 @@ def _note_turn_boundary(title: str, snap: dict, now: float) -> None:
 
     Called from the tail of :func:`_emit_state_changes` with the settled
     snapshot, so it sees exactly the activity the rest of the app was told
-    about. Five gates, in cheapest-first order:
+    about. Eight gates, in cheapest-first order:
 
     1. **The settled activity is idle.** ``limit`` is deliberately excluded — a
        turn the usage cap cut short is not a turn that ended, and the
        default-on ``usage_limit`` rule already covers it. So is ``offline``.
     2. **Boot quiet**, for the same reason the diff events observe it: a
        restart rediscovers every parked session and none of that is news.
-    3. **Provenance.** ``agent_state.worked_at`` is None unless this agent was
-       seen working in its CURRENT tmux incarnation. This is the whole
-       offline-click fix: re-opening a window relaunches its CLI, and the fresh
-       incarnation has no work behind it, so no amount of idling produces a
-       "finished".
-    4. **Dwell**, asked of both clocks: `_TURN_END_DWELL_S` since the announced
-       activity became idle, AND since the agent was last seen working. They can
-       disagree, and the second is what the sentence actually claims.
-    5. **Nothing queued.** An exact check, not a race against the drain's own
-       `_QUEUE_IDLE_SETTLE`: a run with prompts still to feed has not finished.
+    3. **Provenance.** ``agent_state.worked_at`` is None unless work by this
+       agent was CORROBORATED in its CURRENT tmux incarnation — the CLI's own
+       hook/live report, or (only for a CLI that has none) a sustained run of
+       proven-busy pane polls. Two failures live here. Re-opening a window
+       relaunches its CLI, and the fresh incarnation has no work behind it, so
+       no amount of idling produces a "finished". And a parked session that
+       merely LOOKS busy for a poll — its own auto-updater, a ``/clear``, a GC
+       pause, anything that crosses the CPU threshold — moves the badge and
+       arms nothing: the reading is enough to paint a chip, never to interrupt
+       a human.
+    4. **Dwell**, tiered by the evidence's own strength (`_TURN_END_DWELLS`
+       via ``agent_state.work_evidence``) and asked of both clocks: since the
+       announced activity became idle, AND since the agent was last seen
+       working. They can disagree, and the second is what the sentence
+       actually claims.
+    5. **Nothing queued.** An exact check of the pending list. Exact about
+       prompts still WAITING — the next gate covers the one already sent.
+    6. **No send in flight.** The drain popped a prompt (peek reads None) but
+       has not yet observed the agent working: `_QUEUE_SEND_GRACE_S` against
+       the drain's own ``sent_at``/``armed`` record.
+    7. **No human at the keys.** `_HUMAN_HOLD_S` since the last keystroke
+       reached this session — a person mid-follow-up is not a finished run,
+       and a person typing in the window does not need a push about it.
+    8. **Fast-track is not mid-chain.** Held exactly while the autopilot
+       record reads ``running`` — the chain announces its own outcome, and
+       "finished" before its commit/push/PR lands would be mistimed at best.
 
     Emitting SPENDS the evidence (``agent_state.claim_work``). That, not a
     seconds window, is the real dedupe: one announcement per cycle of observed
@@ -890,11 +1031,27 @@ def _note_turn_boundary(title: str, snap: dict, now: float) -> None:
     try:
         if snap.get("activity") != "idle" or _in_boot_quiet():
             return
+        # Evidence label BEFORE the timestamp — the mirror of _verdict's write
+        # order, so no interleaving can pair an old stamp with a newer, faster
+        # label (a fresh stamp always fails the dwell; see _verdict).
+        evidence = _agent_state.work_evidence(title)
         worked = _agent_state.worked_at(title)
         if worked is None:
             return
+        # The tier is keyed on how the WORK was corroborated, but the fast
+        # lane also needs the END to be the CLI's own word: marker-armed work
+        # whose idle reading came from the PANE (the marker went stale mid-
+        # turn and a scrolled-back capture read as parked) is a pane-detected
+        # end wearing marker-armed evidence, and 12s of that can announce —
+        # and SPEND — a turn that is still running. Mismatch takes the slow
+        # lane outright.
+        if evidence == "marker" and not _agent_state.reading_is_authoritative(
+            title, "idle"
+        ):
+            evidence = ""
+        dwell = _TURN_END_DWELLS.get(evidence, _TURN_END_DWELL_S)
         idle_for = now - float(snap.get("activity_at") or now)
-        if idle_for < _TURN_END_DWELL_S:
+        if idle_for < dwell:
             return
         # The same dwell against the EVIDENCE's own clock. The two can disagree:
         # ``activity_at`` moves only when a settled reading reaches this
@@ -908,10 +1065,37 @@ def _note_turn_boundary(title: str, snap: dict, now: float) -> None:
         # both clocks closes the whole class — memo skew, snapshot lag, and the
         # two uncached probes — with one comparison. (Epoch here, monotonic
         # above; each is compared only against its own kind.)
-        if time.time() - float(worked) < _TURN_END_DWELL_S:
+        if time.time() - float(worked) < dwell:
             return
         if _prompt_queue.peek_next(title) is not None:
             return
+        # A popped-but-not-picked-up prompt: the drain disarms on send and
+        # re-arms only when it OBSERVES working, so "disarmed and recently
+        # sent" is precisely the in-flight window peek_next cannot see.
+        q = _QUEUE_STATE.get(title)
+        if (
+            q
+            and not q.get("armed", True)
+            and time.time() - float(q.get("sent_at") or 0.0) < _QUEUE_SEND_GRACE_S
+        ):
+            return
+        if time.time() - _HUMAN_INPUT_AT.get(title, 0.0) < _HUMAN_HOLD_S:
+            return
+        if _tmux_client_input_recent(title, _HUMAN_HOLD_S):
+            return
+        # Exact, not a bigger number: while the chain runs, its own events are
+        # the narrative, and its completion releases this gate. A file read,
+        # but only reachable once every cheaper gate has passed — at most a
+        # couple of reads per announce, not per tick. Bounded by the driver's
+        # own lease: _autopilot_observe early-returns WITHOUT claiming on the
+        # paths it cannot step (budget lock, missing worktree), so a chain no
+        # driver is actually advancing goes lease-stale and announcements
+        # resume — "running" alone must not be able to mute a session forever.
+        run = _autopilot.get(title)
+        if run is not None and (run.get("state") or "") == "running":
+            owner_at = float(run.get("owner_at") or 0.0)
+            if time.time() - owner_at <= _autopilot.LEASE_STALE_S * 2:
+                return
         # Claiming the evidence is what grants permission to speak: two
         # unsynchronised tickers can reach this line in the same instant, and
         # only one of them can win the clear.
@@ -1075,7 +1259,7 @@ def _forget_session_state(title: str) -> None:
     dicts accumulate dead entries for the life of the server under churn.
     """
     _forget_probes(title)
-    for _d in (_ACTIVITY_CACHE, _LIMIT_PROBE, _TRUST_DISMISS_AT):
+    for _d in (_ACTIVITY_CACHE, _LIMIT_PROBE, _TRUST_DISMISS_AT, _HUMAN_INPUT_AT):
         _d.pop(title, None)
     # Keyed by TMUX SESSION NAME, not by title (see agent_state._maybe_record_
     # thread), so it needs the translation the others do not.
@@ -1092,7 +1276,7 @@ def _prune_session_state(live_titles) -> None:
     """
     live = set(live_titles or ())
     live_names = {tmux.to_mindflock_tmux_name(t) for t in live}
-    for _d in (_ACTIVITY_CACHE, _LIMIT_PROBE, _TRUST_DISMISS_AT):
+    for _d in (_ACTIVITY_CACHE, _LIMIT_PROBE, _TRUST_DISMISS_AT, _HUMAN_INPUT_AT):
         for dead in [t for t in list(_d) if t not in live]:
             _d.pop(dead, None)
     for dead in [n for n in list(_THREAD_RECORD_AT) if n not in live_names]:
@@ -1217,7 +1401,18 @@ _QUEUE_REBOOT_COOLDOWN = 30.0  # min seconds between reboots of a dead session
 # Stop between turns, or the ~1s lull before the next UserPromptSubmit/PreToolUse
 # re-marks "working", would otherwise let the drain fire a queued prompt prematurely.
 # Requiring idle to hold this long absorbs that flicker while still resuming promptly.
+#
+# TIERED by the reading's source: an idle the CLI reported ITSELF (a Stop-hook
+# marker, an exit marker — agent_state.reading_is_authoritative) is not a
+# flicker candidate, so it takes the fast tier and the next queued prompt goes
+# out one drain pass sooner. Pane-derived idle keeps the full settle: the pane
+# can misread a quiet moment mid-turn, and typing into a live turn is the one
+# failure this dwell exists to prevent. The premature-Stop lull the comment
+# above describes is still absorbed at the fast tier — idle_since resets on any
+# working sighting, and the drain's pass cadence plus this floor spans the
+# ~1s Stop→UserPromptSubmit gap with margin.
 _QUEUE_IDLE_SETTLE = 12.0
+_QUEUE_IDLE_SETTLE_MARKER = 4.0
 # After WE rebooted a dead agent, hold the queue this long regardless of what the
 # activity probe says. A CLI relaunching with a large `--continue` transcript can
 # spend twenty seconds on a quiet, I/O-bound start, and a quiet pane is exactly
@@ -1543,7 +1738,12 @@ def _drain_one_queue(title: str) -> None:
     if rec.get("idle_since") is None:
         rec["idle_since"] = now
         return
-    if now - rec["idle_since"] < _QUEUE_IDLE_SETTLE:
+    settle = (
+        _QUEUE_IDLE_SETTLE_MARKER
+        if _agent_state.reading_is_authoritative(title, "idle")
+        else _QUEUE_IDLE_SETTLE
+    )
+    if now - rec["idle_since"] < settle:
         return
     # A send that never started a turn (it landed while the CLI sat on a
     # usage-limit screen, or the turn finished between two 5s polls) leaves
@@ -6281,6 +6481,10 @@ async def instance_send(title: str, payload: dict) -> JSONResponse:
     name, err = await asyncio.to_thread(_agent_session_ready, inst, title)
     if err is not None:
         return JSONResponse({"error": err}, status_code=409)
+    # This route is only reachable from human surfaces (the send box, the
+    # command palette, the prompts dialog) — automation types via
+    # _send_queued_item and the limit watcher, never through here.
+    _note_human_input(title)
     ok = await asyncio.to_thread(_send_to_agent, name, text, submit)
     if not ok:
         return JSONResponse(
@@ -6458,6 +6662,7 @@ async def post_queue_send_now(title: str, payload: dict) -> JSONResponse:
     name, err = await asyncio.to_thread(_agent_session_ready, inst, title)
     if err is not None:
         return JSONResponse({"error": err}, status_code=409)
+    _note_human_input(title)  # the user clicked Send now
     ok = await asyncio.to_thread(_send_to_agent, name, it["text"], True)
     if not ok:
         return JSONResponse(
@@ -10200,7 +10405,20 @@ async def shell_ws(ws: WebSocket, title: str) -> None:
         await ws.send_text(json.dumps({"type": "error", "message": str(err)}))
         await ws.close(code=4500)
         return
-    await _serve_pty(ws, proc, allow_input=True)
+    # Typing in the session's shell is presence at the window too — a person
+    # running git commands there does not need a push about this session. Same
+    # post-attach grace as the agent terminal: tmux's client probes are
+    # answered by the emulator, not the human.
+    attached_at = time.time()
+    await _serve_pty(
+        ws,
+        proc,
+        allow_input=True,
+        on_input=lambda: (
+            time.time() - attached_at > _ATTACH_PROBE_GRACE_S
+            and _note_human_input(title)
+        ),
+    )
 
 
 # _agent_transcript_text moved to core.session_stats (imported above).
@@ -10341,6 +10559,18 @@ async def terminal_ws(ws: WebSocket, title: str) -> None:
             pass
 
     sender = asyncio.create_task(_pump_out())
+    # Presence stamps get a short post-attach grace: attaching a tmux client
+    # makes tmux probe the terminal's capabilities, and xterm.js auto-answers
+    # (DA1/DSR/CPR replies) through the SAME data path as typing — so every
+    # pane mount, wifi blip, or laptop wake would otherwise stamp "a human is
+    # here" for every open pane with nobody at any keyboard, deferring
+    # announcements it was supposed to speed up.
+    attached_at = time.time()
+
+    def note_presence() -> None:
+        if time.time() - attached_at > _ATTACH_PROBE_GRACE_S:
+            _note_human_input(title)
+
     try:
         while True:
             msg = await ws.receive()
@@ -10348,6 +10578,10 @@ async def terminal_ws(ws: WebSocket, title: str) -> None:
                 break
             b = msg.get("bytes")
             if b is not None:
+                # A human is at this window (stamped even when the budget lock
+                # drops the keystroke below — presence is about the person, not
+                # about whether the bytes landed).
+                note_presence()
                 # Budget lock: drop keystrokes once the session is over its
                 # ceiling (authoritative — the UI overlay is just the visible
                 # half). Resize control frames (text/JSON) still pass below.
@@ -10361,17 +10595,25 @@ async def terminal_ws(ws: WebSocket, title: str) -> None:
                 try:
                     j = json.loads(t)
                 except (ValueError, TypeError):
+                    note_presence()
                     if _budget_locked(title):
                         continue
                     os.write(fd, t.encode("utf-8"))
                     continue
                 if isinstance(j, dict) and j.get("type") == "resize":
+                    # NOT presence: resizes fire on layout changes with nobody
+                    # at the keyboard.
                     try:
                         proc.setwinsize(int(j["rows"]), int(j["cols"]))
                     except Exception:  # noqa: BLE001
                         pass
-                elif not _budget_locked(title):
-                    os.write(fd, t.encode("utf-8"))
+                else:
+                    # A keystroke that happens to parse as JSON ("1", "true",
+                    # "{}"). Stamp before the budget gate, same as the other
+                    # two input branches — presence is about the person.
+                    note_presence()
+                    if not _budget_locked(title):
+                        os.write(fd, t.encode("utf-8"))
     except WebSocketDisconnect:
         pass
     finally:

--- a/backend/web/static/addons/notify.js
+++ b/backend/web/static/addons/notify.js
@@ -74,23 +74,40 @@ function ruleMatches(rule, env) {
 // answers on a page where the bundle has not published the bridge (an older
 // build, or an event arriving before first paint).
 function sessionLabel(title) {
+  let name = "";
   try {
     const named = window.mindflock && window.mindflock.displayName;
     if (typeof named === "function") {
       const shown = named(title);
-      if (typeof shown === "string" && shown) return shown;
+      if (typeof shown === "string" && shown) name = shown;
     }
   } catch (e) {
     /* the bridge is optional by construction */
   }
-  try {
-    const aliases = JSON.parse(localStorage.getItem("mf_aliases") || "{}");
-    const alias = aliases && aliases[title];
-    if (typeof alias === "string" && alias) return alias;
-  } catch (e) {
-    /* unreadable storage: fall back to the raw title */
+  if (!name) {
+    try {
+      const aliases = JSON.parse(localStorage.getItem("mf_aliases") || "{}");
+      const alias = aliases && aliases[title];
+      if (typeof alias === "string" && alias) name = alias;
+    } catch (e) {
+      /* unreadable storage: fall back to the raw title */
+    }
   }
-  return title || "session";
+  if (!name) name = title || "session";
+  // Prefix the sidebar's slot number ("[3] name") so the notification points
+  // at a row you can find at a glance — the same 1-9 the rail shows, resolved
+  // by the app at fill time so drag reorders and filters are already applied.
+  // Feature-detected like displayName: an older bundle simply has no slots.
+  try {
+    const slot = window.mindflock && window.mindflock.slotNumber;
+    if (typeof slot === "function") {
+      const n = slot(title);
+      if (typeof n === "string" && n) return "[" + n + "] " + name;
+    }
+  } catch (e) {
+    /* slots are a garnish, never the meal */
+  }
+  return name;
 }
 
 function fill(template, env) {

--- a/backend/web/static/app.js
+++ b/backend/web/static/app.js
@@ -22515,39 +22515,285 @@ function useTestPlans(enabled = true) {
 function refreshTestPlans() {
   return queryClient.invalidateQueries({ queryKey: ["test-plans"] });
 }
-function escapeRe(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function errMsg(err) {
+  return (err == null ? void 0 : err.message) || "error";
 }
-function featureBranchName(branch, slug) {
-  const m = new RegExp(`^feature/${escapeRe(slug)}/(.+)$`).exec(branch);
-  return m ? m[1] : "";
+function fmtTokens(n) {
+  n = n || 0;
+  if (n < 1e3) return String(n);
+  if (n < 1e6) return (n / 1e3).toFixed(n < 1e4 ? 1 : 0) + "k";
+  return (n / 1e6).toFixed(1) + "M";
 }
-function branchTail(branch) {
-  const parts = branch.split("/").filter(Boolean);
-  return parts.length ? parts[parts.length - 1] : "";
+function fmtUsd(u) {
+  u = u || 0;
+  if (u <= 0) return "$0";
+  if (u < 0.01) return "<$0.01";
+  if (u < 10) return "$" + u.toFixed(2);
+  if (u < 1e3) return "$" + u.toFixed(1);
+  return "$" + (u / 1e3).toFixed(1) + "k";
 }
-function splitKind(title) {
-  if (title.startsWith("pr-")) return { kind: "pr", slug: title.slice(3) };
-  if (title.startsWith("issue-")) return { kind: "iss", slug: title.slice(6) };
-  return null;
+const PROV_LABELS = { claude: "Claude", codex: "Codex", aider: "Aider" };
+function provLabel(name) {
+  if (!name) return "";
+  return PROV_LABELS[name] || name.charAt(0).toUpperCase() + name.slice(1);
 }
-function sessionLabel(title, branch) {
-  const plain = { text: title, kind: "", name: "", slug: title };
-  if (!title) return plain;
-  const split = splitKind(title);
-  const ticketName = split ? "" : featureBranchName(branch, title);
-  if (!split && !ticketName) return plain;
-  const kind = split ? split.kind : "tix";
-  const slug = split ? split.slug : title;
-  if (!slug) return plain;
-  const name = split ? featureBranchName(branch, title) || branchTail(branch) : ticketName;
-  const useName = name && name !== slug && name !== title ? name : "";
-  return {
-    text: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
-    kind,
-    name: useName,
-    slug
-  };
+function relTime(ts) {
+  const secs = Math.max(0, Math.floor(Date.now() / 1e3 - ts));
+  if (secs < 60) return secs + "s ago";
+  if (secs < 3600) return Math.floor(secs / 60) + "m ago";
+  if (secs < 86400) return Math.floor(secs / 3600) + "h ago";
+  return Math.floor(secs / 86400) + "d ago";
+}
+function fmtDurationShort(ms) {
+  const mm = Math.max(1, Math.round(ms / 6e4));
+  return mm >= 60 ? Math.floor(mm / 60) + "h " + mm % 60 + "m" : "~" + mm + "m";
+}
+function displayBranch(inst) {
+  const full = inst.branch || "";
+  let m = full.match(/^feature\/sc-\d+\/(.+)$/);
+  if (m) return m[1];
+  m = full.match(/^mindflock\/(.+)$/);
+  if (m) return m[1];
+  return full || inst.program || "";
+}
+function humanSize(bytes) {
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+  return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
+}
+function copyText(text) {
+  var _a2, _b2;
+  if (!text) return Promise.resolve(false);
+  if ((_a2 = window.mfclip) == null ? void 0 : _a2.writeText) {
+    try {
+      window.mfclip.writeText(text);
+      return Promise.resolve(true);
+    } catch {
+    }
+  }
+  if ((_b2 = navigator.clipboard) == null ? void 0 : _b2.writeText) {
+    return navigator.clipboard.writeText(text).then(
+      () => true,
+      () => fallbackCopy(text)
+    );
+  }
+  return Promise.resolve(fallbackCopy(text));
+}
+let clipBridgeBroken = false;
+function readClipboardText() {
+  var _a2, _b2;
+  if ((_a2 = window.mfclip) == null ? void 0 : _a2.readText) {
+    try {
+      const v = window.mfclip.readText();
+      clipBridgeBroken = false;
+      return Promise.resolve(v);
+    } catch {
+      clipBridgeBroken = true;
+    }
+  }
+  if ((_b2 = navigator.clipboard) == null ? void 0 : _b2.readText) {
+    return navigator.clipboard.readText().catch(() => "");
+  }
+  return Promise.resolve("");
+}
+function readClipboardImage() {
+  var _a2, _b2;
+  if ((_a2 = window.mfclip) == null ? void 0 : _a2.readImagePNG) {
+    try {
+      const b64 = window.mfclip.readImagePNG();
+      if (!b64) return Promise.resolve(null);
+      const bin = atob(b64);
+      const buf = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+      return Promise.resolve(new Blob([buf], { type: "image/png" }));
+    } catch {
+      clipBridgeBroken = true;
+      return Promise.resolve(null);
+    }
+  }
+  if ((_b2 = navigator.clipboard) == null ? void 0 : _b2.read) {
+    return navigator.clipboard.read().then(
+      (items) => {
+        for (const it of items) {
+          const t = (it.types || []).find((x) => x.startsWith("image/"));
+          if (t) return it.getType(t);
+        }
+        return null;
+      },
+      () => null
+    );
+  }
+  return Promise.resolve(null);
+}
+async function pasteClipboard(term, session) {
+  const text = await readClipboardText();
+  if (text) {
+    term.paste(text);
+    toast("Pasted " + text.length + " chars");
+    return;
+  }
+  const img = await readClipboardImage();
+  if (!img) {
+    toast(
+      clipBridgeBroken ? "Clipboard is unavailable in this desktop-app build — update/rebuild the app to fix paste (Ctrl+Shift+V may still work)" : "Clipboard is empty",
+      clipBridgeBroken ? { duration: 6e3 } : void 0
+    );
+    return;
+  }
+  try {
+    const q = session ? "?session=" + encodeURIComponent(session) : "";
+    const r = await api("/api/paste-image" + q, {
+      method: "POST",
+      headers: { "Content-Type": img.type || "image/png" },
+      body: img
+    });
+    term.paste(r.path);
+    toast("Pasted image → " + r.path);
+  } catch (err) {
+    toast("Image paste failed: " + ((err == null ? void 0 : err.message) || "error"));
+  }
+}
+async function uploadFileToWorkspace(blob, session, name) {
+  let q = session ? "?session=" + encodeURIComponent(session) : "";
+  if (name) q += (q ? "&" : "?") + "name=" + encodeURIComponent(name);
+  const r = await api("/api/paste-image" + q, {
+    method: "POST",
+    headers: { "Content-Type": blob.type || "application/octet-stream" },
+    body: blob
+  });
+  return r.path;
+}
+async function pasteFilesAsPaths(files, term, session) {
+  const list = Array.from(files || []);
+  if (!list.length) return;
+  toast(
+    "Uploading " + (list.length === 1 ? list[0].name || "file" : list.length + " files") + "…"
+  );
+  const paths = [];
+  for (const f of list) {
+    try {
+      paths.push(await uploadFileToWorkspace(f, session, f.name));
+    } catch (err) {
+      toast("Upload failed: " + (f.name || "file") + " — " + ((err == null ? void 0 : err.message) || "error"));
+    }
+  }
+  if (!paths.length) return;
+  term.paste(paths.map((p) => /\s/.test(p) ? '"' + p + '"' : p).join(" ") + " ");
+  toast(paths.length === 1 ? "File → " + paths[0] : paths.length + " files → workspace");
+}
+const dtHasFiles = (dt) => !!dt && Array.from(dt.types || []).indexOf("Files") !== -1;
+function installGlobalDropGuards() {
+  window.addEventListener("dragover", (ev) => {
+    if (dtHasFiles(ev.dataTransfer)) ev.preventDefault();
+  });
+  window.addEventListener("drop", (ev) => {
+    if (dtHasFiles(ev.dataTransfer)) ev.preventDefault();
+  });
+}
+function fallbackCopy(text) {
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.top = "-1000px";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+const MAX_VISIBLE = 9;
+const DROP_PH = "\0drop";
+function viewCap(viewMode) {
+  return viewMode === "auto" ? Infinity : parseInt(viewMode, 10);
+}
+function computeVisible(instances2, opts) {
+  const { rows } = orderedInstances(instances2, opts.order);
+  const shown = rows.filter((i) => !opts.hidden.has(i.title));
+  const cap = Math.min(viewCap(opts.viewMode), MAX_VISIBLE);
+  if (shown.length <= cap) return shown;
+  const shownTitles = shown.map((i) => i.title);
+  const byMru = opts.mru.filter((t) => shownTitles.includes(t));
+  const rest = shownTitles.filter((t) => !byMru.includes(t));
+  const chosen = new Set(byMru.concat(rest).slice(0, cap));
+  return shown.filter((i) => chosen.has(i.title));
+}
+function balancedRows(titles) {
+  const n = titles.length;
+  if (!n) return [];
+  const rowCount = Math.max(1, Math.round(Math.sqrt(n)));
+  const perRow = Math.ceil(n / rowCount);
+  const rows = [];
+  for (let i = 0; i < n; i += perRow) rows.push(titles.slice(i, i + perRow));
+  return rows;
+}
+function insertIntoGrid(rows, title) {
+  const n = rows.flat().length + 1;
+  const rowCount = Math.max(1, Math.round(Math.sqrt(n)));
+  const perRow = Math.ceil(n / rowCount);
+  const last = rows[rows.length - 1];
+  if (last && last.length < perRow) last.push(title);
+  else rows.push([title]);
+  return rows;
+}
+function reconcileGridRows(prev, visibleTitles) {
+  const vis = new Set(visibleTitles);
+  const kept = new Set(prev.flat().filter((t) => vis.has(t)));
+  const incoming = visibleTitles.filter((t) => !kept.has(t));
+  let rows = prev.map((r) => r.map((t) => vis.has(t) ? t : incoming.shift() || null).filter(Boolean)).filter((r) => r.length);
+  if (!rows.length) return balancedRows(visibleTitles);
+  for (const t of incoming) rows = insertIntoGrid(rows, t);
+  return rows;
+}
+function insertBeside(prev, removeTitle, token, targetTitle, side) {
+  const rows = prev.map((r) => r.filter((t) => t !== removeTitle)).filter((r) => r.length);
+  let ri = -1, ci = -1;
+  rows.forEach((r, i) => {
+    const j = r.indexOf(targetTitle);
+    if (j >= 0) {
+      ri = i;
+      ci = j;
+    }
+  });
+  if (ri < 0) rows.push([token]);
+  else if (side === "left") rows[ri].splice(ci, 0, token);
+  else if (side === "right") rows[ri].splice(ci + 1, 0, token);
+  else if (side === "top") rows.splice(ri, 0, [token]);
+  else rows.splice(ri + 1, 0, [token]);
+  return rows;
+}
+function placeInGrid(prev, dragTitle, targetTitle, side) {
+  if (!dragTitle || dragTitle === targetTitle) return prev;
+  return insertBeside(prev, dragTitle, dragTitle, targetTitle, side);
+}
+function previewRowsFor(prev, dragTitle, targetTitle, side) {
+  return insertBeside(prev, dragTitle, DROP_PH, targetTitle, side);
+}
+function dropSideFor(rect, clientX, clientY) {
+  const dx = (clientX - rect.left) / rect.width - 0.5;
+  const dy = (clientY - rect.top) / rect.height - 0.5;
+  if (Math.abs(dx) >= Math.abs(dy)) return dx < 0 ? "left" : "right";
+  return dy < 0 ? "top" : "bottom";
+}
+const inflight$1 = /* @__PURE__ */ new Map();
+function freshStage(title) {
+  if (!title) return Promise.resolve(null);
+  const live = inflight$1.get(title);
+  if (live) return live;
+  const p = instApi(title, "/stage").then((row) => {
+    if (row && row.title) patchInstance(title, row);
+    return row ?? null;
+  }).catch(() => null).finally(() => {
+    inflight$1.delete(title);
+  });
+  inflight$1.set(title, p);
+  return p;
 }
 const createStoreImpl = (createState) => {
   let state;
@@ -22941,176 +23187,65 @@ function tourDecision(opts) {
   if (opts.onboarded === void 0) return "wait";
   return opts.onboarded ? "skip" : "open";
 }
-function snapshot() {
-  var _a2, _b2;
-  const w = globalThis;
-  try {
-    const list = (_b2 = (_a2 = w.mindflock) == null ? void 0 : _a2.sessions) == null ? void 0 : _b2.call(_a2);
-    return Array.isArray(list) ? list : [];
-  } catch {
-    return [];
-  }
+const DEPTHS = ["agent", "commit", "push", "pr", "merge"];
+const SESSION_DEPTHS = ["commit", "push", "pr", "merge"];
+const SOURCE_DEPTHS = ["agent", "commit", "push", "pr"];
+const DEPTH_LABELS = {
+  off: "Off",
+  agent: "Agent only",
+  commit: "Commit",
+  push: "Push",
+  pr: "Open PR",
+  merge: "Merge"
+};
+const DEPTH_STEP_LABELS = {
+  off: "Off",
+  agent: "Agent only",
+  commit: "Commit only",
+  push: "Then push",
+  pr: "Then open PR",
+  merge: "Then merge"
+};
+const DEPTH_SHORT = {
+  agent: "→ agent",
+  commit: "→ commit",
+  push: "→ push",
+  pr: "→ PR",
+  merge: "→ merge"
+};
+function depthLabel(depth) {
+  return DEPTH_LABELS[depth] || depth || "Off";
 }
-function windowName(title) {
-  const raw = String(title || "");
-  if (!raw) return "";
-  const alias = useUi.getState().aliases[raw];
-  if (alias) return alias;
-  const inst = snapshot().find(
-    (i) => i && (i.title === raw || i.display_title === raw)
-  );
-  if (!inst) return raw;
-  return sessionLabel(inst.display_title || inst.title || raw, inst.branch || "").text || raw;
+function normalizeDepth(value) {
+  const d = String(value || "").trim().toLowerCase();
+  if (d === "off") return "off";
+  return DEPTHS.includes(d) ? d : "";
 }
-function publishWindowName() {
-  const w = globalThis;
-  w.mindflock = w.mindflock || {};
-  w.mindflock.displayName = windowName;
+function autopilotChipTitle(run) {
+  var _a2;
+  const target = depthLabel(run.depth);
+  if (run.state === "halted")
+    return "Fast-track stopped: " + (run.reason || "unknown reason");
+  if (run.state === "done")
+    return "Fast-track finished at " + target + " and switched itself off.";
+  const where = run.note ? " — " + run.note : run.step ? " (last step: " + run.step + ")" : " (waiting to start)";
+  const skipped = ((_a2 = run.skipped) == null ? void 0 : _a2.length) ? "\nSkipped hooks: " + run.skipped.join(", ") : "";
+  return "Fast-tracking to " + target + where + "\nClick to stop." + skipped;
 }
-function copyText(text) {
-  var _a2, _b2;
-  if (!text) return Promise.resolve(false);
-  if ((_a2 = window.mfclip) == null ? void 0 : _a2.writeText) {
-    try {
-      window.mfclip.writeText(text);
-      return Promise.resolve(true);
-    } catch {
-    }
-  }
-  if ((_b2 = navigator.clipboard) == null ? void 0 : _b2.writeText) {
-    return navigator.clipboard.writeText(text).then(
-      () => true,
-      () => fallbackCopy(text)
-    );
-  }
-  return Promise.resolve(fallbackCopy(text));
-}
-let clipBridgeBroken = false;
-function readClipboardText() {
-  var _a2, _b2;
-  if ((_a2 = window.mfclip) == null ? void 0 : _a2.readText) {
-    try {
-      const v = window.mfclip.readText();
-      clipBridgeBroken = false;
-      return Promise.resolve(v);
-    } catch {
-      clipBridgeBroken = true;
-    }
-  }
-  if ((_b2 = navigator.clipboard) == null ? void 0 : _b2.readText) {
-    return navigator.clipboard.readText().catch(() => "");
-  }
-  return Promise.resolve("");
-}
-function readClipboardImage() {
-  var _a2, _b2;
-  if ((_a2 = window.mfclip) == null ? void 0 : _a2.readImagePNG) {
-    try {
-      const b64 = window.mfclip.readImagePNG();
-      if (!b64) return Promise.resolve(null);
-      const bin = atob(b64);
-      const buf = new Uint8Array(bin.length);
-      for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
-      return Promise.resolve(new Blob([buf], { type: "image/png" }));
-    } catch {
-      clipBridgeBroken = true;
-      return Promise.resolve(null);
-    }
-  }
-  if ((_b2 = navigator.clipboard) == null ? void 0 : _b2.read) {
-    return navigator.clipboard.read().then(
-      (items) => {
-        for (const it of items) {
-          const t = (it.types || []).find((x) => x.startsWith("image/"));
-          if (t) return it.getType(t);
-        }
-        return null;
-      },
-      () => null
-    );
-  }
-  return Promise.resolve(null);
-}
-async function pasteClipboard(term, session) {
-  const text = await readClipboardText();
-  if (text) {
-    term.paste(text);
-    toast("Pasted " + text.length + " chars");
-    return;
-  }
-  const img = await readClipboardImage();
-  if (!img) {
-    toast(
-      clipBridgeBroken ? "Clipboard is unavailable in this desktop-app build — update/rebuild the app to fix paste (Ctrl+Shift+V may still work)" : "Clipboard is empty",
-      clipBridgeBroken ? { duration: 6e3 } : void 0
-    );
-    return;
-  }
-  try {
-    const q = session ? "?session=" + encodeURIComponent(session) : "";
-    const r = await api("/api/paste-image" + q, {
-      method: "POST",
-      headers: { "Content-Type": img.type || "image/png" },
-      body: img
-    });
-    term.paste(r.path);
-    toast("Pasted image → " + r.path);
-  } catch (err) {
-    toast("Image paste failed: " + ((err == null ? void 0 : err.message) || "error"));
-  }
-}
-async function uploadFileToWorkspace(blob, session, name) {
-  let q = session ? "?session=" + encodeURIComponent(session) : "";
-  if (name) q += (q ? "&" : "?") + "name=" + encodeURIComponent(name);
-  const r = await api("/api/paste-image" + q, {
-    method: "POST",
-    headers: { "Content-Type": blob.type || "application/octet-stream" },
-    body: blob
-  });
-  return r.path;
-}
-async function pasteFilesAsPaths(files, term, session) {
-  const list = Array.from(files || []);
-  if (!list.length) return;
-  toast(
-    "Uploading " + (list.length === 1 ? list[0].name || "file" : list.length + " files") + "…"
-  );
-  const paths = [];
-  for (const f of list) {
-    try {
-      paths.push(await uploadFileToWorkspace(f, session, f.name));
-    } catch (err) {
-      toast("Upload failed: " + (f.name || "file") + " — " + ((err == null ? void 0 : err.message) || "error"));
-    }
-  }
-  if (!paths.length) return;
-  term.paste(paths.map((p) => /\s/.test(p) ? '"' + p + '"' : p).join(" ") + " ");
-  toast(paths.length === 1 ? "File → " + paths[0] : paths.length + " files → workspace");
-}
-const dtHasFiles = (dt) => !!dt && Array.from(dt.types || []).indexOf("Files") !== -1;
-function installGlobalDropGuards() {
-  window.addEventListener("dragover", (ev) => {
-    if (dtHasFiles(ev.dataTransfer)) ev.preventDefault();
-  });
-  window.addEventListener("drop", (ev) => {
-    if (dtHasFiles(ev.dataTransfer)) ev.preventDefault();
-  });
-}
-function fallbackCopy(text) {
-  try {
-    const ta = document.createElement("textarea");
-    ta.value = text;
-    ta.style.position = "fixed";
-    ta.style.top = "-1000px";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
-    ta.focus();
-    ta.select();
-    const ok = document.execCommand("copy");
-    document.body.removeChild(ta);
-    return ok;
-  } catch {
-    return false;
+function mergeBlockerLabel(ms) {
+  switch (ms.state) {
+    case "dirty":
+      return "conflicts";
+    case "behind":
+      return "behind base";
+    case "draft":
+      return "draft PR";
+    case "blocked":
+      if (ms.checks === "failed") return "checks ✗";
+      if (ms.checks === "pending") return "checks…";
+      return "review needed";
+    default:
+      return ms.mergeable === null ? "checking…" : "can't merge";
   }
 }
 function cssVar(name, fallback) {
@@ -23614,388 +23749,6 @@ if (typeof document !== "undefined") {
 function focusTerm(title, kind = "agent") {
   var _a2;
   (_a2 = peekTerm(title, kind)) == null ? void 0 : _a2.term.focus();
-}
-const SURFACES = [
-  ["", "Swallow (default)", "#0f1117", "#1e222e"],
-  ["raven", "Raven", "#000000", "#141419"],
-  ["heron", "Heron", "#16181b", "#292d33"],
-  ["cardinal", "Cardinal", "#d51322", "#16060a", "#3d060d"],
-  ["macaw", "Scarlet Macaw", "#1554e0", "#06773a", "#43060a"],
-  ["pheasant", "Golden Pheasant", "#f5b800", "#05361f", "#3f070c"],
-  ["oriole", "Oriole", "#ff7a12", "#140c03", "#421d03"],
-  ["lorikeet", "Rainbow Lorikeet", "#4b1fd6", "#256e0a", "#4f1c05"],
-  ["roller", "Lilac-breasted Roller", "#9b6ef0", "#00736b", "#3a2412"],
-  ["goldfinch", "Goldfinch", "#f2e00d", "#131300", "#33350d"],
-  ["toucan", "Toco Toucan", "#ffb01f", "#08080a", "#181820"],
-  ["quetzal", "Quetzal", "#00a35c", "#4a0512", "#033524"],
-  ["greenjay", "Green Jay", "#1440d6", "#d6b800", "#103a0e"],
-  ["gouldian", "Gouldian Finch", "#00c2b2", "#52157a", "#0e3a19"],
-  ["mallard", "Mallard", "#0d9c62", "#5e330f", "#22262e"],
-  ["kingfisher", "Kingfisher", "#00a8d6", "#5e2404", "#06323f"],
-  ["peacock", "Peacock", "#0a9cb8", "#141f8f", "#05383f"],
-  ["bluejay", "Bluejay", "#1266e6", "#0a0e1c", "#071a44"],
-  ["bunting", "Indigo Bunting", "#3b2ff0", "#08061f", "#150f52"],
-  ["violetear", "Violetear", "#7c2ff0", "#0e0420", "#220c40"],
-  ["mandarin", "Mandarin Duck", "#12a85e", "#f2820f", "#3a1445"],
-  ["flamingo", "Flamingo", "#ff2d8a", "#180110", "#420527"]
-];
-function swatchGradient(tones) {
-  const step = 100 / tones.length;
-  const stops = tones.map(
-    (c, i) => `${c} ${(i * step).toFixed(1)}% ${((i + 1) * step).toFixed(1)}%`
-  );
-  return `linear-gradient(135deg,${stops.join(",")})`;
-}
-const ACCENTS = [
-  ["", "Violetear (default)", "#7d56f4"],
-  ["cardinal", "Cardinal", "#e5484d"],
-  ["oriole", "Oriole", "#f07b3c"],
-  ["goldfinch", "Goldfinch", "#f0cf28"],
-  ["quetzal", "Quetzal", "#44b556"],
-  ["bluejay", "Bluejay", "#3d8bfd"],
-  ["bunting", "Indigo Bunting", "#4f46e5"],
-  ["flamingo", "Flamingo", "#f2559b"],
-  ["pheasant", "Golden Pheasant", "linear-gradient(135deg,#f0d78a,#b8860b)"],
-  ["heron", "Heron", "linear-gradient(135deg,#e2e7ef,#8d95a3)"]
-];
-const DIMS = {
-  accent: { field: "accent", attr: "data-accent", lsKey: "cs_accent" },
-  surface: { field: "surface", attr: "data-surface", lsKey: "cs_surface" }
-};
-function applyStoredAppearance() {
-  for (const dim of Object.values(DIMS)) {
-    let saved = "";
-    try {
-      saved = localStorage.getItem(dim.lsKey) || "";
-    } catch {
-    }
-    if (saved) document.documentElement.setAttribute(dim.attr, saved);
-    else document.documentElement.removeAttribute(dim.attr);
-  }
-}
-function current(dim) {
-  return document.documentElement.getAttribute(dim.attr) || "";
-}
-function apply(dim, name) {
-  if (name) document.documentElement.setAttribute(dim.attr, name);
-  else document.documentElement.removeAttribute(dim.attr);
-  try {
-    if (name) localStorage.setItem(dim.lsKey, name);
-    else localStorage.removeItem(dim.lsKey);
-  } catch {
-  }
-  api("/api/settings", { json: { ui: { [dim.field]: name } } }).catch(() => {
-  });
-  rethemeAll();
-}
-function Appearance(_) {
-  const [accent, setAccent] = reactExports.useState(() => current(DIMS.accent));
-  const [surface, setSurface] = reactExports.useState(() => current(DIMS.surface));
-  const surfaceSwatch = ([name, label, ...tones]) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "button",
-    {
-      type: "button",
-      className: "accent-swatch surface-swatch" + (surface === name ? " active" : ""),
-      "data-surface-choice": name,
-      onClick: () => {
-        setSurface(name);
-        apply(DIMS.surface, name);
-      },
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sw-dot", style: { background: swatchGradient(tones) } }),
-        label
-      ]
-    },
-    name || "default"
-  );
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Appearance" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "One bird per set, painted the way the bird actually is: most give the top bar, the sidebar and the window a hue each — Scarlet Macaw is a cobalt bar over an emerald sidebar over a scarlet window. Swallow, Raven and Heron are the quiet ones. Every set has its own light-mode palette, so the moon toggle in the top bar keeps working inside all of them. Synced to all your devices." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "surface-swatches", className: "accent-swatches", children: SURFACES.map(surfaceSwatch) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Accents recolor highlights, focus rings, buttons and the terminal cursor — mix freely with any theme set." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "accent-swatches", className: "accent-swatches", children: ACCENTS.map(([name, label, color]) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        type: "button",
-        className: "accent-swatch" + (accent === name ? " active" : ""),
-        "data-accent-choice": name,
-        onClick: () => {
-          setAccent(name);
-          apply(DIMS.accent, name);
-        },
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sw-dot", style: { background: color } }),
-          label
-        ]
-      },
-      name || "default"
-    )) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Dark / light mode itself is the moon toggle in the top bar." })
-  ] });
-}
-function errMsg(err) {
-  return (err == null ? void 0 : err.message) || "error";
-}
-function fmtTokens(n) {
-  n = n || 0;
-  if (n < 1e3) return String(n);
-  if (n < 1e6) return (n / 1e3).toFixed(n < 1e4 ? 1 : 0) + "k";
-  return (n / 1e6).toFixed(1) + "M";
-}
-function fmtUsd(u) {
-  u = u || 0;
-  if (u <= 0) return "$0";
-  if (u < 0.01) return "<$0.01";
-  if (u < 10) return "$" + u.toFixed(2);
-  if (u < 1e3) return "$" + u.toFixed(1);
-  return "$" + (u / 1e3).toFixed(1) + "k";
-}
-const PROV_LABELS = { claude: "Claude", codex: "Codex", aider: "Aider" };
-function provLabel(name) {
-  if (!name) return "";
-  return PROV_LABELS[name] || name.charAt(0).toUpperCase() + name.slice(1);
-}
-function relTime(ts) {
-  const secs = Math.max(0, Math.floor(Date.now() / 1e3 - ts));
-  if (secs < 60) return secs + "s ago";
-  if (secs < 3600) return Math.floor(secs / 60) + "m ago";
-  if (secs < 86400) return Math.floor(secs / 3600) + "h ago";
-  return Math.floor(secs / 86400) + "d ago";
-}
-function fmtDurationShort(ms) {
-  const mm = Math.max(1, Math.round(ms / 6e4));
-  return mm >= 60 ? Math.floor(mm / 60) + "h " + mm % 60 + "m" : "~" + mm + "m";
-}
-function displayBranch(inst) {
-  const full = inst.branch || "";
-  let m = full.match(/^feature\/sc-\d+\/(.+)$/);
-  if (m) return m[1];
-  m = full.match(/^mindflock\/(.+)$/);
-  if (m) return m[1];
-  return full || inst.program || "";
-}
-function humanSize(bytes) {
-  if (bytes < 1024) return bytes + " B";
-  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
-  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + " MB";
-  return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB";
-}
-function orderedInstances(instances2, order) {
-  if (!instances2.length) return { rows: [], nextOrder: order };
-  const byTitle = new Map(instances2.map((i) => [i.title, i]));
-  const rows = [];
-  for (const t of order) {
-    const inst = byTitle.get(t);
-    if (inst) {
-      rows.push(inst);
-      byTitle.delete(t);
-    }
-  }
-  for (const i of instances2) {
-    if (byTitle.has(i.title)) {
-      rows.push(i);
-      byTitle.delete(i.title);
-    }
-  }
-  return { rows, nextOrder: rows.map((i) => i.title) };
-}
-function orderWithAfter(order, title, after) {
-  if (!title || !after || title === after) return order;
-  const next = order.filter((t) => t !== title);
-  const at = next.indexOf(after);
-  if (at < 0) return order;
-  next.splice(at + 1, 0, title);
-  return next;
-}
-const SEARCH_MIN = 6;
-function matchesFilter(inst, filter, aliases) {
-  if (!filter) return true;
-  const hay = [inst.title, aliases[inst.title], inst.branch].filter(Boolean).join(" ").toLowerCase();
-  return hay.indexOf(filter) >= 0;
-}
-const WEDGE_IDLE_S = 20 * 60;
-function attentionItems(instances2) {
-  var _a2;
-  const items = [];
-  for (const inst of instances2 || []) {
-    if (inst.workspace_missing || inst.status === "paused") continue;
-    const act = effectiveActivity(inst);
-    if (act === "clarify")
-      items.push({ p: 0, title: inst.title, reason: "needs your answer", snippet: inst.last_turn || "" });
-    else if (inst.stage === "interrupt")
-      items.push({
-        p: 1,
-        title: inst.title,
-        reason: "pre-commit failed" + (inst.failed_step ? " at " + inst.failed_step : "")
-      });
-    else if (inst.setup && inst.setup.state === "failed")
-      items.push({ p: 1, title: inst.title, reason: "worktree setup failed" });
-    else if (inst.check && inst.check.state === "failed" && !inst.check.stale)
-      items.push({ p: 2, title: inst.title, reason: "checks failing" });
-    else if (inst.stage === "pushed")
-      items.push({ p: 3, title: inst.title, reason: "pushed — ready for PR" });
-    else if (act === "idle" && Number(inst.activity_since) > 0) {
-      const idleFor = Date.now() / 1e3 - Number(inst.activity_since);
-      const un = ((_a2 = inst.diff_stat || {}) == null ? void 0 : _a2.uncommitted) || {};
-      const unfinished = (Number(un.additions) || 0) + (Number(un.deletions) || 0) > 0;
-      if (idleFor > WEDGE_IDLE_S && unfinished)
-        items.push({
-          p: 1,
-          title: inst.title,
-          reason: "idle " + relTime(Number(inst.activity_since)).replace(" ago", "") + " with unfinished work — possibly stuck",
-          snippet: inst.last_turn || ""
-        });
-    }
-  }
-  return items.sort((a, b) => a.p - b.p || a.title.localeCompare(b.title));
-}
-const MAX_VISIBLE = 9;
-const DROP_PH = "\0drop";
-function viewCap(viewMode) {
-  return viewMode === "auto" ? Infinity : parseInt(viewMode, 10);
-}
-function computeVisible(instances2, opts) {
-  const { rows } = orderedInstances(instances2, opts.order);
-  const shown = rows.filter((i) => !opts.hidden.has(i.title));
-  const cap = Math.min(viewCap(opts.viewMode), MAX_VISIBLE);
-  if (shown.length <= cap) return shown;
-  const shownTitles = shown.map((i) => i.title);
-  const byMru = opts.mru.filter((t) => shownTitles.includes(t));
-  const rest = shownTitles.filter((t) => !byMru.includes(t));
-  const chosen = new Set(byMru.concat(rest).slice(0, cap));
-  return shown.filter((i) => chosen.has(i.title));
-}
-function balancedRows(titles) {
-  const n = titles.length;
-  if (!n) return [];
-  const rowCount = Math.max(1, Math.round(Math.sqrt(n)));
-  const perRow = Math.ceil(n / rowCount);
-  const rows = [];
-  for (let i = 0; i < n; i += perRow) rows.push(titles.slice(i, i + perRow));
-  return rows;
-}
-function insertIntoGrid(rows, title) {
-  const n = rows.flat().length + 1;
-  const rowCount = Math.max(1, Math.round(Math.sqrt(n)));
-  const perRow = Math.ceil(n / rowCount);
-  const last = rows[rows.length - 1];
-  if (last && last.length < perRow) last.push(title);
-  else rows.push([title]);
-  return rows;
-}
-function reconcileGridRows(prev, visibleTitles) {
-  const vis = new Set(visibleTitles);
-  const kept = new Set(prev.flat().filter((t) => vis.has(t)));
-  const incoming = visibleTitles.filter((t) => !kept.has(t));
-  let rows = prev.map((r) => r.map((t) => vis.has(t) ? t : incoming.shift() || null).filter(Boolean)).filter((r) => r.length);
-  if (!rows.length) return balancedRows(visibleTitles);
-  for (const t of incoming) rows = insertIntoGrid(rows, t);
-  return rows;
-}
-function insertBeside(prev, removeTitle, token, targetTitle, side) {
-  const rows = prev.map((r) => r.filter((t) => t !== removeTitle)).filter((r) => r.length);
-  let ri = -1, ci = -1;
-  rows.forEach((r, i) => {
-    const j = r.indexOf(targetTitle);
-    if (j >= 0) {
-      ri = i;
-      ci = j;
-    }
-  });
-  if (ri < 0) rows.push([token]);
-  else if (side === "left") rows[ri].splice(ci, 0, token);
-  else if (side === "right") rows[ri].splice(ci + 1, 0, token);
-  else if (side === "top") rows.splice(ri, 0, [token]);
-  else rows.splice(ri + 1, 0, [token]);
-  return rows;
-}
-function placeInGrid(prev, dragTitle, targetTitle, side) {
-  if (!dragTitle || dragTitle === targetTitle) return prev;
-  return insertBeside(prev, dragTitle, dragTitle, targetTitle, side);
-}
-function previewRowsFor(prev, dragTitle, targetTitle, side) {
-  return insertBeside(prev, dragTitle, DROP_PH, targetTitle, side);
-}
-function dropSideFor(rect, clientX, clientY) {
-  const dx = (clientX - rect.left) / rect.width - 0.5;
-  const dy = (clientY - rect.top) / rect.height - 0.5;
-  if (Math.abs(dx) >= Math.abs(dy)) return dx < 0 ? "left" : "right";
-  return dy < 0 ? "top" : "bottom";
-}
-const inflight$1 = /* @__PURE__ */ new Map();
-function freshStage(title) {
-  if (!title) return Promise.resolve(null);
-  const live = inflight$1.get(title);
-  if (live) return live;
-  const p = instApi(title, "/stage").then((row) => {
-    if (row && row.title) patchInstance(title, row);
-    return row ?? null;
-  }).catch(() => null).finally(() => {
-    inflight$1.delete(title);
-  });
-  inflight$1.set(title, p);
-  return p;
-}
-const DEPTHS = ["agent", "commit", "push", "pr", "merge"];
-const SESSION_DEPTHS = ["commit", "push", "pr", "merge"];
-const SOURCE_DEPTHS = ["agent", "commit", "push", "pr"];
-const DEPTH_LABELS = {
-  off: "Off",
-  agent: "Agent only",
-  commit: "Commit",
-  push: "Push",
-  pr: "Open PR",
-  merge: "Merge"
-};
-const DEPTH_STEP_LABELS = {
-  off: "Off",
-  agent: "Agent only",
-  commit: "Commit only",
-  push: "Then push",
-  pr: "Then open PR",
-  merge: "Then merge"
-};
-const DEPTH_SHORT = {
-  agent: "→ agent",
-  commit: "→ commit",
-  push: "→ push",
-  pr: "→ PR",
-  merge: "→ merge"
-};
-function depthLabel(depth) {
-  return DEPTH_LABELS[depth] || depth || "Off";
-}
-function normalizeDepth(value) {
-  const d = String(value || "").trim().toLowerCase();
-  if (d === "off") return "off";
-  return DEPTHS.includes(d) ? d : "";
-}
-function autopilotChipTitle(run) {
-  var _a2;
-  const target = depthLabel(run.depth);
-  if (run.state === "halted")
-    return "Fast-track stopped: " + (run.reason || "unknown reason");
-  if (run.state === "done")
-    return "Fast-track finished at " + target + " and switched itself off.";
-  const where = run.note ? " — " + run.note : run.step ? " (last step: " + run.step + ")" : " (waiting to start)";
-  const skipped = ((_a2 = run.skipped) == null ? void 0 : _a2.length) ? "\nSkipped hooks: " + run.skipped.join(", ") : "";
-  return "Fast-tracking to " + target + where + "\nClick to stop." + skipped;
-}
-function mergeBlockerLabel(ms) {
-  switch (ms.state) {
-    case "dirty":
-      return "conflicts";
-    case "behind":
-      return "behind base";
-    case "draft":
-      return "draft PR";
-    case "blocked":
-      if (ms.checks === "failed") return "checks ✗";
-      if (ms.checks === "pending") return "checks…";
-      return "review needed";
-    default:
-      return ms.mergeable === null ? "checking…" : "can't merge";
-  }
 }
 function caps() {
   var _a2;
@@ -24782,6 +24535,274 @@ function nextStep(inst) {
       return null;
   }
 }
+function orderedInstances(instances2, order) {
+  if (!instances2.length) return { rows: [], nextOrder: order };
+  const byTitle = new Map(instances2.map((i) => [i.title, i]));
+  const rows = [];
+  for (const t of order) {
+    const inst = byTitle.get(t);
+    if (inst) {
+      rows.push(inst);
+      byTitle.delete(t);
+    }
+  }
+  for (const i of instances2) {
+    if (byTitle.has(i.title)) {
+      rows.push(i);
+      byTitle.delete(i.title);
+    }
+  }
+  return { rows, nextOrder: rows.map((i) => i.title) };
+}
+function orderWithAfter(order, title, after) {
+  if (!title || !after || title === after) return order;
+  const next = order.filter((t) => t !== title);
+  const at = next.indexOf(after);
+  if (at < 0) return order;
+  next.splice(at + 1, 0, title);
+  return next;
+}
+const SEARCH_MIN = 6;
+function matchesFilter(inst, filter, aliases) {
+  if (!filter) return true;
+  const hay = [inst.title, aliases[inst.title], inst.branch].filter(Boolean).join(" ").toLowerCase();
+  return hay.indexOf(filter) >= 0;
+}
+const WEDGE_IDLE_S = 20 * 60;
+function attentionItems(instances2) {
+  var _a2;
+  const items = [];
+  for (const inst of instances2 || []) {
+    if (inst.workspace_missing || inst.status === "paused") continue;
+    const act = effectiveActivity(inst);
+    if (act === "clarify")
+      items.push({ p: 0, title: inst.title, reason: "needs your answer", snippet: inst.last_turn || "" });
+    else if (inst.stage === "interrupt")
+      items.push({
+        p: 1,
+        title: inst.title,
+        reason: "pre-commit failed" + (inst.failed_step ? " at " + inst.failed_step : "")
+      });
+    else if (inst.setup && inst.setup.state === "failed")
+      items.push({ p: 1, title: inst.title, reason: "worktree setup failed" });
+    else if (inst.check && inst.check.state === "failed" && !inst.check.stale)
+      items.push({ p: 2, title: inst.title, reason: "checks failing" });
+    else if (inst.stage === "pushed")
+      items.push({ p: 3, title: inst.title, reason: "pushed — ready for PR" });
+    else if (act === "idle" && Number(inst.activity_since) > 0) {
+      const idleFor = Date.now() / 1e3 - Number(inst.activity_since);
+      const un = ((_a2 = inst.diff_stat || {}) == null ? void 0 : _a2.uncommitted) || {};
+      const unfinished = (Number(un.additions) || 0) + (Number(un.deletions) || 0) > 0;
+      if (idleFor > WEDGE_IDLE_S && unfinished)
+        items.push({
+          p: 1,
+          title: inst.title,
+          reason: "idle " + relTime(Number(inst.activity_since)).replace(" ago", "") + " with unfinished work — possibly stuck",
+          snippet: inst.last_turn || ""
+        });
+    }
+  }
+  return items.sort((a, b) => a.p - b.p || a.title.localeCompare(b.title));
+}
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function featureBranchName(branch, slug) {
+  const m = new RegExp(`^feature/${escapeRe(slug)}/(.+)$`).exec(branch);
+  return m ? m[1] : "";
+}
+function branchTail(branch) {
+  const parts = branch.split("/").filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : "";
+}
+function splitKind(title) {
+  if (title.startsWith("pr-")) return { kind: "pr", slug: title.slice(3) };
+  if (title.startsWith("issue-")) return { kind: "iss", slug: title.slice(6) };
+  return null;
+}
+function sessionLabel(title, branch) {
+  const plain = { text: title, kind: "", name: "", slug: title };
+  if (!title) return plain;
+  const split = splitKind(title);
+  const ticketName = split ? "" : featureBranchName(branch, title);
+  if (!split && !ticketName) return plain;
+  const kind = split ? split.kind : "tix";
+  const slug = split ? split.slug : title;
+  if (!slug) return plain;
+  const name = split ? featureBranchName(branch, title) || branchTail(branch) : ticketName;
+  const useName = name && name !== slug && name !== title ? name : "";
+  return {
+    text: useName ? `(${kind}) ${useName}/${slug}` : `(${kind}) ${slug}`,
+    kind,
+    name: useName,
+    slug
+  };
+}
+function snapshot() {
+  var _a2, _b2;
+  const w = globalThis;
+  try {
+    const list = (_b2 = (_a2 = w.mindflock) == null ? void 0 : _a2.sessions) == null ? void 0 : _b2.call(_a2);
+    return Array.isArray(list) ? list : [];
+  } catch {
+    return [];
+  }
+}
+function windowName(title) {
+  const raw = String(title || "");
+  if (!raw) return "";
+  const alias = useUi.getState().aliases[raw];
+  if (alias) return alias;
+  const inst = snapshot().find(
+    (i) => i && (i.title === raw || i.display_title === raw)
+  );
+  if (!inst) return raw;
+  return sessionLabel(inst.display_title || inst.title || raw, inst.branch || "").text || raw;
+}
+function slotNumber(title) {
+  const raw = String(title || "");
+  if (!raw) return "";
+  try {
+    const ui = useUi.getState();
+    const listed = snapshot().filter(
+      (i) => i && !isVerifySession(String(i.title || ""))
+    );
+    const { rows } = orderedInstances(listed, ui.order);
+    const filtered = rows.filter((i) => matchesFilter(i, ui.filter, ui.aliases));
+    const local = filtered.filter((i) => !i.device);
+    const remote = filtered.filter((i) => i.device);
+    const idx = [...local, ...remote].findIndex(
+      (i) => i.title === raw || i.display_title === raw
+    );
+    return idx >= 0 && idx < 9 ? String(idx + 1) : "";
+  } catch {
+    return "";
+  }
+}
+function publishWindowName() {
+  const w = globalThis;
+  w.mindflock = w.mindflock || {};
+  w.mindflock.displayName = windowName;
+  w.mindflock.slotNumber = slotNumber;
+}
+const SURFACES = [
+  ["", "Swallow (default)", "#0f1117", "#1e222e"],
+  ["raven", "Raven", "#000000", "#141419"],
+  ["heron", "Heron", "#16181b", "#292d33"],
+  ["cardinal", "Cardinal", "#d51322", "#16060a", "#3d060d"],
+  ["macaw", "Scarlet Macaw", "#1554e0", "#06773a", "#43060a"],
+  ["pheasant", "Golden Pheasant", "#f5b800", "#05361f", "#3f070c"],
+  ["oriole", "Oriole", "#ff7a12", "#140c03", "#421d03"],
+  ["lorikeet", "Rainbow Lorikeet", "#4b1fd6", "#256e0a", "#4f1c05"],
+  ["roller", "Lilac-breasted Roller", "#9b6ef0", "#00736b", "#3a2412"],
+  ["goldfinch", "Goldfinch", "#f2e00d", "#131300", "#33350d"],
+  ["toucan", "Toco Toucan", "#ffb01f", "#08080a", "#181820"],
+  ["quetzal", "Quetzal", "#00a35c", "#4a0512", "#033524"],
+  ["greenjay", "Green Jay", "#1440d6", "#d6b800", "#103a0e"],
+  ["gouldian", "Gouldian Finch", "#00c2b2", "#52157a", "#0e3a19"],
+  ["mallard", "Mallard", "#0d9c62", "#5e330f", "#22262e"],
+  ["kingfisher", "Kingfisher", "#00a8d6", "#5e2404", "#06323f"],
+  ["peacock", "Peacock", "#0a9cb8", "#141f8f", "#05383f"],
+  ["bluejay", "Bluejay", "#1266e6", "#0a0e1c", "#071a44"],
+  ["bunting", "Indigo Bunting", "#3b2ff0", "#08061f", "#150f52"],
+  ["violetear", "Violetear", "#7c2ff0", "#0e0420", "#220c40"],
+  ["mandarin", "Mandarin Duck", "#12a85e", "#f2820f", "#3a1445"],
+  ["flamingo", "Flamingo", "#ff2d8a", "#180110", "#420527"]
+];
+function swatchGradient(tones) {
+  const step = 100 / tones.length;
+  const stops = tones.map(
+    (c, i) => `${c} ${(i * step).toFixed(1)}% ${((i + 1) * step).toFixed(1)}%`
+  );
+  return `linear-gradient(135deg,${stops.join(",")})`;
+}
+const ACCENTS = [
+  ["", "Violetear (default)", "#7d56f4"],
+  ["cardinal", "Cardinal", "#e5484d"],
+  ["oriole", "Oriole", "#f07b3c"],
+  ["goldfinch", "Goldfinch", "#f0cf28"],
+  ["quetzal", "Quetzal", "#44b556"],
+  ["bluejay", "Bluejay", "#3d8bfd"],
+  ["bunting", "Indigo Bunting", "#4f46e5"],
+  ["flamingo", "Flamingo", "#f2559b"],
+  ["pheasant", "Golden Pheasant", "linear-gradient(135deg,#f0d78a,#b8860b)"],
+  ["heron", "Heron", "linear-gradient(135deg,#e2e7ef,#8d95a3)"]
+];
+const DIMS = {
+  accent: { field: "accent", attr: "data-accent", lsKey: "cs_accent" },
+  surface: { field: "surface", attr: "data-surface", lsKey: "cs_surface" }
+};
+function applyStoredAppearance() {
+  for (const dim of Object.values(DIMS)) {
+    let saved = "";
+    try {
+      saved = localStorage.getItem(dim.lsKey) || "";
+    } catch {
+    }
+    if (saved) document.documentElement.setAttribute(dim.attr, saved);
+    else document.documentElement.removeAttribute(dim.attr);
+  }
+}
+function current(dim) {
+  return document.documentElement.getAttribute(dim.attr) || "";
+}
+function apply(dim, name) {
+  if (name) document.documentElement.setAttribute(dim.attr, name);
+  else document.documentElement.removeAttribute(dim.attr);
+  try {
+    if (name) localStorage.setItem(dim.lsKey, name);
+    else localStorage.removeItem(dim.lsKey);
+  } catch {
+  }
+  api("/api/settings", { json: { ui: { [dim.field]: name } } }).catch(() => {
+  });
+  rethemeAll();
+}
+function Appearance(_) {
+  const [accent, setAccent] = reactExports.useState(() => current(DIMS.accent));
+  const [surface, setSurface] = reactExports.useState(() => current(DIMS.surface));
+  const surfaceSwatch = ([name, label, ...tones]) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "button",
+    {
+      type: "button",
+      className: "accent-swatch surface-swatch" + (surface === name ? " active" : ""),
+      "data-surface-choice": name,
+      onClick: () => {
+        setSurface(name);
+        apply(DIMS.surface, name);
+      },
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sw-dot", style: { background: swatchGradient(tones) } }),
+        label
+      ]
+    },
+    name || "default"
+  );
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "set-section-title", children: "Appearance" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "One bird per set, painted the way the bird actually is: most give the top bar, the sidebar and the window a hue each — Scarlet Macaw is a cobalt bar over an emerald sidebar over a scarlet window. Swallow, Raven and Heron are the quiet ones. Every set has its own light-mode palette, so the moon toggle in the top bar keeps working inside all of them. Synced to all your devices." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "surface-swatches", className: "accent-swatches", children: SURFACES.map(surfaceSwatch) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Accents recolor highlights, focus rings, buttons and the terminal cursor — mix freely with any theme set." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "accent-swatches", className: "accent-swatches", children: ACCENTS.map(([name, label, color]) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "button",
+      {
+        type: "button",
+        className: "accent-swatch" + (accent === name ? " active" : ""),
+        "data-accent-choice": name,
+        onClick: () => {
+          setAccent(name);
+          apply(DIMS.accent, name);
+        },
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sw-dot", style: { background: color } }),
+          label
+        ]
+      },
+      name || "default"
+    )) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "set-hint", children: "Dark / light mode itself is the moon toggle in the top bar." })
+  ] });
+}
 let _host = null;
 function isEditingTarget(el) {
   if (!el) return false;
@@ -25406,7 +25427,7 @@ function NotificationsBell() {
             "data-session": n.session,
             onClick: () => jump(n.session),
             children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "notif-sess", children: aliases[n.session] || n.session || "—" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "notif-sess", children: (slotNumber(n.session) ? "[" + slotNumber(n.session) + "] " : "") + (aliases[n.session] || n.session || "—") }),
               /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "notif-text", children: n.text }),
               /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "notif-time", children: relTime(n.ts) })
             ]
@@ -25549,6 +25570,10 @@ function notifyOnce(session, state, msg, opts) {
   notifyAt.set(key, now);
   toast(msg, opts);
 }
+function namedSlot(session) {
+  const n = slotNumber(session);
+  return (n ? "[" + n + "] " : "") + displayName(session);
+}
 function instByTitle(title) {
   return instances().find((i) => i.title === title) || null;
 }
@@ -25579,7 +25604,7 @@ function EventToasts() {
           markClarify(env.session);
           const inst = instByTitle(env.session);
           const snip = (inst == null ? void 0 : inst.last_turn) ? " — “" + inst.last_turn + "”" : "";
-          notifyOnce(env.session, "clarify", displayName(env.session) + " needs your input" + snip, {
+          notifyOnce(env.session, "clarify", namedSlot(env.session) + " needs your input" + snip, {
             onClick: () => selectSession(env.session)
           });
         }
@@ -25588,7 +25613,7 @@ function EventToasts() {
     unsubs.push(
       ev.subscribe("session.setup_finished", (env) => {
         if (isReplay(env) || env.new === "ok") return;
-        notifyOnce(env.session, "setupfail", "worktree setup failed on " + displayName(env.session) + " — prompts held", {
+        notifyOnce(env.session, "setupfail", "worktree setup failed on " + namedSlot(env.session) + " — prompts held", {
           onClick: () => selectSession(env.session)
         });
       })
@@ -25596,7 +25621,7 @@ function EventToasts() {
     unsubs.push(
       ev.subscribe("session.check_finished", (env) => {
         if (isReplay(env) || env.new === "ok") return;
-        notifyOnce(env.session, "checkfail", "checks failed on " + displayName(env.session), {
+        notifyOnce(env.session, "checkfail", "checks failed on " + namedSlot(env.session), {
           onClick: () => selectSession(env.session)
         });
       })
@@ -25638,7 +25663,7 @@ function EventToasts() {
           { live: true }
         );
         if (String(env.new || "") === "halted")
-          notifyOnce(env.session, "ftstop", "fast-track stopped on " + displayName(env.session), {
+          notifyOnce(env.session, "ftstop", "fast-track stopped on " + namedSlot(env.session), {
             onClick: () => selectSession(env.session)
           });
       })
@@ -25690,7 +25715,7 @@ function EventToasts() {
         notifyOnce(
           env.session,
           "budget",
-          displayName(env.session) + " exceeded its budget (" + fmtUsd(d.cost || 0) + " of " + fmtUsd(d.budget || 0) + ")",
+          namedSlot(env.session) + " exceeded its budget (" + fmtUsd(d.cost || 0) + " of " + fmtUsd(d.budget || 0) + ")",
           { onClick: () => selectSession(env.session), duration: 8e3 }
         );
       })

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,7 +232,7 @@ these fields and a "Test connection" button that auto-fills `member_id`.
 | Provider | Required keys | Notes |
 |---|---|---|
 | `github_issues` | **none** | The zero-config on-ramp, and the catalog's first entry. `api_token` falls back to the GitHub connection (`[github].token` / `$GH_TOKEN` / `gh auth token`); `project` falls back to the source's `repo_url`, then `[repository].url`, then this checkout's `origin`. No workflow states. |
-| `shortcut` | `api_token`, `member_id` | `workflow_state` optional (workflow-state id; integer `workflow_state_id` also works). |
+| `shortcut` | `api_token`, `member_id` | `workflow_state` optional (workflow-state id; integer `workflow_state_id` also works). Archived stories, and stories under an archived epic, are always excluded — see below. |
 | `jira` | `base_url`, `email`, `api_token` | Jira Cloud, `assignee = currentUser()`. `member_id` (accountId) optional. `workflow_state` optional (status id → `status = <id>`). |
 | `linear` | `api_token` | GraphQL `viewer.assignedIssues`. `workflow_state` optional (state id). |
 | `asana` | `api_token`, `project` (workspace gid) | Tasks with `assignee = me`. No workflow states. |
@@ -242,6 +242,14 @@ Every source also takes an OPTIONAL-in-TOML-but-required-in-the-UI `repo_url`
 global default repo. `workflow_state` gates ingestion so a ticket only gets a
 session once it reaches the chosen state (blank = any state). The Intake →
 **Tickets** tab loads the live state list per source (Shortcut/Jira/Linear).
+
+**Shortcut also filters archived work, implicitly.** Alongside `workflow_state`
+and `assignee_scope`, a Shortcut source silently narrows to what Shortcut's own
+boards show: archived stories, and stories under an archived epic, are neither
+ingested nor listed, so an otherwise-matching `workflow_state` will ingest less
+than the state's own count suggests. **No setting disables it**, it applies to
+no other provider, and it does not cover a force-start by id
+([ingestion-pipeline.md](ingestion-pipeline.md#current-behavior-caveats)).
 
 Each source also takes an optional **`agent`** — the coding CLI its sessions run
 (`claude`, `codex`, `aider`, `goose`, `opencode`, `cline`, `antigravity`, or a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -457,7 +457,7 @@ Override the directory with `MINDFLOCK_ASSISTANT_DIR`.
 | `MINDFLOCK_WINDOW_REFRESH_FILE` | `~/.mindflock/window_refresh.json` | Path of the scheduled window-refresh keepalive's config + per-provider `last_fired` state |
 | `MINDFLOCK_SESSION_NAME` | — | Read by the injected CLI hook commands at fire time to attribute activity/thread markers to a MindFlock window; unset, the hooks fall back to the live tmux `#{session_name}` |
 | `MINDFLOCK_PROVIDER_BIN_<NAME>` | — | Per-provider binary override (provider name uppercased, non-alphanumerics → `_`; e.g. `MINDFLOCK_PROVIDER_BIN_CLAUDE=/opt/claude`). Wins over Settings → `coding_cli.binary_paths` and the provider TOML's `binary_path` |
-| `MINDFLOCK_ACTIVITY_MARKER_DIR` | `~/.mindflock-assistant/.activity-markers` | Per-session `{state, ts}` markers the CLI activity hooks write (working/idle/clarify detection — Claude, Codex, and opt-in TOML providers; see [providers.md](providers.md)). Note: does **not** follow `MINDFLOCK_ASSISTANT_DIR` |
+| `MINDFLOCK_ACTIVITY_MARKER_DIR` | `~/.mindflock-assistant/.activity-markers` | Per-session `{state, ts}` markers the CLI activity hooks write (working/idle/clarify detection — Claude, Codex, and opt-in TOML providers; see [providers.md](providers.md)). Read by the hook **at fire-time from the firing CLI's environment**, not by the server at install time — so a sandboxed CLI (redirected `HOME`) writes into its own sandbox instead of poisoning the shared hooks file's path for cohabiting sessions. Note: does **not** follow `MINDFLOCK_ASSISTANT_DIR` |
 | `MINDFLOCK_THREAD_MARKER_DIR` | `~/.mindflock-assistant/.thread-markers` | Per-window conversation-id markers so sessions sharing a directory each resume their *own* thread. Note: does **not** follow `MINDFLOCK_ASSISTANT_DIR` |
 | `CODEX_HOME` | `~/.codex` | Codex CLI data dir; usage is read from `$CODEX_HOME/sessions` |
 | `ANTIGRAVITY_CLI_DIR` | `~/.gemini/antigravity-cli` | Antigravity CLI state dir (conversation DBs, usage) |
@@ -520,8 +520,10 @@ Settable from the UI settings dialog (⚙) and persisted server-side:
   author intended. One list governs every delivery channel. The ids are stable
   across releases even when a rule's *meaning* is tightened — `session_idle` is
   now labelled **"A session finishes its work and stays idle"** and fires on
-  `session.turn_ended` (MindFlock watched the agent work, it has been idle for
-  45 s since, and nothing is queued to wake it), rather than on the activity
+  `session.turn_ended` (MindFlock watched the agent work — corroborated by the
+  CLI's own hooks or its status line, not just CPU — it has been idle since for
+  a dwell sized to that evidence, 12–45 s, and nothing is queued to wake it;
+  see [web-api.md](web-api.md)), rather than on the activity
   chip going grey at the end of every assistant turn. An existing opt-in simply
   gets quieter; **no migration is needed**, by hand or otherwise.
 - **ntfy push** (`notifications.ntfy_enabled` / `_server` / `_topic` / `_token` /

--- a/docs/development.md
+++ b/docs/development.md
@@ -275,7 +275,7 @@ refresher re-runs suites automatically.
 | Launch behavior (golden files) | `test_launch_parity` (compares generated launchers to `tests/unit/data/*.golden.sh`), `test_provider_framework`, `test_claude_provider` |
 | Providers: pricing, usage | `test_pricing`, `test_usage_history` |
 | Web: routes, git ops, terminal, addons | `test_route_precedence`, `test_git_ops`, `test_terminal_extras`, `test_scroll_speed`, `test_addons`, `test_frontend_slots`, `test_cursor_window`, `test_webui` |
-| Pipeline: config, state, scan, validate | `test_config`, `test_state`, `test_backfill`, `test_filter`, `test_ticket_validator`, `test_logging_config` |
+| Pipeline: config, state, scan, validate | `test_config`, `test_state`, `test_backfill`, `test_filter`, `test_ticket_providers` (provider-level fetch/filter rules), `test_ticket_validator`, `test_logging_config` |
 | Pipeline: provisioning + launch | `test_environment_provisioner`, `test_session_runner`, `test_orchestrator`, `test_clarification`, `test_workspace_cleanup` |
 | PR flow | `test_pr_pipeline` |
 | Property (hypothesis) | backfill ordering, prompt construction, validation-with-context, assignee filter, timestamp persistence |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -45,7 +45,7 @@ Core vocabulary (emitted by the server):
 | `session.prompt_sent` | The queue drain loop auto-sends a prompt | `data: {text, remaining, loop}` |
 | `session.queue_changed` | Any prompt-queue edit | `data: {pending, enabled, loop}` |
 | `session.usage_restored` | A provider window reopened for a session that had run out | `data: {resumed}` |
-| `session.turn_ended` | A session's work really is over — observed working, idle ever since, nothing queued | `data: {idle_for}` |
+| `session.turn_ended` | A session's work really is over — corroborated work, idle ever since, nothing queued | `data: {idle_for}` |
 
 Addon-originated events (see `AppContext.emit`) live under the `addon.`
 namespace, e.g. `addon.notify.ping`. Notable transitions:
@@ -56,8 +56,12 @@ namespace, e.g. `addon.notify.ping`. Notable transitions:
   fires at the end of *every* assistant turn, so a ten-turn conversation flips
   it ten times, and a window that has merely been re-opened flips it once
   without having run anything at all. `session.turn_ended` is the fact worth
-  acting on — it asserts that the agent was observed working in its current tmux
-  incarnation, has been idle continuously for `server._TURN_END_DWELL_S` (45s),
+  acting on — it asserts that the agent's work was corroborated (its CLI's own
+  hook report, or the live-turn status line on its pane — never a CPU spike on a
+  parked session) in its current tmux
+  incarnation, has been idle continuously for the evidence-tiered dwell
+  (`server._TURN_END_DWELLS`: 12s hook-armed, 25s status-line-armed, 45s for
+  the CPU backstop — see [web-api.md](web-api.md)),
   and has no queued prompt waiting to wake it. Emitted once per cycle of
   observed work, so a session that then sits idle all night says it once
 - **PR merged/closed**: `session.stage_changed` with `old == "pr"` (an open PR
@@ -386,4 +390,5 @@ global:
 | `mindflock.events.onStatus(cb)` | Called on connect/disconnect transitions |
 | `mindflock.sessions()` | The latest instances snapshot array (same shape as `GET /api/instances`) |
 | `mindflock.displayName(title)` | What a session is **called** — its rename, else the label the rail shows (`(tix) add-dark-mode/sc-12345`), else the raw title. Published by the SPA (`lib/windowName.ts`); feature-detect it, because a non-SPA page has no rail to agree with. Use it wherever a user reads a session's name: the event envelope carries the machine slug, and naming a window nobody can find under that name is worse than saying nothing. |
+| `mindflock.slotNumber(title)` | The session's **slot number** in the rail — `"1"`…`"9"`, or `""` when the row shows none (tenth row on, filtered out, verify sessions). The rail's numbers are how people locate a window, so a notification carrying one must show the number the rail shows *right now* — drag order and the live filter applied. Same publish point and the same feature-detect rule as `displayName`; the notify addon renders it as a `[3] ` prefix on the name. |
 | `mindflock.toast(msg, opts?)` | Show a toast. Assigned by `app.js` (F3), so it's present whenever the SPA is loaded — still feature-detect in addon modules for non-SPA pages. `opts` is optional: `{onClick, duration}` makes the toast clickable and/or overrides its lifetime (ms). |

--- a/docs/ingestion-pipeline.md
+++ b/docs/ingestion-pipeline.md
@@ -39,7 +39,7 @@ provider is chosen by `[ticketing].provider` (see
 | Provider | How "assigned to me" is fetched |
 |---|---|
 | `github_issues` | `GET /repos/{owner}/{repo}/issues?assignee=<you>` (PRs filtered out) |
-| `shortcut` | `POST /stories/search` by `owner_id`, then per-story hydration |
+| `shortcut` | `POST /stories/search` by `owner_id`, then per-story hydration; archived stories and stories under an archived epic are excluded |
 | `jira` | `POST /rest/api/3/search/jql`, `assignee = currentUser()` (description flattened from ADF — headings keep their `#` level, which is what acceptance-criteria mining matches on) |
 | `linear` | GraphQL `viewer.assignedIssues(filter: {updatedAt})` |
 | `asana` | `GET /tasks?assignee=me&workspace=<gid>` |
@@ -134,6 +134,13 @@ carries a `source_labels` entry for EVERY configured source — including ones
 that returned nothing or errored — because a source with no tickets still needs
 a heading to say so under.
 
+Shortcut's `search_assigned_all()` applies the **same archived story + archived
+epic filter** as its poll (on both the owner-scoped and the any-assignee
+branch), so the Intake panel matches what you see in Shortcut instead of listing
+rows you cannot find there. That filtering is **Shortcut-only** — Jira, Linear,
+GitHub Issues and Asana have no equivalent — so two sources in the same panel
+are filtered by different rules.
+
 **Multiple sources.** You can configure more than one source at once — different
 providers *and* several of the same provider with different credentials (two Jira
 sites, two GitHub repos, …) — via an array of `[[ticketing.source]]` entries (or
@@ -173,6 +180,16 @@ loops: the story poller (always), the PR poller (if `[github]` is present and
 enabled), and one cache refresher per refresh-enabled `[[workspace.cache]]`
 entry.
 
+**API-call budget.** A Shortcut source costs one extra `GET /epics` per poll
+tick (default every 20 s) and one per Intake panel listing, whenever any result
+row carries an `epic_id`. `/epics` is an unpaginated whole-workspace listing, so
+the response grows with the workspace's age, and it counts against Shortcut's
+per-token rate budget. It is deliberately **not cached** on the adapter: the
+backfill scanner and the orchestrator each hold one provider for the life of the
+process, so a cached set would never notice an epic being un-archived and would
+hide those stories forever. The flip side of that decision is that un-archiving
+brings a story back on the very next poll.
+
 ## Story flow
 
 ```
@@ -186,6 +203,21 @@ Shortcut search ──► dedup ──► validate ──┬─ valid ──► 
    `workflow_state_id`). Search results lack descriptions, so each story is
    re-fetched by id. Retries with exponential backoff; a failed scan never kills
    the pipeline.
+
+   **Archived work is excluded, at two levels**, so the pipeline sees what
+   Shortcut's own boards show. `/stories/search` returns archived stories, so
+   `_search_stories` drops every row whose own `archived` flag is truthy — a
+   *missing* flag reads as live, which fails open (it can only ever list more).
+   That is not the whole rule, though: archiving an **epic** takes its stories
+   off the boards without touching each story's `archived` flag, so one
+   `GET /epics?includes_description=false` per search resolves the archived epic
+   ids and `_drop_archived_epic_stories` removes the rows under them. The epic
+   filter runs **after** the multi-state fan-out and dedup and **before**
+   per-story hydration, so an excluded story costs no hydration request; it is
+   **skipped entirely when no row carries an `epic_id`** (the common case); and
+   any failure — non-200, network, bad token — yields an empty set, logs
+   `Could not resolve archived Shortcut epics`, and keeps every story.
+
 2. **Dedup** — a story is skipped if a remote branch `feature/sc-<id>/…` already
    exists (`git ls-remote`) or its id is in `state.json`'s `processed_stories`.
    Survivors are processed oldest-first.
@@ -333,6 +365,13 @@ pipeline has already taken*:
   eligible. The roll-up therefore filters `has_session` itself, because calling
   work that is being done "waiting to start" would be wrong.
 
+A third exclusion is **not** the roll-up's doing: archived Shortcut stories (and
+stories under an archived epic) are dropped inside the provider, before any
+eligibility is computed, so they never reach `ticket_start.skip_reasons` and get
+no skip-reason chip. They are simply absent from the list rather than shown and
+explained — the one place where the panel and the eligibility annotation are no
+longer derived from the same rule set.
+
 ## Cache refreshers
 
 Each `[[workspace.cache]]` entry with a `refresh_command` gets a background
@@ -372,6 +411,13 @@ hand-editing `state.json`.
   `mode`/`open_cursor`/`skip_permissions`; see
   [configuration.md](configuration.md)).
 - **Ingestion is polling-only** — there is no webhook listener.
+- **The Shortcut archived filter is unconditional.** No `config.toml` key or UI
+  setting turns it off, so a workspace that deliberately tracks archived stories
+  has no opt-out. `fetch(ticket_id)` does **not** apply it either — a
+  force-start by id (Intake's **Start now**, `POST /api/tickets/start`) will
+  still launch an archived story. And a failed or non-200 `/epics` call degrades
+  silently to no epic filtering: if archived rows reappear, grep the log for
+  `Could not resolve archived Shortcut epics`.
 - Only review-thread comments are actioned on PRs; top-level issue comments are
   fetched by dead code and ignored.
 - The clarification handler always continues with the original story after

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -162,9 +162,18 @@ possible, from the CLI's own lifecycle hooks rather than pane scraping. The
 machinery is provider-agnostic (`providers/activity_markers.py`): at every
 launch, MindFlock idempotently merges hook commands into the CLI's hooks
 config; each hook fires and writes a per-session `{state, ts}` JSON marker to
-`~/.mindflock-assistant/.activity-markers/<session>.json`
-(`MINDFLOCK_ACTIVITY_MARKER_DIR` overrides the directory), which the web layer
-trusts over pane inspection. Every MindFlock-written hook command carries a
+`<marker dir>/<session>.json`, which the web layer trusts over pane inspection.
+Both halves of that path are resolved **inside the firing hook**, never baked
+in at install time: the session name from `MINDFLOCK_SESSION_NAME` (falling
+back to the live tmux `#{session_name}`), and the directory from the firing
+CLI's own environment — `MINDFLOCK_ACTIVITY_MARKER_DIR`, else the real
+`~/.mindflock-assistant/.activity-markers`. The install-time alternative was a
+live incident: sessions sharing a repo share one hooks file, and a sandboxed
+MindFlock (a Verify run with `HOME` redirected) re-pinning that shared file
+baked its sandbox path in — after which every cohabiting session's markers
+went into a dead sandbox and their chips froze. Resolving at fire-time gives
+each world its own markers, whoever installed last; `hook_command`'s
+`marker_dir` parameter is accordingly accepted and **ignored**. Every MindFlock-written hook command carries a
 `# mindflock-activity` tag so a re-install recognizes and replaces **only**
 MindFlock's own entries; user-authored hooks are never touched. Hook install is
 best-effort and can never break a launch. (The Claude provider re-exports these
@@ -187,6 +196,15 @@ evidence it never earned. Unknowable inputs still trust the CLI: no creation
 stamp, or an unreadable marker age, and the marker stands. Claude's live
 `claude agents --json` path reports age `0.0` — it is real-time by construction
 — so it always passes.
+
+**`reports_activity()` is the capability question**, distinct from any one
+reading: whether this CLI can announce its own state at all (hooks installed,
+or a live query) — not whether a marker happens to be fresh right now.
+Returning True is a promise the web layer leans on: a turn-end *announcement*
+for such a CLI is never built out of pane guesswork alone (see the arming
+ladder in [web-api.md](web-api.md)). Claude returns True outright;
+`GenericProvider` derives it from whether the TOML declares an
+`activity.hooks_file`; the base default is False (pane inspection only).
 
 Two built-in wirings:
 
@@ -259,7 +277,9 @@ for LLM`.
 The optional `[activity]` table opts a CLI that has its own hooks engine into
 the marker mechanism above: `hooks_file` names the repo-local hooks config
 (e.g. Codex's `.codex/hooks.json`) and each `[[activity.events]]` maps a hook
-event to the state it records (`working`/`idle`/`clarify`). An empty/omitted
+event to the state it records (`working`/`idle`/`clarify`). Declaring a
+`hooks_file` is also what flips the provider's `reports_activity()` capability
+(above). An empty/omitted
 `hooks_file` means pane-inspection only (unchanged behaviour); the `[classify]`
 pane patterns remain as a fallback for CLI builds without hooks.
 

--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -147,9 +147,23 @@ poll catches it 4 s later.
 
 **The per-title rolling record has a lifecycle, and it is short.** It holds the
 pane hash, the CPU baseline, the hysteresis clocks and the layer-wide
-*provenance* (`reported` / `state_since` / `worked_at`, written on every return
-path, so a session reporting through its CLI's hooks leaves a trail too). It is
-reset:
+*provenance* (`reported` / `state_since` / `worked_at` / `reading` — the
+`(value, source)` pair as ONE atomic store, since it is read as one fact — /
+`worked_evidence`, written on every return path, so a session reporting through
+its CLI's hooks leaves a trail too), plus what the pane layer used to *prove*
+its current busy run (`hard_since` / `proof`, cleared by every non-working
+reading so a proven-busy run can never straddle an agent death or a relaunch).
+`worked_at` is stamped only by a reading that CORROBORATES work — the CLI's own
+report, or its live-turn status line; a busy process tree on its own moves the
+chip and arms nothing (see `_verdict`'s `arms`, and the ladder in
+[web-api.md](web-api.md)). `source` names the layer that produced the current
+reading ("marker" / "exit" / "proc" / "trust" / "pane");
+`reading_is_authoritative` is how the settle skip and the queue drain's fast
+tier ask about it. Arming decides only that a turn-end *may* be announced;
+whether it actually fires also passes the web layer's exact gates — recent
+human input (either terminal socket, `/send`, send-now, raw tmux client
+activity), the queue's send-grace, and fast-track's own record — see
+[web-api.md](web-api.md). It is reset:
 
 - when the **tmux incarnation** changes — the record is keyed to tmux's own
   `session_created`, so a relaunched session starts clean (its `_LIMIT_PROBE`

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -361,7 +361,12 @@ survives server restarts. Events: `session.setup_started/finished`,
 | DELETE | `/api/instances/{title}/queue?item=<id>` | Remove one item; omit `item` to clear the whole queue |
 
 A background drain loop feeds the queue into the agent whenever it is **idle**
-(finished a turn / at its prompt): it never interrupts `working`/`clarify`, and
+(finished a turn / at its prompt) — idle that has *persisted*: for
+`_QUEUE_IDLE_SETTLE` (12s) before the first send, dropped to
+`_QUEUE_IDLE_SETTLE_MARKER` (4s) when the idle reading is authoritative
+(`agent_state.reading_is_authoritative` — the CLI's own hook said so), so a
+hook CLI's queue drains one pass sooner. It never interrupts
+`working`/`clarify`, and
 if a started session's agent tmux has died (e.g. the CLI exited when usage ran
 out) it reboots it — rate-limited — so a queued run resumes on its own the
 moment usage returns. Before each would-be send the drain re-checks the
@@ -505,14 +510,74 @@ happens ten times in a ten-turn conversation, between two prompts of a draining
 queue, and once more for a window that has merely been re-opened (attaching a
 pane relaunches a dead agent, which then parks at an empty prompt). **`session.
 turn_ended`** is the fact that answers it, and it asserts three things at once:
-the agent was *observed working* in its current tmux incarnation, it has been
-idle continuously for `_TURN_END_DWELL_S` (45s), and no queued prompt is waiting
-to wake it. It is emitted once per cycle of observed work — the evidence is
-spent on emit and re-earned by the next `working` reading — so a session left
-idle overnight announces itself once. 45s is chosen to sit above every other
-idle dwell in the app (`_QUEUE_IDLE_SETTLE` 12s, `autopilot.IDLE_SETTLE_S` 30s),
-so the queue drains and a fast-track chain decides the agent is done *before*
-anyone is told the work finished.
+work by the agent was *corroborated* in its current tmux incarnation, it has been
+idle continuously for the evidence-tiered dwell (next paragraph), and no queued
+prompt is waiting to wake it. It is emitted once per cycle of observed work — the evidence is
+spent on emit and re-earned by the next armed `working` reading — so a session
+left idle overnight announces itself once.
+
+The dwell is **tiered by the evidence's strength** — `agent_state.work_evidence`
+— because it only has to buy the confidence the evidence lacks: 12s when the
+CLI's own hook report both armed the work AND delivered the idle (the fast lane
+requires the END to be authoritative too — marker-armed work whose idle came
+from a pane misread takes the slow lane outright), 25s for status-line-armed
+work (pane CLIs), 45s for the CPU backstop. The hazards the old flat 45s
+blanketed are now **exact gates**: recent human input (both terminal
+websockets, `/send`, send-now — plus `tmux list-clients` client activity at
+announce time, for people attached to tmux directly), a queue send-grace
+(`peek_next` reads None the instant the last prompt is *popped*, which is at
+tmux-typing time — the drain's own `armed`/`sent_at` record covers the
+in-flight window), and fast-track (held exactly while the autopilot record
+reads `running` *and its driver lease is live* — a wedged chain the driver
+cannot step goes lease-stale and announcements resume). The working→idle
+marker transition also forces a **fresh limit-screen probe** (a forced miss
+never refreshes the probe throttle, so a banner that paints late is caught by
+the next tick's re-probe), closing the old 15s probe-cache blind window.
+
+An **authoritative idle/clarify skips the 3s activity settle** entirely — a
+hook marker cannot misread a frame, so the chip and the default-on
+"needs your input" push react within one tick. `limit` never skips: both
+marker-branch limit reclassifications are pane captures, and one frame can
+misread scrollback or quoted output — so the default-on "ran out of usage"
+push keeps its two-sighting guard whatever triggered the reading.
+
+*Corroborated*, because a `working` reading is not by itself evidence of a turn.
+A reading paints the chip; only some readings may interrupt a human. The ladder
+(`agent_state._verdict`'s `arms` argument):
+
+- the **CLI's own report** — a fresh hook marker or live agent query — arms at
+  any duration. A hook fires because a prompt was submitted or a tool ran;
+- the provider's **live-turn status line** (Claude's `esc to interrupt`, a
+  climbing token counter) arms too: it is on screen *because* a turn is running,
+  which covers a marker that went stale mid-turn;
+- a **busy process tree alone does not**. A parked Claude session's own
+  auto-updater crossed `_CPU_ACTIVE_JIFFIES_PER_S` for one 4s poll, read as
+  `working` for ~12s — past the settle above — and 45s later announced a turn
+  its transcript shows never happened. `/clear`, a GC pause and a compile all
+  cross that line as well;
+- a CLI that does **not** report for itself keeps a CPU backstop: an unbroken
+  busy run of `_CPU_ONLY_ARMS_AFTER_S` (20s) arms, which no single spike
+  survives (`hard_since`/`proof` are cleared by EVERY non-working reading,
+  whatever layer delivered it, so a run can never straddle an agent death, a
+  Stop hook, or a relaunch). Such a provider's only other signal is a
+  status-line regex, and a regex can be wrong — losing the announcement to a
+  reworded hint would be worse than the spike the strict rule guards against.
+  No backstop where the CLI's hooks are actually *speaking* (a marker was read
+  this poll): those have two independent signals already, and the phantom this
+  ladder exists to kill was one of theirs. A CLI that merely *declares* hooks
+  while its marker never appears (an older codex build, a failed install)
+  keeps the backstop — declared capability is not observed capability.
+
+Of the bundled providers, Claude and Codex report through hooks; aider,
+antigravity, cline, goose and opencode are covered by their status line, with
+the CPU backstop behind it. `test_provider_activity_patterns.py` pins that
+roster, so a provider added with no signal at all shows up as a failing test
+rather than a silent notification. The backstop's 45s is chosen to sit above
+every other idle dwell in the app (`_QUEUE_IDLE_SETTLE` 12s,
+`autopilot.IDLE_SETTLE_S` 30s), so the queue drains and a fast-track chain
+decides the agent is done *before* anyone is told the work finished; the
+faster tiers don't need that ordering, because the send-grace and fast-track
+gates above check those hazards exactly instead of outwaiting them.
 
 For ~30s after the server process starts (including a Settings-triggered
 restart, which re-execs), the `status/activity/stage_changed` diff events are

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -698,7 +698,13 @@ credential.
   its **Thinking effort**, ingest-state picker, credentials, **Test connection**,
   **Remove**), then
   **Assigned tickets** — the slowest of the three fan-outs (~3 s: a provider
-  search per source plus a `git ls-remote` per repo). A source's **Agent CLI**
+  search per source plus a `git ls-remote` per repo). A **Shortcut** source
+  lists what Shortcut's own boards show: archived stories, and stories under an
+  archived epic, no longer appear at all. Bucket counts can therefore drop
+  without anything changing in the tracker, and a source whose open work is all
+  archived now renders an empty heading. No other provider hides archived work,
+  and no setting turns this one off
+  ([ingestion-pipeline.md](ingestion-pipeline.md#providers)). A source's **Agent CLI**
   lists `GET /api/providers` (so a provider you defined yourself is selectable
   too), its unset option names the app default rather than showing a blank, and
   the collapsed card always states which CLI the queue runs — the difference
@@ -909,7 +915,11 @@ unmounts anyway); they're held in the query client
 (`frontend/src/state/queries.ts`), so reopening the dialog or switching away and
 back shows the last list **immediately** while a refresh runs behind it. The
 panel's note area says `Loading…` on a cold panel and `Refreshing…` over rows
-already on screen. Opening the Intake dialog **prefetches all three**
+already on screen. A cached list can therefore still hold a row for a story
+archived since it was fetched — and **starting that row bypasses the archived
+filter**, because a force-start goes through `fetch(ticket_id)`, which does not
+apply it. **Refresh** re-lists and the row disappears.
+Opening the Intake dialog **prefetches all three**
 (`prefetchIntakePanels()`), so clicking through to one finds it loaded — and it is
 what fills the tab strip's counts, which read the same cached query the tab does
 and therefore can never disagree with the list underneath.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -311,12 +311,22 @@ the events bus, **including the backlog replayed on connect** so it answers
 opened it (keyed on timestamp so it survives server restarts); clicking an entry
 focuses that session.
 
+**Every notification leads with the session's rail slot** — *[3] sitecheck-bot7
+has finished* — the same 1–9 number `Ctrl/Alt+1…9` jump to, resolved
+client-side at render time so drag order and the live sidebar filter are
+honored (the order is per-browser state the server never sees). Desktop
+popups, bell rows and in-app toasts all carry it; rows past the ninth,
+sessions the filter is hiding, and phone (ntfy) pushes — which have no rail to
+agree with — carry no number rather than a wrong one. Extension pages get the
+same resolver as `mindflock.slotNumber(title)`
+(see [extensions.md](extensions.md)).
+
 A raw idle transition no longer produces a row at all. The feed used to log
 *finished — now idle* on every activity flip to idle, with no rule gate and no
 dedupe — so it fired at the end of every assistant turn, between two prompts of
 a draining queue, and for a re-opened window whose agent had run nothing. The
 finished row now comes from `session.turn_ended` and says how long the quiet has
-lasted — **finished — idle 45s**, **finished — idle 2m** — because the dwell is
+lasted — **finished — idle 25s**, **finished — idle 2m** — because the dwell is
 the part that makes the claim trustworthy. `working`/`offline` flips remain
 chip colours and are still filtered out.
 
@@ -332,8 +342,11 @@ goes grey at the end of every assistant turn — the CLI's Stop hook cannot tell
 "the work is done" from "this reply is done" — and also for a window you merely
 re-opened, since attaching its pane relaunches a dead agent that then parks at an
 empty prompt. Before the event fires, three things have to be true: MindFlock
-*watched this agent work* in the tmux session that is running now, it has been
-idle for 45 seconds since, and there is no queued prompt about to wake it. Each
+*watched this agent work* in the tmux session that is running now — corroborated
+by the CLI's own hook report or its live-turn status line, never a bare CPU
+spike on a parked session — it has been idle since for a dwell sized to that
+evidence (12 s when the CLI reports through hooks, 25 s for a status-line read,
+45 s for the CPU backstop), and there is no queued prompt about to wake it. Each
 cycle of work announces itself once, however long the session then sits there.
 
 The two usage rules are a pair: **"A session runs out of usage"** fires on the

--- a/electron/README.md
+++ b/electron/README.md
@@ -207,6 +207,14 @@ therefore your sessions) stays shared, which is usually what you want:
   only when missing or stale, and a Start menu locked down by policy costs you
   the label, not the app.
 
+  Its icon is **staged onto the local disk** first (into the dev profile dir).
+  A shortcut's `IconLocation` is read by the Windows shell, not by us, and the
+  shell will not extract an icon from the WSL share the checkout lives on — so
+  pointing it at `dev-icon.ico` in place left the toast headed correctly and
+  badged with the blank white document tile. The window and taskbar icons are
+  unaffected either way: Electron loads those itself, with an ordinary file
+  read. A checkout on a local drive keeps using its own file.
+
 Prod is untouched: with neither the env var nor the flag set, every one of
 these is a no-op, so it is safe to ship in the packaged build.
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -70,6 +70,47 @@ if (DEV) {
 //
 // Windows-only, and only in dev: prod already has the installer's shortcut, and
 // no other platform resolves notification identity this way.
+// A shortcut's icon has to live where the Windows SHELL can read it.
+//
+// `IconLocation` is not loaded by us — we hand Windows a path and the shell
+// extracts the icon from it later, in whatever process is drawing a Start-menu
+// tile, a taskbar button, or the app logo on a toast. On the supported Windows
+// shape that path was the checkout itself, which is a WSL share
+// (`\\wsl.localhost\<Distro>\...`), and the shell's icon extraction does not
+// resolve it: the toast came up headed correctly and badged with the generic
+// white document icon. Nothing was wrong with the .ico — the window and taskbar
+// icons load the very same file and always looked right, because Electron reads
+// those itself with an ordinary file read.
+//
+// So for a UNC source, keep a copy on the local disk — in the dev profile dir,
+// which is per-user, always local, and thrown away with the rest of the dev
+// state — and point the shortcut at that. Byte-compared rather than blindly
+// rewritten, so a changed MINDFLOCK_DEV_ICON is picked up and an unchanged one
+// costs a 77KB read. Returns null if it cannot be staged, and the caller falls
+// back to the exe's own icon rather than writing a path that renders as blank.
+//
+// A local checkout keeps using its own file: the copy is a workaround for the
+// share, not an improvement. (A mapped network drive would need it too and does
+// not get it — no one runs the supported shape that way.)
+function stageShortcutIcon (src) {
+  try {
+    if (!src || !fs.existsSync(src)) return null
+    if (!src.startsWith('\\\\')) return src // already local — nothing to fix
+    const dst = path.join(app.getPath('userData'), 'dev-icon.ico')
+    const from = fs.readFileSync(src)
+    let have = null
+    try { have = fs.readFileSync(dst) } catch (e) { /* first run */ }
+    if (!have || !have.equals(from)) {
+      fs.mkdirSync(path.dirname(dst), { recursive: true })
+      fs.writeFileSync(dst, from)
+    }
+    return dst
+  } catch (e) {
+    console.warn('[mindflock] could not stage the dev shortcut icon:', e && e.message)
+    return null
+  }
+}
+
 function ensureDevToastName () {
   if (!DEV || process.platform !== 'win32') return
   try {
@@ -80,7 +121,8 @@ function ensureDevToastName () {
     // A shortcut's icon must be an .ico; MINDFLOCK_DEV_ICON may legitimately be
     // a .png (that override is shared with the window/dock icon, which takes
     // either), so fall back to the exe rather than writing a broken IconLocation.
-    const icon = DEV_ICON && DEV_ICON.toLowerCase().endsWith('.ico') ? DEV_ICON : process.execPath
+    const ico = DEV_ICON && DEV_ICON.toLowerCase().endsWith('.ico') ? DEV_ICON : null
+    const icon = (ico && stageShortcutIcon(ico)) || process.execPath
     const want = {
       target: process.execPath,
       args: '"' + app.getAppPath() + '" --mindflock-dev',

--- a/frontend/src/__tests__/windowName.test.ts
+++ b/frontend/src/__tests__/windowName.test.ts
@@ -6,7 +6,7 @@
  * under that name is the one mistake this channel cannot make.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { windowName, publishWindowName } from "../lib/windowName";
+import { slotNumber, windowName, publishWindowName } from "../lib/windowName";
 import { useUi } from "../state/store";
 
 type Row = { title: string; branch?: string; display_title?: string };
@@ -91,5 +91,53 @@ describe("publishWindowName", () => {
     expect((mf.displayName as (t: string) => string)("my-refactor")).toBe(
       "my-refactor"
     );
+  });
+});
+
+
+describe("slotNumber", () => {
+  it("numbers sessions the way the rail does: saved order first, 1-based", () => {
+    useUi.setState({ order: ["b", "a"], filter: "" });
+    withSessions([{ title: "a" }, { title: "b" }, { title: "c" }]);
+    expect(slotNumber("b")).toBe("1");
+    expect(slotNumber("a")).toBe("2");
+    expect(slotNumber("c")).toBe("3"); // unlisted-in-order rows file after
+  });
+
+  it("excludes verify sessions, exactly as the rail does", () => {
+    useUi.setState({ order: [], filter: "" });
+    withSessions([{ title: "verify-x-abc" }, { title: "real" }]);
+    expect(slotNumber("real")).toBe("1");
+    expect(slotNumber("verify-x-abc")).toBe("");
+  });
+
+  it("renumbers under the live filter — the number shown IS the number sent", () => {
+    useUi.setState({ order: [], filter: "bot", aliases: {} });
+    withSessions([{ title: "alpha" }, { title: "bot-1" }, { title: "bot-2" }]);
+    expect(slotNumber("bot-1")).toBe("1");
+    expect(slotNumber("bot-2")).toBe("2");
+    expect(slotNumber("alpha")).toBe("");
+  });
+
+  it("goes blank from the tenth row on, mirroring the rail's hotkey slots", () => {
+    useUi.setState({ order: [], filter: "" });
+    withSessions(Array.from({ length: 11 }, (_, i) => ({ title: "s" + i })));
+    expect(slotNumber("s8")).toBe("9");
+    expect(slotNumber("s9")).toBe("");
+  });
+
+  it("answers blank, never throws, for the unknown and the unlisted", () => {
+    useUi.setState({ order: [], filter: "" });
+    withSessions([{ title: "a" }]);
+    expect(slotNumber("nope")).toBe("");
+    expect(slotNumber("")).toBe("");
+    delete (globalThis as unknown as { mindflock?: unknown }).mindflock;
+    expect(slotNumber("a")).toBe("");
+  });
+
+  it("is published on the bridge next to displayName", () => {
+    publishWindowName();
+    const w = globalThis as unknown as { mindflock?: Record<string, unknown> };
+    expect(typeof w.mindflock?.slotNumber).toBe("function");
   });
 });

--- a/frontend/src/components/EventToasts.tsx
+++ b/frontend/src/components/EventToasts.tsx
@@ -12,6 +12,7 @@ import {
   type EventEnvelope,
 } from "../state/queries";
 import { displayName, useUi } from "../state/store";
+import { slotNumber } from "../lib/windowName";
 import { fmtUsd } from "../lib/format";
 import {
   dropActivity,
@@ -156,6 +157,15 @@ function notifyOnce(session: string, state: string, msg: string, opts?: ToastOpt
   toast(msg, opts);
 }
 
+// The name with its rail slot in front — "[3] sitecheck-bot7" — so a toast
+// points at a row you can find at a glance. Same live resolver the OS
+// notification and the bell use; blank slot (filtered out, tenth row on)
+// degrades to the bare name.
+function namedSlot(session: string): string {
+  const n = slotNumber(session);
+  return (n ? "[" + n + "] " : "") + displayName(session);
+}
+
 function instByTitle(title: string): Instance | null {
   return instances().find((i) => i.title === title) || null;
 }
@@ -196,7 +206,7 @@ export function EventToasts() {
           markClarify(env.session);
           const inst = instByTitle(env.session);
           const snip = inst?.last_turn ? " — “" + inst.last_turn + "”" : "";
-          notifyOnce(env.session, "clarify", displayName(env.session) + " needs your input" + snip, {
+          notifyOnce(env.session, "clarify", namedSlot(env.session) + " needs your input" + snip, {
             onClick: () => selectSession(env.session),
           });
         }
@@ -205,7 +215,7 @@ export function EventToasts() {
     unsubs.push(
       ev.subscribe("session.setup_finished", (env) => {
         if (isReplay(env) || env.new === "ok") return;
-        notifyOnce(env.session, "setupfail", "worktree setup failed on " + displayName(env.session) + " — prompts held", {
+        notifyOnce(env.session, "setupfail", "worktree setup failed on " + namedSlot(env.session) + " — prompts held", {
           onClick: () => selectSession(env.session),
         });
       })
@@ -213,7 +223,7 @@ export function EventToasts() {
     unsubs.push(
       ev.subscribe("session.check_finished", (env) => {
         if (isReplay(env) || env.new === "ok") return;
-        notifyOnce(env.session, "checkfail", "checks failed on " + displayName(env.session), {
+        notifyOnce(env.session, "checkfail", "checks failed on " + namedSlot(env.session), {
           onClick: () => selectSession(env.session),
         });
       })
@@ -260,7 +270,7 @@ export function EventToasts() {
           { live: true }
         );
         if (String(env.new || "") === "halted")
-          notifyOnce(env.session, "ftstop", "fast-track stopped on " + displayName(env.session), {
+          notifyOnce(env.session, "ftstop", "fast-track stopped on " + namedSlot(env.session), {
             onClick: () => selectSession(env.session),
           });
       })
@@ -321,7 +331,7 @@ export function EventToasts() {
         notifyOnce(
           env.session,
           "budget",
-          displayName(env.session) + " exceeded its budget (" + fmtUsd(d.cost || 0) + " of " + fmtUsd(d.budget || 0) + ")",
+          namedSlot(env.session) + " exceeded its budget (" + fmtUsd(d.cost || 0) + " of " + fmtUsd(d.budget || 0) + ")",
           { onClick: () => selectSession(env.session), duration: 8000 }
         );
       })

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -9,6 +9,7 @@ import { useUi } from "../state/store";
 import { relTime } from "../lib/format";
 import { selectSession } from "../lib/sessionActions";
 import { attentionItems } from "./sidebar/ordering";
+import { slotNumber } from "../lib/windowName";
 
 const NOTIF_CAP = 100;
 const NOTIF_SEEN_KEY = "mf_notif_seen_ts";
@@ -270,7 +271,10 @@ export function NotificationsBell() {
                     data-session={n.session}
                     onClick={() => jump(n.session)}
                   >
-                    <span className="notif-sess">{aliases[n.session] || n.session || "—"}</span>
+                    <span className="notif-sess">
+                      {(slotNumber(n.session) ? "[" + slotNumber(n.session) + "] " : "") +
+                        (aliases[n.session] || n.session || "—")}
+                    </span>
                     <span className="notif-text">{n.text}</span>
                     <span className="notif-time">{relTime(n.ts)}</span>
                   </div>

--- a/frontend/src/lib/windowName.ts
+++ b/frontend/src/lib/windowName.ts
@@ -22,6 +22,9 @@
  * page where the bridge has not been installed yet, keeps working.
  */
 
+import { isVerifySession } from "../components/dialogs/verify";
+import { matchesFilter, orderedInstances } from "../components/sidebar/ordering";
+import type { Instance } from "../api/types";
 import { sessionLabel } from "./sessionLabel";
 import { useUi } from "../state/store";
 
@@ -65,10 +68,46 @@ export function windowName(title: string): string {
   return sessionLabel(inst.display_title || inst.title || raw, inst.branch || "").text || raw;
 }
 
+/** The session's SLOT NUMBER in the sidebar — "1"…"9", or "" when the row
+ * shows none (tenth row onward, or not currently listed).
+ *
+ * The rail's numbers are how people locate a window ("[3] finished" → glance
+ * at row 3), so a notification carrying one must show THE number the rail
+ * shows right now. That number is client state — the drag order plus the live
+ * filter — so it is derived here, at render time, exactly the way the rail
+ * derives its rows: verify sessions excluded, the saved order applied, the
+ * filter applied. One deliberate divergence: on a tailnet with device groups
+ * the rail numbers grouped rows in section order and skips collapsed groups;
+ * this resolver lists local rows first and cannot see collapse state, so a
+ * remote session's number can drift from its row there. Local sessions — the
+ * ones this machine's events are about — always match.
+ */
+export function slotNumber(title: string): string {
+  const raw = String(title || "");
+  if (!raw) return "";
+  try {
+    const ui = useUi.getState();
+    const listed = (snapshot() as Instance[]).filter(
+      (i) => i && !isVerifySession(String(i.title || ""))
+    );
+    const { rows } = orderedInstances(listed, ui.order);
+    const filtered = rows.filter((i) => matchesFilter(i, ui.filter, ui.aliases));
+    const local = filtered.filter((i) => !(i as { device?: string }).device);
+    const remote = filtered.filter((i) => (i as { device?: string }).device);
+    const idx = [...local, ...remote].findIndex(
+      (i) => i.title === raw || (i as { display_title?: string }).display_title === raw
+    );
+    return idx >= 0 && idx < 9 ? String(idx + 1) : "";
+  } catch {
+    return "";
+  }
+}
+
 /** Publish on the extension API, next to `mf.toast`. `core/events.js` creates
  * `window.mindflock` before the bundle runs, so this only ever adds a key. */
 export function publishWindowName() {
   const w = globalThis as unknown as { mindflock?: Record<string, unknown> };
   w.mindflock = w.mindflock || {};
   w.mindflock.displayName = windowName;
+  w.mindflock.slotNumber = slotNumber;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for the ticket-ingestion-pipeline test suite."""
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -182,14 +183,45 @@ def _isolate_git_config(_isolated_gitconfig_path, monkeypatch):
     function of each test's own repo. A test that needs different global config
     (e.g. ``test_git_ops`` probing origin state) still overrides these via its own
     ``monkeypatch.setenv`` in the test body — which runs after this fixture.
+
+    Config does not only arrive in FILES. ``git -c k=v`` re-exports its options
+    to every child process as ``GIT_CONFIG_PARAMETERS``, and
+    ``GIT_CONFIG_COUNT``/``KEY_n``/``VALUE_n`` inject config the same way — so a
+    suite launched from inside any git process (a hook, a ``!`` alias, a wrapper)
+    silently inherits that repo's overrides no matter what the file variables
+    say. That hole has bitten once already: an inherited
+    ``safe.bareRepository=explicit`` makes every ``git -C <bare repo>`` in the
+    suite fail, which surfaced as five provisioning tests reporting that a push
+    never reached its (bare) test forge.
     """
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(_isolated_gitconfig_path))
     monkeypatch.setenv("GIT_CONFIG_SYSTEM", "/dev/null")
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     # A stray process/shell must not be able to redirect these subprocesses at the
-    # repo or index level either.
-    for _var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_CONFIG"):
+    # repo, index, object-store or ref-namespace level either — nor inject config
+    # through the environment, which bypasses the file variables set above.
+    for _var in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_CONFIG",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_NAMESPACE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_QUARANTINE_PATH",
+        "GIT_TEMPLATE_DIR",
+    ):
         monkeypatch.delenv(_var, raising=False)
+    # GIT_CONFIG_COUNT=n is read together with GIT_CONFIG_KEY_i/VALUE_i; dropping
+    # the count alone disarms the pairs, but they are cheap to clear too.
+    _count = os.environ.get("GIT_CONFIG_COUNT", "")
+    monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
+    if _count.isdigit():
+        for _i in range(int(_count)):
+            monkeypatch.delenv("GIT_CONFIG_KEY_{}".format(_i), raising=False)
+            monkeypatch.delenv("GIT_CONFIG_VALUE_{}".format(_i), raising=False)
 
 
 def _real_repo_worktree_paths():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,14 @@ def _redirect_tempfiles(tmp_path, monkeypatch):
     monkeypatch.setenv(
         "MINDFLOCK_TEST_PLANS_FILE", str(tmp_path / "mindflock" / "test_plans.json")
     )
+    # The autopilot store, for the same reason as the rest: server code that
+    # consults _autopilot.get() (the turn-end announcement gate does) must read
+    # an empty per-test store, never the developer's live ~/.mindflock/
+    # autopilot.json — a real armed run on this machine would silently gate a
+    # test's events. Tests that fake their own store re-set this themselves.
+    monkeypatch.setenv(
+        "MINDFLOCK_AUTOPILOT_FILE", str(tmp_path / "mindflock" / "autopilot.json")
+    )
     # Neutralize the web auth gate's enable signals so the suite never depends on
     # the ambient shell. auth.auth_enabled() turns on when CS_WEB_MODE is a
     # non-local mode (a dev shell often exports CS_WEB_MODE=tailscale), when an

--- a/tests/unit/test_activity_markers.py
+++ b/tests/unit/test_activity_markers.py
@@ -134,6 +134,72 @@ def test_hook_command_record_thread_false_skips_thread_marker(marker_dir, thread
     assert thread_markers.read("sess_b") == ""
 
 
+def test_hook_command_never_bakes_the_passed_marker_dir(tmp_path):
+    """THE SANDBOX-POISONING REGRESSION.
+
+    An install-time marker dir baked into the command was a live incident: a
+    sandboxed run (HOME redirected into a scratchpad) re-pinned a SHARED
+    repo's hooks file with its sandbox's absolute path, and every cohabiting
+    session's markers silently routed into a dead sandbox — chips frozen on
+    the last pre-poison reading. ``marker_dir`` is now accepted and IGNORED;
+    the emitted command must never contain the passed path.
+    """
+    poisoned = str(tmp_path / "verify-sandbox" / "markers")
+    for cmd in (
+        am.hook_command("working", poisoned),
+        am.hook_command("idle", poisoned, record_thread=False),
+        am.notification_hook_command(poisoned),
+    ):
+        assert poisoned not in cmd, "an install-time path must never be baked in"
+    # And the new default (marker_dir=None) is a valid command, not a
+    # TypeError or a literal 'None' path component.
+    cmd = am.hook_command("working")
+    assert "None" not in cmd
+    assert shlex.split(cmd)[0] == "python3"
+
+
+def test_hook_command_resolves_marker_dir_in_the_firing_env(marker_dir, tmp_path):
+    # The dir comes from the FIRING shell's environment, not the installer's:
+    # this process (the installer) points at `marker_dir`, the firing shell
+    # points elsewhere, and the marker must land in the firing shell's world.
+    cmd = am.hook_command("working", record_thread=False)
+    fire_dir = tmp_path / "firing-world"
+    subprocess.run(
+        ["sh", "-c", cmd],
+        input=b"{}",
+        check=True,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "MINDFLOCK_SESSION_NAME": "sess_fire",
+            "MINDFLOCK_ACTIVITY_MARKER_DIR": str(fire_dir),
+        },
+    )
+    obj = json.loads((fire_dir / "sess_fire.json").read_text(encoding="utf-8"))
+    assert obj["state"] == "working"
+    # Nothing leaked into the installer's own (fixture) dir.
+    assert am.read_activity_marker("sess_fire") is None
+
+
+def test_hook_command_falls_back_to_the_firing_homes_default(marker_dir, tmp_path):
+    # With no env override in the firing shell, the marker lands under the
+    # firing process's OWN home — a sandboxed CLI writes into its sandbox, a
+    # real one into the real home, whoever installed the hooks last.
+    cmd = am.hook_command("idle", record_thread=False)
+    home = tmp_path / "other-home"
+    subprocess.run(
+        ["sh", "-c", cmd],
+        input=b"{}",
+        check=True,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(home),
+            "MINDFLOCK_SESSION_NAME": "sess_home",
+        },
+    )
+    p = home / ".mindflock-assistant" / ".activity-markers" / "sess_home.json"
+    assert json.loads(p.read_text(encoding="utf-8"))["state"] == "idle"
+
+
 # --------------------------------------------------------------------------- #
 # merge_activity_hooks: the shared settings-file merge
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_activity_resize.py
+++ b/tests/unit/test_activity_resize.py
@@ -12,6 +12,11 @@ from backend.web import server
 
 
 class _FakeProvider:
+    # A CLI that says nothing about itself: these tests are the pure pane path,
+    # and it is the only path allowed to arm a turn end for such a CLI.
+    def reports_activity(self):
+        return False
+
     def activity_state(self, name):
         return None
 

--- a/tests/unit/test_cursor_window.py
+++ b/tests/unit/test_cursor_window.py
@@ -858,6 +858,9 @@ class _MarkedProvider:
     def __init__(self, state, age):
         self.state, self.age = state, age
 
+    def reports_activity(self):
+        return True
+
     def activity_state(self, name):
         return self.state
 

--- a/tests/unit/test_dev_toast_identity.py
+++ b/tests/unit/test_dev_toast_identity.py
@@ -15,7 +15,13 @@ work as a launcher rather than a decoy.
 
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
+
+import pytest
 
 _MAIN_JS = Path(__file__).resolve().parents[2] / "electron" / "main.js"
 
@@ -88,7 +94,10 @@ def test_a_png_icon_override_does_not_become_a_broken_shortcut():
     is used verbatim only when it is an .ico, and otherwise falls back."""
     fn = _fn(_js())
     assert "endsWith('.ico')" in fn
-    assert "? DEV_ICON : process.execPath" in fn
+    # A non-.ico override is discarded before staging, and the `|| ...` on the
+    # next line is what turns that into the exe's icon.
+    assert "? DEV_ICON : null" in fn
+    assert "|| process.execPath" in fn
 
 
 def test_a_drifted_shortcut_is_rewritten_whichever_field_moved():
@@ -111,3 +120,113 @@ def test_it_runs_where_its_own_log_line_is_readable():
     ready = ready[: ready.index("startUpdateChecks()")]
     assert "ensureDevToastName()" in ready
     assert ready.index("logger.init") < ready.index("ensureDevToastName()")
+
+
+# --------------------------------------------------------------------------- #
+# …and the icon Windows draws beside that name
+# --------------------------------------------------------------------------- #
+# The name landed and the icon did not: the toast came up headed "MindFlock-dev"
+# with the generic white document tile beside it. `IconLocation` is resolved by
+# the SHELL, not by us, and on the supported Windows shape it pointed into the
+# WSL share the checkout lives on (`\\wsl.localhost\...`), which the shell's icon
+# extraction does not read. Nothing was wrong with dev-icon.ico — the window and
+# taskbar icons load that same file through Electron and always rendered.
+def _stage_fn(js: str) -> str:
+    fn = js[js.index("function stageShortcutIcon") :]
+    return fn[: fn.index("\n}\n")]
+
+
+def test_a_unc_icon_is_copied_somewhere_the_shell_can_read():
+    """The whole fix: a share path is staged onto the local disk first."""
+    fn = _stage_fn(_js())
+    assert "startsWith('\\\\\\\\')" in fn, "the UNC test itself"
+    assert (
+        "app.getPath('userData')" in fn
+    ), "staged into the dev profile, which is local"
+    assert "dev-icon.ico" in fn
+
+
+def test_a_local_icon_is_used_where_it_lies():
+    """The copy is a workaround for the share, not an improvement — a normal
+    Windows checkout must keep pointing at its own file, so that a user editing
+    MINDFLOCK_DEV_ICON is not shadowed by a stale duplicate."""
+    fn = _stage_fn(_js())
+    assert "return src" in fn
+
+
+def test_a_changed_icon_is_restaged_and_an_unchanged_one_is_not():
+    """Byte-compared, so an override that changes is picked up and one that has
+    not costs a read instead of a write on every dev launch."""
+    fn = _stage_fn(_js())
+    assert ".equals(from)" in fn
+    assert "writeFileSync(dst" in fn
+
+
+def test_a_failed_stage_falls_back_to_the_exe_icon():
+    """Returning a path the shell cannot read is what produced the blank tile in
+    the first place; the exe's own icon is wrong but visible."""
+    fn = _stage_fn(_js())
+    assert "return null" in fn
+    # …and the caller has to actually honour that null.
+    assert "(ico && stageShortcutIcon(ico)) || process.execPath" in _fn(_js())
+
+
+def test_the_staged_path_is_what_the_shortcut_is_compared_against():
+    """Staleness is checked on `icon`, so the shortcut already on disk — which
+    carries the old UNC path — is rewritten on the next dev run rather than
+    needing to be deleted by hand."""
+    fn = _fn(_js())
+    assert "have.icon === want.icon" in fn
+
+
+def test_the_path_logic_actually_holds_when_run():
+    """The one assertion in this file that is not a string match.
+
+    Everything above pins the *wiring*, which is all a Linux CI can normally see
+    of a Windows shortcut. But the bug this function exists to fix was a path
+    bug — the difference between a share path and a local one — and a structural
+    test cannot tell a correct UNC check from an inverted one. ``stage
+    ShortcutIcon`` touches nothing but ``fs``/``path`` and ``app.getPath``, so it
+    can be lifted out of main.js and run for real against stubs.
+    """
+    node = shutil.which("node")
+    if node is None:  # a checkout without the electron toolchain
+        pytest.skip("node is not installed")
+    harness = r"""
+const fs=require('fs'),path=require('path'),os=require('os');
+const src=fs.readFileSync(process.argv[2],'utf8');
+const body=src.slice(src.indexOf('function stageShortcutIcon'));
+const fn=body.slice(0,body.indexOf('\n}\n')+3);
+const dir=fs.mkdtempSync(path.join(os.tmpdir(),'ico-'));
+const app={getPath:()=>dir};
+const stage=new Function('fs','path','app','console',fn+'; return stageShortcutIcon')(fs,path,app,console);
+const out={};
+const local=path.join(dir,'src.ico'); fs.writeFileSync(local,Buffer.from('V1'));
+out.local_passthrough = stage(local)===local;
+out.missing_is_null   = stage(path.join(dir,'nope.ico'))===null;
+out.null_is_null      = stage(null)===null;
+const unc='\\\\wsl.localhost\\Ubuntu\\home\\u\\app\\electron\\dev-icon.ico';
+const rE=fs.existsSync, rR=fs.readFileSync; let content=Buffer.from('V1');
+fs.existsSync=(p)=>p===unc?true:rE(p);
+fs.readFileSync=(p,...r)=>p===unc?content:rR(p,...r);
+const a=stage(unc);
+out.unc_is_staged_locally = !!a && a!==unc && !a.startsWith('\\\\');
+out.staged_bytes_match    = rR(a).equals(content);
+const m=fs.statSync(a).mtimeMs; const b=stage(unc);
+out.unchanged_not_rewritten = b===a && fs.statSync(b).mtimeMs===m;
+content=Buffer.from('V2-CHANGED');
+out.changed_is_restaged = rR(stage(unc)).equals(content);
+console.log(JSON.stringify(out));
+"""
+    with tempfile.TemporaryDirectory() as td:
+        hp = Path(td) / "h.js"
+        hp.write_text(harness, encoding="utf-8")
+        cp = subprocess.run(
+            [node, str(hp), str(_MAIN_JS)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    assert cp.returncode == 0, cp.stderr
+    got = json.loads(cp.stdout.strip().splitlines()[-1])
+    assert all(got.values()), got

--- a/tests/unit/test_intake_surface.py
+++ b/tests/unit/test_intake_surface.py
@@ -793,6 +793,82 @@ def test_every_configured_source_gets_a_label_even_when_it_fails(monkeypatch):
     assert [e["source"] for e in out["errors"]] == ["linear"]
 
 
+def test_a_shortcut_source_of_only_archived_stories_still_gets_a_heading(monkeypatch):
+    """The Shortcut adapter hides archived work, so a source whose every story
+    is archived is a *successful* listing that returns nothing — the panel must
+    show it as an empty heading, not drop it. A vanished source reads as "not
+    configured" rather than "nothing to do", and an all-archived source is
+    exactly the case the archive filter creates."""
+    from backend.ticket_ingestion.config import TicketProviderConfig
+    from backend.ticket_ingestion.providers.shortcut import ShortcutProvider
+    from backend.web.core import ticket_start
+
+    src = types.SimpleNamespace(
+        id="shortcut", provider="shortcut", label="", repo_url="", member_id="m"
+    )
+    cfg = types.SimpleNamespace(ticketing_sources=[src], repo_url="")
+    monkeypatch.setattr(ticket_start, "_load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "backend.ticket_ingestion.providers.get_provider",
+        lambda _s: ShortcutProvider(
+            TicketProviderConfig(provider="shortcut", api_token="t", member_id="m")
+        ),
+    )
+
+    class _Resp:
+        """One canned aiohttp response, used as an async context manager."""
+
+        def __init__(self, payload):
+            self.status = 200
+            self._payload = payload
+
+        async def json(self):
+            return self._payload
+
+        async def text(self):
+            return ""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+    class _Session:
+        """Every story archived; /workflows and /members answer empty."""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        def post(self, _url, **_kw):
+            return _Resp([{"id": 1, "name": "shipped last quarter", "archived": True}])
+
+        def get(self, _url, **_kw):
+            return _Resp([])
+
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *a, **k: _Session())
+    monkeypatch.setattr(
+        "backend.ticket_ingestion.state.load_processed_story_statuses", lambda _r: {}
+    )
+    monkeypatch.setattr(
+        "backend.ticket_ingestion.state.load_processed_story_failures", lambda _r: {}
+    )
+    monkeypatch.setattr(
+        "backend.ticket_ingestion.state.load_pending_stories", lambda _r: []
+    )
+
+    out = _run(ticket_start.list_assigned_tickets())
+    assert out["tickets"] == []
+    # Empty, not broken: no error row, and the heading is still there under the
+    # provider's own label (the source left its label blank).
+    assert out["errors"] == []
+    assert out["sources"] == ["shortcut"]
+    assert out["source_labels"]["shortcut"] == "Shortcut"
+
+
 # --------------------------------------------------------------------------- #
 # The Intake dialog itself (asserted on the built bundle, like the other frontend
 # contracts in this suite)

--- a/tests/unit/test_limit_after_stop_hook.py
+++ b/tests/unit/test_limit_after_stop_hook.py
@@ -38,6 +38,9 @@ _CLEAN = "> summarise the diff\n\nDone — the diff touches three files.\n\n> \n
 class _StopHookProvider:
     """A CLI that reports idle through its own hook marker (Claude Code)."""
 
+    def reports_activity(self):
+        return True
+
     def activity_state(self, name):
         return "idle"
 

--- a/tests/unit/test_prompt_queue.py
+++ b/tests/unit/test_prompt_queue.py
@@ -453,6 +453,70 @@ def test_drain_sends_when_idle(drain, monkeypatch):
     assert pq.list_queue("d1") == []
 
 
+def test_drain_sends_sooner_on_an_authoritative_idle(drain, monkeypatch):
+    """The settle is TIERED by the reading's source: an idle the CLI reported
+    itself (a Stop-hook marker) is not a flicker candidate, so the next queued
+    prompt goes out on the fast tier — one drain pass sooner — while a
+    pane-derived idle keeps the full guard below."""
+    import time as _t
+
+    from backend.web.core import agent_state
+
+    server, sent = drain
+    server._QUEUE_STATE.pop("d1", None)
+    clock = {"now": 1_000_000.0}
+    monkeypatch.setattr(_t, "time", lambda: clock["now"])
+    monkeypatch.setattr(server, "_agent_activity", lambda i, t: "idle")
+    agent_state._ACTIVITY_CACHE["d1"] = {
+        "created": 1.0,
+        "reported": "idle",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("idle", "marker"),
+    }
+    try:
+        pq.enqueue("d1", "task one")
+        server._drain_one_queue("d1")  # first idle tick: arm the dwell timer
+        assert sent == []
+        clock["now"] += server._QUEUE_IDLE_SETTLE_MARKER + 1
+        server._drain_one_queue("d1")
+        assert sent == ["task one"], "marker-sourced idle takes the fast tier"
+    finally:
+        agent_state._ACTIVITY_CACHE.pop("d1", None)
+
+
+def test_drain_keeps_the_full_settle_for_a_pane_idle(drain, monkeypatch):
+    # The pane can misread a quiet moment mid-turn, and typing into a live
+    # turn is the one failure this dwell exists to prevent.
+    import time as _t
+
+    from backend.web.core import agent_state
+
+    server, sent = drain
+    server._QUEUE_STATE.pop("d1", None)
+    clock = {"now": 1_000_000.0}
+    monkeypatch.setattr(_t, "time", lambda: clock["now"])
+    monkeypatch.setattr(server, "_agent_activity", lambda i, t: "idle")
+    agent_state._ACTIVITY_CACHE["d1"] = {
+        "created": 1.0,
+        "reported": "idle",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("idle", "pane"),
+    }
+    try:
+        pq.enqueue("d1", "task one")
+        server._drain_one_queue("d1")
+        clock["now"] += server._QUEUE_IDLE_SETTLE_MARKER + 1
+        server._drain_one_queue("d1")
+        assert sent == [], "pane-sourced idle must wait out the full settle"
+        clock["now"] += server._QUEUE_IDLE_SETTLE
+        server._drain_one_queue("d1")
+        assert sent == ["task one"]
+    finally:
+        agent_state._ACTIVITY_CACHE.pop("d1", None)
+
+
 def test_drain_waits_for_idle_to_settle(drain, monkeypatch):
     """A fresh idle must PERSIST for _QUEUE_IDLE_SETTLE before the first send, so a
     transient Stop between turns can't fire a queued prompt prematurely."""

--- a/tests/unit/test_provider_activity_patterns.py
+++ b/tests/unit/test_provider_activity_patterns.py
@@ -10,6 +10,7 @@ import re
 
 from backend import providers
 from backend.providers.base import LaunchContext
+from backend.providers.config import BUILTIN_CONFIGS
 
 # provider -> (a working-state pane, a paused-for-the-human pane)
 PANES = {
@@ -80,6 +81,87 @@ def test_antigravity_clarifying_question_is_waiting():
     assert any(
         re.search(pat, ANTIGRAVITY_QUESTION_PANE) for pat in p.waiting_prompt_patterns()
     ), "antigravity clarifying-question menu not detected as waiting"
+
+
+def _bundled(name):
+    """The BUNDLED provider under ``name`` — built from BUILTIN_CONFIGS
+    directly, never through providers.resolve(): the registry is populated at
+    import time from the developer's own ~/.mindflock-assistant/providers/
+    TOMLs, and a user TOML overriding a bundled name (a codex.toml tweaking
+    launch flags, say) would flip these roster assertions per-machine while CI
+    stays green."""
+    from backend.providers import _CONFIG_PROVIDER_CLASSES, GenericProvider
+    from backend.providers.claude import ClaudeProvider
+
+    if name == "claude":
+        return ClaudeProvider()
+    cfg = next(c for c in BUILTIN_CONFIGS if c.name == name)
+    cls = _CONFIG_PROVIDER_CLASSES.get(cfg.name, GenericProvider)
+    return cls(cfg)
+
+
+def test_every_bundled_provider_can_arm_a_turn_end():
+    """Every CLI here can still say "the agent has finished" — and by which
+    route.
+
+    Since a ``working`` reading alone stopped being enough to announce a turn
+    (agent_state._verdict's ``arms``), a provider needs at least one signal that
+    CORROBORATES work: its own hook report, or a status-line pattern that
+    matches a real working pane. A provider with neither is not broken — it
+    falls back to a sustained-CPU backstop — but it is the weakest rung, and
+    nothing bundled should land there by accident.
+    """
+    for name, (working, _waiting) in PANES.items():
+        p = _bundled(name)
+        on_pane = any(re.search(pat, working) for pat in p.working_pane_patterns())
+        assert p.reports_activity() or on_pane, (
+            f"{name} can no longer corroborate work: no hook report and its "
+            f"status-line patterns miss a real working pane"
+        )
+    # claude is not in PANES (it is exercised all over the activity tests); pin
+    # it here anyway, since it is the CLI the arming rule was written against.
+    claude = _bundled("claude")
+    assert claude.reports_activity()
+    assert any(
+        re.search(pat, "\u283b Thinking… (esc to interrupt)")
+        for pat in claude.working_pane_patterns()
+    )
+
+
+def test_only_hook_reporting_clis_skip_the_cpu_backstop():
+    # The two halves of the ladder, as a roster. A CLI that reports for itself
+    # has two independent signals and needs no CPU backstop — and must not have
+    # one, because a CPU spike on a PARKED session of exactly this kind is what
+    # announced a turn that never happened. Everyone else keeps the backstop.
+    #
+    # BUNDLED providers only, built hermetically (see _bundled): both
+    # all_providers() AND resolve() read the live registry, which user TOMLs
+    # feed — a test reading the developer's own config passes or fails by
+    # accident.
+    bundled = {"claude"} | {c.name for c in BUILTIN_CONFIGS}
+    reporting = {n for n in bundled if _bundled(n).reports_activity()}
+    assert reporting == {"claude", "codex"}
+
+
+def test_reports_activity_is_a_capability_with_a_conservative_default():
+    # reports_activity() answers CAPABILITY ("can this CLI speak for itself?"),
+    # not the moment-to-moment activity_state(...) — the web layer keys the
+    # turn-end arming rules off it, so the default must be the weakest claim.
+    from dataclasses import replace
+
+    from backend.providers import GenericProvider
+    from backend.providers.base import BaseProvider
+    from backend.providers.claude import ClaudeProvider
+
+    assert BaseProvider().reports_activity() is False, "default: no self-report"
+    assert ClaudeProvider().reports_activity() is True
+    # For a generic CLI the declared hooks file IS the capability: with it the
+    # CLI writes markers, without it pane inspection is all there is.
+    codex_cfg = next(c for c in BUILTIN_CONFIGS if c.name == "codex")
+    assert codex_cfg.activity_hooks_file
+    assert GenericProvider(codex_cfg).reports_activity() is True
+    hookless = replace(codex_cfg, activity_hooks_file="")
+    assert GenericProvider(hookless).reports_activity() is False
 
 
 def test_no_false_positives_on_idle_prompts():

--- a/tests/unit/test_provision_generalization.py
+++ b/tests/unit/test_provision_generalization.py
@@ -1168,9 +1168,18 @@ _FORGE_URL = "git@forge.invalid:Org/app.git"
 
 
 def _branches(repo) -> list:
-    """Local branch names in ``repo`` (works on a bare repo too)."""
-    out = _git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads").stdout
-    return [b for b in out.splitlines() if b]
+    """Local branch names in ``repo`` (works on a bare repo too).
+
+    A failed ``git`` is raised, not swallowed: this helper reads a BARE repo, and
+    anything that makes git refuse one (a leaked ``GIT_DIR``, a vanished path)
+    would otherwise return ``[]`` and be reported as "the branch never reached
+    the forge" — sending the reader after a push bug that isn't there.
+    """
+    cp = _git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+    assert cp.returncode == 0, "git for-each-ref failed in {}: {}{}".format(
+        repo, cp.stdout, cp.stderr
+    )
+    return [b for b in cp.stdout.splitlines() if b]
 
 
 @pytest.fixture

--- a/tests/unit/test_resume_threads.py
+++ b/tests/unit/test_resume_threads.py
@@ -160,12 +160,20 @@ def test_claude_hook_persists_session_id(tmp_path, monkeypatch):
         env={
             "MINDFLOCK_SESSION_NAME": "mindflock_hooked",
             "PATH": "/usr/bin:/bin",
-            "MINDFLOCK_THREAD_MARKER_DIR": str(tmp_path / "threads_ignored"),
+            "MINDFLOCK_THREAD_MARKER_DIR": str(tmp_path / "threads_own_env"),
         },
     )
-    # The hook bakes the thread dir at INSTALL time (this process's env), so it
-    # wrote into the autouse fixture's dir regardless of the subprocess env.
-    assert thread_markers.read("mindflock_hooked") == "dead-beef-0001"
+    # The hook resolves the thread dir at FIRE time, from ITS OWN environment —
+    # never from the env of whoever installed it. Baking the installer's path
+    # was a live incident: a sandboxed Verify run (HOME redirected into a
+    # scratchpad) re-pinned a SHARED repo's hooks file with its sandbox path,
+    # and every cohabiting session's markers silently vanished into /tmp —
+    # chips frozen on the last pre-poison reading.
+    assert (tmp_path / "threads_own_env" / "mindflock_hooked.thread").read_text() == (
+        "dead-beef-0001"
+    )
+    # And nothing leaked into this process's own (autouse-fixture) dir.
+    assert not thread_markers.read("mindflock_hooked")
 
 
 def test_codex_discovery_binds_by_cwd_and_launch_time(tmp_path, monkeypatch):

--- a/tests/unit/test_terminal_extras.py
+++ b/tests/unit/test_terminal_extras.py
@@ -361,6 +361,62 @@ async def test_pump_pty_forwards_output_and_input(monkeypatch):
     os.close(r)
 
 
+async def test_pump_pty_on_input_fires_for_input_and_never_for_resize(monkeypatch):
+    # The presence callback: keystrokes (bytes and text alike) count, resize
+    # control frames never do (they fire on layout changes with nobody at the
+    # keyboard), and a read-only pump never calls it at all. A raising
+    # callback must not break the pump.
+    r, w = os.pipe()
+    os.close(w)
+    monkeypatch.setattr(terminal.os, "write", lambda fd, data: None)
+    proc = _FakeProc(r)
+    hits = []
+    frames = [
+        {"type": "websocket.receive", "bytes": b"typed"},
+        {
+            "type": "websocket.receive",
+            "text": json.dumps({"type": "resize", "rows": 30, "cols": 100}),
+        },
+        {"type": "websocket.receive", "text": "plain"},
+    ]
+    await terminal.pump_pty(
+        _FakeWS(list(frames), []),
+        proc,
+        allow_input=True,
+        on_input=lambda: hits.append(1),
+    )
+    assert len(hits) == 2, "bytes + plain text fire; the resize frame does not"
+    os.close(r)
+
+    r2, w2 = os.pipe()
+    os.close(w2)
+    proc2 = _FakeProc(r2)
+    await terminal.pump_pty(
+        _FakeWS(list(frames), []),
+        proc2,
+        allow_input=False,
+        on_input=lambda: hits.append(1),
+    )
+    assert len(hits) == 2, "a read-only pump never reports presence"
+    os.close(r2)
+
+    r3, w3 = os.pipe()
+    os.close(w3)
+    proc3 = _FakeProc(r3)
+
+    def _boom():
+        raise RuntimeError("presence stamp failed")
+
+    await terminal.pump_pty(
+        _FakeWS([{"type": "websocket.receive", "bytes": b"x"}], []),
+        proc3,
+        allow_input=True,
+        on_input=_boom,
+    )
+    assert proc3.terminated, "a raising callback never breaks the pump"
+    os.close(r3)
+
+
 async def test_pump_pty_read_only_drops_input(monkeypatch):
     r, w = os.pipe()
     os.close(w)  # immediate EOF; no output needed for this case

--- a/tests/unit/test_ticket_providers.py
+++ b/tests/unit/test_ticket_providers.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import aiohttp
 import pytest
 
 from backend.ticket_ingestion.config import TicketProviderConfig
@@ -30,6 +31,7 @@ from backend.ticket_ingestion.providers.github_issues import GithubIssuesProvide
 from backend.ticket_ingestion.providers.jira import JiraProvider, flatten_adf
 from backend.ticket_ingestion.providers.linear import LinearProvider
 from backend.ticket_ingestion.providers.shortcut import (
+    _SHORTCUT_API_BASE,
     ShortcutProvider,
     story_from_api_response,
 )
@@ -415,6 +417,15 @@ class _FakeSession:
         return self._post.pop(0)
 
 
+class _ExplodingSession(_FakeSession):
+    """A session whose GET raises, for the best-effort lookups that must
+    degrade rather than propagate (the non-200 path has its own branch)."""
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        raise aiohttp.ClientError("connection reset")
+
+
 def _patch_session(session):
     """Patch aiohttp.ClientSession so ``async with aiohttp.ClientSession()``
     yields ``session``."""
@@ -422,6 +433,7 @@ def _patch_session(session):
 
 
 _SINCE = datetime(2025, 1, 1, tzinfo=timezone.utc)
+_SHORTCUT_LOGGER = "backend.ticket_ingestion.providers.shortcut"
 
 
 # --------------------------------------------------------------------------- #
@@ -540,13 +552,359 @@ class TestShortcutSearchStories:
             assert await prov._search_stories({}) == []
 
     async def test_error_status_raises_client_error(self):
-        import aiohttp
-
         prov = self._prov()
         session = _FakeSession(post_responses=[_FakeResp(500, text_data="boom")])
         with _patch_session(session):
             with pytest.raises(aiohttp.ClientError, match="500"):
                 await prov._search_stories({})
+
+
+class TestShortcutArchived:
+    """Archived work is invisible in Shortcut, so it must be invisible here.
+
+    Both halves of the rule: the story's own ``archived`` flag, and the epic's
+    — archiving an epic hides its stories on the board without flagging any of
+    them."""
+
+    def _prov(self, **cfg):
+        base = dict(provider="shortcut", api_token="t", member_id="m")
+        base.update(cfg)
+        return ShortcutProvider(TicketProviderConfig(**base))
+
+    # ----------------------------------------------------------------- #
+    # The story's own flag
+    # ----------------------------------------------------------------- #
+    async def test_search_drops_archived_stories(self):
+        prov = self._prov()
+        session = _FakeSession(
+            post_responses=[
+                _FakeResp(
+                    200,
+                    json_data=[
+                        {"id": 1},
+                        {"id": 2, "archived": True},
+                        {"id": 3, "archived": False},
+                    ],
+                )
+            ]
+        )
+        with _patch_session(session):
+            out = await prov._search_stories({"owner_id": "m"})
+        # Story 2 is gone; a missing flag (story 1) reads as live.
+        assert [s["id"] for s in out] == [1, 3]
+
+    async def test_search_keeps_non_dict_rows(self):
+        # The filter's isinstance guard is deliberate: a row that isn't a story
+        # object carries no flag to judge, and the callers already skip it.
+        prov = self._prov()
+        session = _FakeSession(post_responses=[_FakeResp(200, json_data=["junk", 5])])
+        with _patch_session(session):
+            assert await prov._search_stories({}) == ["junk", 5]
+
+    # ----------------------------------------------------------------- #
+    # The epic's flag
+    # ----------------------------------------------------------------- #
+    async def test_archived_epic_ids_selects_archived_epics_with_an_id(self):
+        prov = self._prov()
+        session = _FakeSession(
+            get_responses=[
+                _FakeResp(
+                    200,
+                    json_data=[
+                        {"id": 10, "archived": True},
+                        {"id": 11, "archived": False},
+                        {"id": 12},  # missing flag reads as live
+                        {"archived": True},  # archived but unusable — no id
+                        "junk",
+                    ],
+                )
+            ]
+        )
+        with _patch_session(session):
+            assert await prov._archived_epic_ids() == {10}
+
+    async def test_archived_epic_ids_non_list_body_is_empty(self):
+        prov = self._prov()
+        session = _FakeSession(get_responses=[_FakeResp(200, json_data={"epics": []})])
+        with _patch_session(session):
+            assert await prov._archived_epic_ids() == set()
+
+    async def test_archived_epic_ids_http_error_is_empty(self):
+        prov = self._prov()
+        session = _FakeSession(get_responses=[_FakeResp(500, text_data="boom")])
+        with _patch_session(session):
+            assert await prov._archived_epic_ids() == set()
+
+    async def test_archived_epic_ids_network_failure_is_empty_and_warns(self, caplog):
+        # The empty set fails open, so the log line is the only trace that the
+        # filter was skipped at all — without it the degradation is silent.
+        prov = self._prov()
+        caplog.set_level(logging.WARNING, logger=_SHORTCUT_LOGGER)
+        with _patch_session(_ExplodingSession()):
+            assert await prov._archived_epic_ids() == set()
+        assert "Could not resolve archived Shortcut epics" in caplog.text
+
+    async def test_epics_request_is_slim_and_authenticated(self):
+        # A refactor that drops the token would get 401 -> empty set -> a filter
+        # that fails open and never complains, so pin the request itself.
+        prov = self._prov()
+        session = _FakeSession(get_responses=[_FakeResp(200, json_data=[])])
+        with _patch_session(session):
+            await prov._archived_epic_ids()
+        url, kwargs = session.get_calls[0]
+        assert url == f"{_SHORTCUT_API_BASE}/epics?includes_description=false"
+        assert kwargs["headers"] == {"Shortcut-Token": "t"}
+
+    async def test_stories_under_an_archived_epic_are_dropped(self):
+        prov = self._prov()
+        rows = [{"id": 1, "epic_id": 10}, {"id": 2, "epic_id": 11}, {"id": 3}]
+        session = _FakeSession(
+            get_responses=[
+                _FakeResp(
+                    200,
+                    json_data=[
+                        {"id": 10, "archived": True},
+                        {"id": 11, "archived": False},
+                    ],
+                )
+            ]
+        )
+        with _patch_session(session):
+            out = await prov._drop_archived_epic_stories(rows)
+        assert [r["id"] for r in out] == [2, 3]
+        assert len(session.get_calls) == 1
+        assert (
+            session.get_calls[0][0]
+            == f"{_SHORTCUT_API_BASE}/epics?includes_description=false"
+        )
+
+    async def test_no_archived_epics_leaves_the_rows_untouched(self):
+        prov = self._prov()
+        rows = [{"id": 1, "epic_id": 10}, {"id": 2, "epic_id": 11}]
+        session = _FakeSession(
+            get_responses=[_FakeResp(200, json_data=[{"id": 10, "archived": False}])]
+        )
+        with _patch_session(session):
+            out = await prov._drop_archived_epic_stories(rows)
+        assert out is rows
+
+    async def test_no_epic_ids_means_no_epics_call(self):
+        # The common case must not pay for a lookup it cannot use — and a falsy
+        # epic_id (0, null) is "no epic", not "epic zero".
+        prov = self._prov()
+        rows = [{"id": 1}, {"id": 2, "epic_id": 0}, {"id": 3, "epic_id": None}, "junk"]
+        session = _FakeSession()
+        with _patch_session(session):
+            out = await prov._drop_archived_epic_stories(rows)
+        assert out is rows
+        assert session.get_calls == []
+        assert session.post_calls == []
+
+    async def test_epics_lookup_failure_keeps_every_story(self):
+        # Best-effort: losing the filter must never lose the tickets. (The non-200
+        # branch returns before the warning — the logging is asserted on the
+        # network-failure variant above.)
+        prov = self._prov()
+        rows = [{"id": 1, "epic_id": 10}]
+        session = _FakeSession(get_responses=[_FakeResp(500, text_data="boom")])
+        with _patch_session(session):
+            assert await prov._drop_archived_epic_stories(rows) == rows
+
+    async def test_a_string_epic_id_does_not_match_an_int_epic(self):
+        # Shortcut sends ints on both sides, so this is theory only — pinned so
+        # that a payload change surfaces as a failing test rather than as a
+        # filter that quietly stops matching.
+        prov = self._prov()
+        rows = [{"id": 1, "epic_id": "10"}]
+        session = _FakeSession(
+            get_responses=[_FakeResp(200, json_data=[{"id": 10, "archived": True}])]
+        )
+        with _patch_session(session):
+            assert await prov._drop_archived_epic_stories(rows) == rows
+
+    # ----------------------------------------------------------------- #
+    # Wiring: both callers, both assignee scopes
+    # ----------------------------------------------------------------- #
+    def _rows(self):
+        return [
+            {"id": 1, "name": "live", "created_at": "2025-01-01T00:00:00Z"},
+            {
+                "id": 2,
+                "name": "under a finished epic",
+                "created_at": "2025-01-01T00:00:00Z",
+                "epic_id": 10,
+            },
+        ]
+
+    async def test_panel_listing_applies_the_epic_filter(self, monkeypatch):
+        prov = self._prov()
+        monkeypatch.setattr(prov, "_search_stories", lambda body: _acoro(self._rows()))
+        monkeypatch.setattr(prov, "list_states", lambda: _acoro([]))
+        monkeypatch.setattr(prov, "_member_names", lambda: _acoro({}))
+        monkeypatch.setattr(prov, "_archived_epic_ids", lambda: _acoro({10}))
+        out = await prov.search_assigned_all()
+        assert [t.id for t in out] == [1]
+
+    async def test_panel_any_assignee_listing_applies_the_epic_filter(
+        self, monkeypatch
+    ):
+        # The any-assignee branch builds its own de-duped list before filtering,
+        # so it needs its own proof.
+        prov = self._prov(assignee_scope="anyone", workflow_state="100")
+        monkeypatch.setattr(prov, "_search_stories", lambda body: _acoro(self._rows()))
+        monkeypatch.setattr(prov, "list_states", lambda: _acoro([]))
+        monkeypatch.setattr(prov, "_member_names", lambda: _acoro({}))
+        monkeypatch.setattr(prov, "_archived_epic_ids", lambda: _acoro({10}))
+        out = await prov.search_assigned_all()
+        assert [t.id for t in out] == [1]
+
+    async def test_ingest_poll_drops_archived_epics_before_hydration(self, monkeypatch):
+        # The panel is only half of it: the scanner must not start a story that
+        # was archived out from under it either — and the drop happens before
+        # hydration, so an archived-epic story costs no request at all.
+        prov = self._prov(workflow_state="100")
+        hydrated: list = []
+
+        async def fake_hydrate(session, sid):
+            hydrated.append(sid)
+            return {
+                "id": sid,
+                "name": f"full-{sid}",
+                "description": "d",
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+
+        monkeypatch.setattr(prov, "_search_stories", lambda body: _acoro(self._rows()))
+        monkeypatch.setattr(prov, "_hydrate_story", fake_hydrate)
+        monkeypatch.setattr(prov, "_archived_epic_ids", lambda: _acoro({10}))
+        with _patch_session(_FakeSession()):
+            out = await prov.search_assigned(_SINCE)
+        assert [t.id for t in out] == [1]
+        assert hydrated == [1]
+
+    async def test_any_assignee_poll_applies_the_epic_filter(self, monkeypatch):
+        prov = self._prov(assignee_scope="anyone", workflow_state="100")
+        monkeypatch.setattr(prov, "_search_stories", lambda body: _acoro(self._rows()))
+        monkeypatch.setattr(
+            prov,
+            "_hydrate_story",
+            lambda session, sid: _acoro({"id": sid, "name": "f"}),
+        )
+        monkeypatch.setattr(prov, "_archived_epic_ids", lambda: _acoro({10}))
+        with _patch_session(_FakeSession()):
+            out = await prov.search_assigned(_SINCE)
+        assert [t.id for t in out] == [1]
+
+    async def test_one_epics_call_per_poll_across_several_states(self, monkeypatch):
+        # The per-state fan-out is a loop of searches, but the epic lookup sits
+        # after the dedup — several ingest states must not multiply it.
+        prov = self._prov(workflow_state="100,200")
+
+        async def fake_search(body):
+            sid = body["workflow_state_id"]
+            return [
+                {
+                    "id": sid,
+                    "name": str(sid),
+                    "created_at": "2025-01-01T00:00:00Z",
+                    "epic_id": 10,
+                }
+            ]
+
+        monkeypatch.setattr(prov, "_search_stories", fake_search)
+        monkeypatch.setattr(
+            prov, "_hydrate_story", lambda session, s: _acoro({"id": s, "name": "f"})
+        )
+        session = _FakeSession(
+            get_responses=[_FakeResp(200, json_data=[{"id": 10, "archived": False}])]
+        )
+        with _patch_session(session):
+            out = await prov.search_assigned(_SINCE)
+        assert sorted(t.id for t in out) == [100, 200]
+        assert len(session.get_calls) == 1
+
+    async def test_both_filters_compose_over_the_real_http_path(self):
+        # No monkeypatched provider methods here: the real _search_stories and
+        # the real _archived_epic_ids run against scripted responses, so the
+        # wiring (search -> epic lookup -> filter) is exercised, not assumed.
+        prov = self._prov()
+        session = _FakeSession(
+            post_responses=[
+                _FakeResp(
+                    200,
+                    json_data=[
+                        {"id": 1, "name": "live"},
+                        {"id": 2, "name": "archived story", "archived": True},
+                        {"id": 3, "name": "under a finished epic", "epic_id": 10},
+                        {"id": 4, "name": "under a live epic", "epic_id": 11},
+                        "junk",  # non-dict rows survive both filters...
+                    ],
+                )
+            ],
+            get_responses=[
+                _FakeResp(
+                    200,
+                    json_data=[
+                        {"id": 10, "archived": True},
+                        {"id": 11, "archived": False},
+                    ],
+                ),
+                _FakeResp(200, json_data=[]),  # /workflows
+                _FakeResp(200, json_data=[]),  # /members
+            ],
+        )
+        with _patch_session(session):
+            out = await prov.search_assigned_all()
+        # ...and are skipped here, without raising.
+        assert [t.id for t in out] == [1, 4]
+        assert session.post_calls[0][0].endswith("/stories/search")
+        assert [url for url, _ in session.get_calls] == [
+            f"{_SHORTCUT_API_BASE}/epics?includes_description=false",
+            f"{_SHORTCUT_API_BASE}/workflows",
+            f"{_SHORTCUT_API_BASE}/members",
+        ]
+
+    async def test_a_story_with_no_epic_never_triggers_the_lookup_in_the_panel(self):
+        prov = self._prov()
+        session = _FakeSession(
+            post_responses=[_FakeResp(200, json_data=[{"id": 1, "name": "live"}])],
+            get_responses=[
+                _FakeResp(200, json_data=[]),  # /workflows
+                _FakeResp(200, json_data=[]),  # /members
+            ],
+        )
+        with _patch_session(session):
+            out = await prov.search_assigned_all()
+        assert [t.id for t in out] == [1]
+        assert [url for url, _ in session.get_calls] == [
+            f"{_SHORTCUT_API_BASE}/workflows",
+            f"{_SHORTCUT_API_BASE}/members",
+        ]
+
+    # ----------------------------------------------------------------- #
+    # The gap this change leaves open
+    # ----------------------------------------------------------------- #
+    async def test_fetch_by_id_still_returns_an_archived_story(self):
+        # Known and deliberate: the filters live in the two *search* paths, so a
+        # force-start by id — including one fired from a panel row cached before
+        # the story was archived — still launches the work. Pinned so closing
+        # the gap is a visible decision rather than a silent behaviour change.
+        prov = self._prov()
+        session = _FakeSession(
+            get_responses=[
+                _FakeResp(
+                    200,
+                    json_data={
+                        "id": 9,
+                        "name": "shipped last quarter",
+                        "archived": True,
+                    },
+                )
+            ]
+        )
+        with _patch_session(session):
+            t = await prov.fetch("9")
+        assert t.id == 9 and t.slug == "sc-9"
 
 
 class TestShortcutSearchAssigned:

--- a/tests/unit/test_turn_boundary.py
+++ b/tests/unit/test_turn_boundary.py
@@ -19,6 +19,7 @@ plus an empty queue, produce the event?).
 
 from __future__ import annotations
 
+import time
 import types
 
 import pytest
@@ -46,7 +47,7 @@ def test_working_stamps_work_evidence_and_idle_does_not():
     assert agent_state.worked_at("s") is None
     agent_state._verdict(rec, "idle", 1000.0)
     assert agent_state.worked_at("s") is None, "a quiet session has no work behind it"
-    agent_state._verdict(rec, "working", 1010.0)
+    agent_state._verdict(rec, "working", 1010.0, arms=True)
     assert agent_state.worked_at("s") == 1010.0
     agent_state._verdict(rec, "idle", 1020.0)
     assert agent_state.worked_at("s") == 1010.0, "idling does not erase the evidence"
@@ -72,7 +73,7 @@ def test_state_since_tracks_the_reported_value():
 
 def test_a_new_tmux_incarnation_resets_the_record():
     rec = agent_state._activity_record("s", 100.0)
-    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True)
     rec["hash"] = "deadbeef"
     agent_state._LIMIT_PROBE["s"] = {"at": 1000.0, "limit": True}
     # Same session_created -> the record is the same object, history intact.
@@ -94,7 +95,7 @@ def test_a_stampless_first_sighting_is_not_kept():
     # next real stamp to either adopt a dead run's history or discard it, and
     # discarding it a poll earlier is the same answer without the ambiguity.
     rec = agent_state._activity_record("s", None)
-    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True)
     assert "s" not in agent_state._ACTIVITY_CACHE
     assert agent_state.worked_at("s") is None
 
@@ -105,20 +106,20 @@ def test_limit_spends_the_work_evidence():
     # evidence here the session announces "has finished" the moment the pane
     # redraws — for work that was abandoned mid-thought.
     rec = agent_state._activity_record("s", 100.0)
-    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True)
     assert agent_state.worked_at("s") == 1000.0
     agent_state._verdict(rec, "limit", 1010.0)
     assert agent_state.worked_at("s") is None
     agent_state._verdict(rec, "idle", 1020.0)
     assert agent_state.worked_at("s") is None, "a redrawn prompt must not re-arm it"
     # A resume re-earns it, so the genuine ending still announces.
-    agent_state._verdict(rec, "working", 1030.0)
+    agent_state._verdict(rec, "working", 1030.0, arms=True)
     assert agent_state.worked_at("s") == 1030.0
 
 
 def test_claim_work_is_once_only():
     rec = agent_state._activity_record("s", 100.0)
-    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True)
     assert agent_state.claim_work("s") == 1000.0
     assert agent_state.claim_work("s") is None
     assert agent_state.claim_work("never-seen") is None
@@ -138,7 +139,7 @@ def test_offline_no_longer_wipes_the_record():
     # whose tmux was briefly gone came back with no history at all, straight
     # into the pane layer's first-sighting branch.
     rec = agent_state._activity_record("s", 100.0)
-    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True)
 
     def fake_run(cmd, **kwargs):
         if cmd[:2] == ["tmux", "has-session"]:
@@ -155,6 +156,359 @@ def test_offline_no_longer_wipes_the_record():
             assert server._agent_activity(inst, "s") == "offline"
     assert agent_state.worked_at("s") == 1000.0
     assert "s" in agent_state._ACTIVITY_CACHE
+
+
+# --------------------------------------------------------------------------- #
+# Which readings may ARM a turn end
+#
+# A reading is enough to paint the chip. It is not, by itself, enough to
+# interrupt a human. These pin the ladder: the CLI's own word and its live-turn
+# status line arm; a busy process tree does not, unless the CPU rate is
+# genuinely all the CLI has to offer.
+# --------------------------------------------------------------------------- #
+class _StubProvider:
+    """One configurable CLI: does it report for itself, does it declare a
+    live-turn pane pattern, and what does its marker say."""
+
+    def __init__(self, *, reports=False, patterns=(), marker=None, age=None):
+        self._reports, self._patterns = reports, patterns
+        self._marker, self._age = marker, age
+
+    def reports_activity(self):
+        return self._reports
+
+    def activity_state(self, name):
+        return self._marker
+
+    def activity_state_age(self, name):
+        return self._age
+
+    def record_thread(self, *a, **k):
+        return None
+
+    def waiting_prompt_patterns(self):
+        return []
+
+    def working_pane_patterns(self):
+        return self._patterns
+
+    def progress_token_pattern(self):
+        return None
+
+
+_QUIET_PANE = "line-1\nline-2\nline-3\nfiller\nbottom-a\nbottom-b\n"
+_LIVE_TURN_PANE = "\u283b Thinking… (esc to interrupt)\n" + _QUIET_PANE
+
+
+@pytest.fixture()
+def pane(monkeypatch):
+    """A controllable pane: text, CPU jiffies and a fake clock, so a poll is a
+    function call rather than a wait. Mirrors the harness in
+    test_activity_resize.py; kept local because these tests drive the CPU
+    counter, which that one's fixture does not expose per-poll."""
+    state = {"text": _QUIET_PANE, "cpu": 0, "t": 1000.0, "provider": _StubProvider()}
+    monkeypatch.setattr(server.time, "time", lambda: state["t"])
+    monkeypatch.setattr(server.tmux, "to_mindflock_tmux_name", lambda t: t)
+    monkeypatch.setattr(server, "_agent_exited", lambda name, created: False)
+    monkeypatch.setattr(server, "_pane_has_agent_process", lambda pid: True)
+    monkeypatch.setattr(server.providers, "resolve", lambda prog: state["provider"])
+    monkeypatch.setattr(
+        server, "_pane_meta", lambda name: ("node", 1.0, "123", "80x24")
+    )
+    monkeypatch.setattr(server, "_pane_cpu_jiffies", lambda pid: state["cpu"])
+    monkeypatch.setattr(server, "_dismiss_trust_prompt", lambda *a, **k: False)
+    monkeypatch.setattr(server.session, "Paused", "paused", raising=False)
+
+    def fake_run(argv, **kw):
+        joined = " ".join(argv)
+        if "has-session" in joined:
+            return types.SimpleNamespace(returncode=0, stdout=b"")
+        if "capture-pane" in joined:
+            return types.SimpleNamespace(returncode=0, stdout=state["text"].encode())
+        return types.SimpleNamespace(returncode=0, stdout=b"")
+
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+    return state
+
+
+def _poll(state, *, jiffies=0):
+    """One 4s tick, having burned ``jiffies`` of CPU since the last one.
+    120 jiffies over 4s is 30/s — above `_CPU_ACTIVE_JIFFIES_PER_S` (25)."""
+    state["t"] += 4.0
+    state["cpu"] += jiffies
+    inst = types.SimpleNamespace(
+        Title="s", Program="claude", Status="running", Started=lambda: True
+    )
+    return server._agent_activity(inst, "s")
+
+
+def test_an_unarmed_working_reading_moves_the_badge_and_arms_nothing():
+    # The split the whole fix rests on, at its smallest.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0)
+    assert agent_state.state_since("s") == 1000.0, "the chip still turns green"
+    assert agent_state.worked_at("s") is None, "and nothing may be announced"
+
+
+def test_a_cpu_spike_on_a_reporting_cli_arms_nothing(pane):
+    """THE PHANTOM-FINISH FIX.
+
+    A parked Claude session, untouched for 19 hours, announced "has finished".
+    Its own auto-updater crossed `_CPU_ACTIVE_JIFFIES_PER_S` for a single poll;
+    that read as working for ~12s — past the announce path's flicker settle —
+    and 45s of quiet later the turn-end gate found work evidence waiting.
+
+    The CLI reports for itself and its hooks said nothing, and no interrupt hint
+    was ever on the pane. Whatever burned that CPU, it was not a turn.
+    """
+    # A STALE working marker: the hooks demonstrably speak (the marker
+    # machinery works), classification just fell through to the pane. Stale
+    # past the 45s trust window but young enough to belong to this
+    # incarnation — a marker older than the 6h freshness cut reads as None
+    # and (rightly) re-earns the backstop, being indistinguishable from hooks
+    # that never worked.
+    pane["provider"] = _StubProvider(
+        reports=True, patterns=(r"esc to interrupt",), marker="working", age=60.0
+    )
+    assert _poll(pane) == "idle"
+    # The spike: real CPU, a redrawn pane, and no sign of a live turn on it.
+    pane["text"] = "a new line appeared\n" + _QUIET_PANE
+    assert _poll(pane, jiffies=120) == "working"
+    assert agent_state.worked_at("s") is None
+    # Not after a while, either: a CLI whose hooks are actually SPEAKING gets
+    # no CPU backstop, so an hour of a busy process tree is still not a turn.
+    started = pane["t"]
+    while pane["t"] - started < agent_state._CPU_ONLY_ARMS_AFTER_S * 3:
+        assert _poll(pane, jiffies=120) == "working"
+    assert agent_state.worked_at("s") is None
+    # And it decays back to idle on its own, still having armed nothing.
+    for _ in range(4):
+        _poll(pane)
+    assert agent_state.worked_at("s") is None
+
+
+def test_a_declared_reporter_whose_hooks_never_speak_keeps_the_backstop(pane):
+    # reports_activity is a config DECLARATION: a codex build without the
+    # hooks engine, or a hook install that failed silently, still declares
+    # True while activity_state answers None forever. Denying that session
+    # the backstop leaves one regex as its only route to a turn-end — so a
+    # silent marker keeps the sustained-CPU rung, spikes still excluded.
+    pane["provider"] = _StubProvider(reports=True, patterns=(), marker=None)
+    assert _poll(pane) == "idle"
+    assert _poll(pane, jiffies=120) == "working"
+    assert agent_state.worked_at("s") is None, "one busy poll is still a spike"
+    started = pane["t"]
+    while pane["t"] - started < agent_state._CPU_ONLY_ARMS_AFTER_S:
+        assert _poll(pane, jiffies=120) == "working"
+    assert agent_state.worked_at("s") == pane["t"]
+
+
+def test_the_live_turn_status_line_arms_even_with_no_marker(pane):
+    # The other half: an interrupt hint is on the pane BECAUSE a turn is
+    # running. It is turn-specific proof, so it arms whether or not the CLI's
+    # own hooks are reporting — which is the case where a marker went stale
+    # mid-turn and the pane is all that is left.
+    pane["provider"] = _StubProvider(reports=True, patterns=(r"esc to interrupt",))
+    pane["text"] = _LIVE_TURN_PANE
+    assert _poll(pane) == "working"
+    assert agent_state.worked_at("s") == pane["t"]
+
+
+def test_a_fresh_working_marker_arms_at_any_duration(pane):
+    # Layer 1. A hook fires because a prompt was submitted or a tool ran; there
+    # is no cosmetic redraw behind it, so no dwell is required of it.
+    pane["provider"] = _StubProvider(reports=True, marker="working", age=0.0)
+    assert _poll(pane) == "working"
+    assert agent_state.worked_at("s") == pane["t"]
+
+
+def test_a_cli_that_cannot_report_keeps_a_cpu_backstop(pane):
+    # Five of the six shipped providers have no hooks: their whole turn signal
+    # is one regex against a status line, and a regex can be wrong (the CLI
+    # reworded its hint, nobody filled one in). Losing the announcement to a bad
+    # pattern is worse than the spike the strict rule protects against, so a
+    # SUSTAINED busy run still arms here — `_CPU_ONLY_ARMS_AFTER_S`, which is
+    # longer than any single spike survives. A CLI that does report gets no such
+    # backstop; it has two independent signals already.
+    pane["provider"] = _StubProvider(reports=False, patterns=(r"esc to interrupt",))
+    assert _poll(pane) == "idle"
+    assert _poll(pane, jiffies=120) == "working"
+    assert agent_state.worked_at("s") is None, "one busy poll is still a spike"
+    started = pane["t"]
+    while pane["t"] - started < agent_state._CPU_ONLY_ARMS_AFTER_S:
+        assert _poll(pane, jiffies=120) == "working"
+    assert agent_state.worked_at("s") == pane["t"]
+
+
+def test_two_spikes_either_side_of_a_lull_do_not_add_up(pane):
+    # The run has to be unbroken: settling back to idle drops the clock, so a
+    # session that twitches every few minutes never accumulates a turn.
+    pane["provider"] = _StubProvider(reports=False, patterns=())
+    assert _poll(pane) == "idle"
+    for _ in range(2):
+        assert _poll(pane, jiffies=120) == "working"
+        for _ in range(4):  # CPU quiet, past _ACTIVITY_IDLE_AFTER
+            _poll(pane)
+        assert agent_state._ACTIVITY_CACHE["s"].get("hard_since") is None
+    assert agent_state.worked_at("s") is None
+
+
+# --------------------------------------------------------------------------- #
+# Reading sources: which layer spoke, and who gets to skip the guard rails
+#
+# _verdict records WHERE each reading came from; reading_is_authoritative is
+# the one question two consumers ask (the announce path's settle skip, the
+# queue drain's fast tier), and work_evidence is what the dwell tiers key on.
+# --------------------------------------------------------------------------- #
+def test_verdict_records_the_source_with_the_value():
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True, source="marker")
+    assert rec["source"] == "marker"
+    agent_state._verdict(rec, "idle", 1010.0, source="pane")
+    assert rec["source"] == "pane"
+
+
+def test_authoritative_needs_both_the_source_AND_the_value():
+    # The value comparison is the memo-skew guard: the tickers serve activity
+    # out of a 2.5s memo while the drain probes uncached, so the record can
+    # describe a NEWER reading than the value a caller holds. A mismatch must
+    # answer False — never let a stale value borrow a fresh reading's
+    # authority.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "idle", 1000.0, source="marker")
+    assert agent_state.reading_is_authoritative("s", "idle")
+    assert not agent_state.reading_is_authoritative("s", "working")
+    agent_state._verdict(rec, "idle", 1010.0, source="pane")
+    assert not agent_state.reading_is_authoritative("s", "idle")
+    assert not agent_state.reading_is_authoritative("never-seen", "idle")
+
+
+def test_exit_marker_is_authoritative_and_process_tree_is_not():
+    # An exit marker is written once, at process death — definitive. The
+    # process-tree probe can misread transiently (a ps race), which is exactly
+    # what the settle exists to absorb, so it stays on the guarded path.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "idle", 1000.0, source="exit")
+    assert agent_state.reading_is_authoritative("s", "idle")
+    agent_state._verdict(rec, "idle", 1010.0, source="proc")
+    assert not agent_state.reading_is_authoritative("s", "idle")
+
+
+def test_work_evidence_labels_the_armed_tier_and_survives_the_claim():
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True, source="marker")
+    assert agent_state.work_evidence("s") == "marker"
+    # Spending the evidence keeps the label: it describes the cycle that was
+    # just claimed, and it is only ever read next to worked_at.
+    assert agent_state.claim_work("s") == 1000.0
+    assert agent_state.work_evidence("s") == "marker"
+
+
+def test_pane_armed_evidence_carries_the_pane_proof():
+    rec = agent_state._activity_record("s", 100.0)
+    rec["proof"] = "status"
+    agent_state._verdict(rec, "working", 1000.0, arms=True, source="pane")
+    assert agent_state.work_evidence("s") == "status"
+    rec["proof"] = "cpu"
+    agent_state._verdict(rec, "working", 1010.0, arms=True, source="pane")
+    assert agent_state.work_evidence("s") == "cpu"
+
+
+def test_marker_working_evidence_is_marker_even_with_stale_pane_proof():
+    # A pane run earlier in the session leaves proof="status" behind; the
+    # CLI's own report must not inherit a weaker (or merely different) label.
+    rec = agent_state._activity_record("s", 100.0)
+    rec["proof"] = "cpu"
+    agent_state._verdict(rec, "working", 1000.0, arms=True, source="marker")
+    assert agent_state.work_evidence("s") == "marker"
+
+
+# --------------------------------------------------------------------------- #
+# The forced limit probe: the first idle after a turn always captures fresh
+# --------------------------------------------------------------------------- #
+class _Srv:
+    """Stand-in for the server module: _idle_or_limit only needs _run_capped."""
+
+    def __init__(self, pane_text):
+        self.pane_text = pane_text
+        self.captures = 0
+
+    def _run_capped(self, cmd, **kw):
+        self.captures += 1
+        return types.SimpleNamespace(
+            returncode=0, stdout=self.pane_text.encode("utf-8")
+        )
+
+
+def test_first_idle_after_a_turn_probes_the_pane_fresh(monkeypatch):
+    """THE LIMIT BLIND-WINDOW FIX.
+
+    A turn shorter than the probe throttle that ends BECAUSE of the limit used
+    to be invisible: the cache held a pre-turn "no banner" verdict, and if the
+    banner left the pane before the throttle expired, the cut-short turn's
+    work evidence stayed armed forever — a "has finished" for abandoned work.
+    Forcing a fresh capture on the working→idle transition closes the window
+    at the moment it opens.
+    """
+    monkeypatch.setattr(agent_state.time, "time", lambda: 1000.0)
+    # A fresh-looking cached verdict from BEFORE the turn: no banner.
+    agent_state._LIMIT_PROBE["s"] = {"at": 999.0, "limit": False}
+    srv = _Srv("Claude usage limit reached · resets 3am\n❯ 1. Wait\n")
+    out = agent_state._idle_or_limit(srv, "s", "s", None, force=True)
+    assert out == "limit"
+    assert srv.captures == 1, "the throttle was bypassed"
+
+
+def test_steady_state_idle_keeps_the_throttle(monkeypatch):
+    monkeypatch.setattr(agent_state.time, "time", lambda: 1000.0)
+    agent_state._LIMIT_PROBE["s"] = {"at": 999.0, "limit": False}
+    srv = _Srv("Claude usage limit reached\n")
+    out = agent_state._idle_or_limit(srv, "s", "s", None)
+    assert out == "idle", "cached verdict served — no banner known yet"
+    assert srv.captures == 0, "one capture per _LIMIT_RECHECK_S, as before"
+
+
+def test_a_forced_miss_does_not_buy_the_throttle_a_fresh_window(monkeypatch):
+    # The one forced capture can race the CLI's banner paint or fail outright
+    # (a busy tmux server). A miss must leave the throttle OPEN so the next
+    # 4s poll re-probes — caching it would serve "no banner" for 15s while
+    # the fast dwell announces a limit-cut turn as finished.
+    monkeypatch.setattr(agent_state.time, "time", lambda: 1000.0)
+    agent_state._LIMIT_PROBE.pop("s", None)
+    srv = _Srv("a plain prompt, banner not painted yet\n")
+    assert agent_state._idle_or_limit(srv, "s", "s", None, force=True) == "idle"
+    # A fresh cache seeded 0.5s ago (the pre-turn steady-state probe):
+    agent_state._LIMIT_PROBE["s"] = {"at": 999.5, "limit": False}
+    assert agent_state._idle_or_limit(srv, "s", "s", None, force=True) == "idle"
+    entry = agent_state._LIMIT_PROBE.get("s") or {}
+    assert float(entry.get("at", 1.0)) == 0.0, (
+        "a forced miss zeroes the stamp so the NEXT poll re-probes at tick "
+        "cadence instead of trusting a possibly pre-banner frame for 15s"
+    )
+    # And the banner painting late is caught by that very next poll.
+    srv2 = _Srv("Claude usage limit reached · resets 3am\n")
+    assert agent_state._idle_or_limit(srv2, "s", "s", None) == "limit"
+
+
+def test_marker_idle_after_working_forces_the_probe(pane):
+    # End to end through _agent_activity: the reading before the Stop was
+    # "working" (marker), the Stop lands with a limit banner on the pane and a
+    # FRESH (1s-old) cached no-banner verdict — the transition must see the
+    # banner anyway, and the cut-short turn's evidence must be dropped.
+    pane["provider"] = _StubProvider(reports=True, marker="working", age=0.0)
+    assert _poll(pane) == "working"
+    assert agent_state.worked_at("s") is not None
+    # Cache stamped with REAL wall time (agent_state keeps its own clock; the
+    # fixture only fakes the server module's): the throttle would serve this
+    # no-banner verdict for 15 more real seconds, so only the forced fresh
+    # capture can explain a "limit" answer below.
+    import time as _real_time
+
+    agent_state._LIMIT_PROBE["s"] = {"at": _real_time.time(), "limit": False}
+    pane["provider"] = _StubProvider(reports=True, marker="idle", age=0.0)
+    pane["text"] = "Claude usage limit reached · resets 3am\n" + _QUIET_PANE
+    assert _poll(pane) == "limit"
+    assert agent_state.worked_at("s") is None, "a cut-short turn is not a turn"
 
 
 # --------------------------------------------------------------------------- #
@@ -356,21 +710,439 @@ def test_boot_quiet_covers_turn_ends_too(bus, monkeypatch):
     assert _ended(got) == []
 
 
-def test_dwell_exceeds_every_other_idle_settle_in_the_app():
+def test_dwell_tier_ordering_and_exact_gate_coverage():
     """The ordering these numbers have to keep, pinned so a future tweak of any
     one of them cannot silently invert it.
 
-    The queue drains, and autopilot decides the agent is done, BEFORE anyone is
-    told the work finished. Announcing first would mean telling the user a
-    session was over and then watching it start typing again.
+    The tiers must be ordered by evidence strength — the weaker the evidence,
+    the longer the dwell — and the hazards the old flat 45s blanketed are now
+    covered by exact gates, each of which has its own constant to keep honest:
+    the send-grace must outlast the drain's whole worst-case pickup path, and
+    the human hold must exceed the inter-turn gap of a person reading a long
+    answer and typing a follow-up (10-30s).
     """
     from backend.web.core import autopilot
 
+    # Weaker evidence -> longer dwell.
+    assert (
+        server._TURN_END_DWELL_MARKER_S
+        < server._TURN_END_DWELL_STATUS_S
+        < server._TURN_END_DWELL_S
+    )
+    # Every tier must be large against the 4s tick (two unsynchronised tickers
+    # plus an on-demand republish shift the answer by about a tick).
+    assert server._TURN_END_DWELL_MARKER_S >= 12.0
+    # The slow tier keeps the old blanket relations: cpu-armed evidence gets
+    # no exact-gate credit, so it still outlasts the queue's and autopilot's
+    # own settles the way the flat dwell always did.
     assert server._TURN_END_DWELL_S > server._QUEUE_IDLE_SETTLE
     assert server._TURN_END_DWELL_S > autopilot.IDLE_SETTLE_S
-    # And it must dwarf the flicker filter, which answers a different question
-    # ("did two probes agree?") and cannot answer this one.
-    assert server._TURN_END_DWELL_S > server._ACTIVITY_SETTLE_SECONDS * 10
+    # The status tier must exceed the pane layer's own idle hysteresis plus
+    # the settle — its turn-END detection is itself pane-derived.
+    assert server._TURN_END_DWELL_STATUS_S > (
+        server._agent_state._ACTIVITY_IDLE_AFTER + server._ACTIVITY_SETTLE_SECONDS
+    )
+    # The send-grace covers the pop->visible-working window: a reboot's boot
+    # grace plus the drain's own settle plus a couple of passes.
+    assert server._QUEUE_SEND_GRACE_S > (
+        server._QUEUE_BOOT_GRACE + server._QUEUE_IDLE_SETTLE + 10.0
+    )
+    # A person reading a long answer types the follow-up within 10-30s.
+    assert server._HUMAN_HOLD_S >= 30.0
+    # The drain's fast tier still spans the ~1s Stop->UserPromptSubmit lull
+    # with margin, and stays under the guarded tier.
+    assert 2.0 < server._QUEUE_IDLE_SETTLE_MARKER < server._QUEUE_IDLE_SETTLE
+    # And every tier must dwarf the flicker filter, which answers a different
+    # question ("did two probes agree?") and cannot answer this one.
+    assert server._TURN_END_DWELL_MARKER_S > server._ACTIVITY_SETTLE_SECONDS * 3
+
+
+def test_marker_evidence_announces_on_the_fast_tier(bus, monkeypatch):
+    """The whole point of the tiering: a hook CLI's finished run is announced
+    in ~12s instead of ~45, because every hazard the extra 33s used to blanket
+    is checked exactly."""
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server._agent_state, "work_evidence", lambda t: "marker")
+    # The fast lane also requires the END to be the CLI's own word (see the
+    # mismatch test below) — grant it here.
+    monkeypatch.setattr(
+        server._agent_state, "reading_is_authoritative", lambda t, v: True
+    )
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    _tick("s20", "working")
+    clock["t"] += 4
+    _tick("s20", "idle")
+    clock["t"] += 4
+    _tick("s20", "idle")  # settles the chip
+    # Under the fast dwell but past what the settle alone would allow.
+    clock["t"] += server._TURN_END_DWELL_MARKER_S - 6
+    _tick("s20", "idle")
+    assert _ended(got) == []
+    clock["t"] += 8
+    _tick("s20", "idle")
+    assert len(_ended(got)) == 1
+    assert _ended(got)[0]["data"]["idle_for"] < server._TURN_END_DWELL_S
+
+
+def test_cpu_evidence_stays_on_the_slow_tier(bus, monkeypatch):
+    # The backstop tier bought its admission with the 45s dwell; a fast
+    # announcement on CPU-armed evidence would resurrect the phantom-finish.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server._agent_state, "work_evidence", lambda t: "cpu")
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    _tick("s21", "working")
+    clock["t"] += 4
+    _tick("s21", "idle")
+    clock["t"] += 4
+    _tick("s21", "idle")
+    clock["t"] += server._TURN_END_DWELL_STATUS_S + 5
+    _tick("s21", "idle")
+    assert _ended(got) == [], "status-tier time is not enough for cpu evidence"
+    clock["t"] += server._TURN_END_DWELL_S
+    _tick("s21", "idle")
+    assert len(_ended(got)) == 1
+
+
+def test_marker_armed_work_with_a_pane_detected_end_takes_the_slow_lane(
+    bus, monkeypatch
+):
+    # The tier is keyed on how the WORK was corroborated, but the END must be
+    # the CLI's own word to ride the fast lane: a marker-armed turn whose idle
+    # came from the pane (the marker went stale mid-turn, a scrolled-back
+    # capture read as parked) is a pane-detected end wearing marker evidence,
+    # and 12s of that would announce — and SPEND — a turn still running.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server._agent_state, "work_evidence", lambda t: "marker")
+    monkeypatch.setattr(
+        server._agent_state, "reading_is_authoritative", lambda t, v: False
+    )
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    _tick("s29", "working")
+    clock["t"] += 4
+    _tick("s29", "idle")
+    clock["t"] += 4
+    _tick("s29", "idle")
+    clock["t"] += server._TURN_END_DWELL_MARKER_S + 8
+    _tick("s29", "idle")
+    assert _ended(got) == [], "a pane-detected end must not ride the fast lane"
+    clock["t"] += server._TURN_END_DWELL_S
+    _tick("s29", "idle")
+    assert len(_ended(got)) == 1
+
+
+def test_recent_human_input_holds_the_announcement(bus, monkeypatch):
+    # A person mid-follow-up is not a finished run — and a person typing in
+    # the window does not need a push about the window.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    server._note_human_input("s22")
+    try:
+        for _ in range(3):
+            _tick("s22", "idle")
+        assert _ended(got) == []
+        # The person walked away: the hold expires and the announcement lands.
+        server._HUMAN_INPUT_AT["s22"] -= server._HUMAN_HOLD_S + 1
+        _tick("s22", "idle")
+        assert len(_ended(got)) == 1
+    finally:
+        server._HUMAN_INPUT_AT.pop("s22", None)
+
+
+def test_a_sent_but_unstarted_prompt_holds_the_announcement(bus, monkeypatch):
+    """THE POPPED-PROMPT WINDOW.
+
+    record_sent pops the final queued item the instant tmux typing succeeds,
+    so peek_next reads None seconds before the agent visibly starts (or
+    never, for a send that didn't take). The drain's own record carries the
+    truth: disarmed + recently sent = in flight.
+    """
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    server._QUEUE_STATE["s23"] = {
+        "armed": False,
+        "sent_at": time.time(),
+        "rebooted_at": 0.0,
+        "idle_since": None,
+    }
+    try:
+        for _ in range(3):
+            _tick("s23", "idle")
+        assert _ended(got) == []
+        # The drain observed the agent working since: the flight is over, and
+        # a later idle may announce.
+        server._QUEUE_STATE["s23"]["armed"] = True
+        _tick("s23", "idle")
+        assert len(_ended(got)) == 1
+    finally:
+        server._QUEUE_STATE.pop("s23", None)
+
+
+def test_a_lost_send_does_not_hold_forever(bus, monkeypatch):
+    # Past the grace with the agent never seen working, the send is presumed
+    # lost and the announcement falls through — the old flat dwell's behavior.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    server._QUEUE_STATE["s24"] = {
+        "armed": False,
+        "sent_at": time.time() - server._QUEUE_SEND_GRACE_S - 1,
+        "rebooted_at": 0.0,
+        "idle_since": None,
+    }
+    try:
+        _tick("s24", "working")
+        _tick("s24", "idle")
+        _tick("s24", "idle")
+        assert len(_ended(got)) == 1
+    finally:
+        server._QUEUE_STATE.pop("s24", None)
+
+
+def test_a_running_fast_track_chain_holds_the_announcement(bus, monkeypatch):
+    # "The chain decided the agent was done, THEN we said so" — now enforced
+    # exactly rather than by dwell arithmetic, so it holds at any tier.
+    from backend.web.core import autopilot as ap
+
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    ap.arm("s25", "push")
+    # A live driver holds the lease (claim refreshes owner_at every ~5s pass);
+    # the gate is bounded by exactly that lease, so grant it here.
+    ap.claim("s25", "test-driver")
+    try:
+        for _ in range(3):
+            _tick("s25", "idle")
+        assert _ended(got) == []
+        ap.finish("s25")
+        _tick("s25", "idle")
+        assert len(_ended(got)) == 1
+    finally:
+        ap.disarm("s25")
+
+
+def test_a_wedged_running_chain_cannot_mute_announcements_forever(bus, monkeypatch):
+    # _autopilot_observe early-returns WITHOUT claiming on the paths it cannot
+    # step (budget lock, missing worktree), so a "running" record nobody is
+    # advancing goes lease-stale — and announcements must resume rather than
+    # be muted for as long as the record says "running".
+    from backend.web.core import autopilot as ap
+
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: 5.0)
+    monkeypatch.setattr(server, "_TURN_END_DWELL_S", 0.0)
+    ap.arm("s30", "push")
+    ap.claim("s30", "test-driver")
+    ap.update("s30", owner_at=time.time() - ap.LEASE_STALE_S * 2 - 1)
+    try:
+        _tick("s30", "working")
+        _tick("s30", "idle")
+        _tick("s30", "idle")
+        assert len(_ended(got)) == 1, "a lease-stale running chain must not hold"
+    finally:
+        ap.disarm("s30")
+
+
+# --------------------------------------------------------------------------- #
+# The settle skip: an authoritative reading adopts in ONE tick
+# --------------------------------------------------------------------------- #
+def test_marker_sourced_idle_skips_the_settle(bus, monkeypatch):
+    """A hook marker cannot flicker — it changes only when the CLI fires a
+    hook — so parking it 3s+a tick was pure latency on the chip and on the
+    default-on needs-input/limit pushes."""
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: None)
+    monkeypatch.setattr(server, "_ACTIVITY_SETTLE_SECONDS", 3.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    server._ACTIVITY_CACHE["s26"] = {
+        "created": 1.0,
+        "reported": "idle",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("idle", "marker"),
+    }
+    try:
+        _tick("s26", "working")
+        clock["t"] += 4
+        _tick("s26", "idle")  # ONE sighting — adopted immediately
+        idles = [
+            e
+            for e in got
+            if e["event"] == "session.activity_changed" and e["new"] == "idle"
+        ]
+        assert len(idles) == 1, "authoritative idle must not park"
+        assert server._EVENT_SNAPSHOT["s26"]["activity"] == "idle"
+    finally:
+        server._ACTIVITY_CACHE.pop("s26", None)
+        server._EVENT_SNAPSHOT.pop("s26", None)
+
+
+def test_pane_sourced_idle_still_settles(bus, monkeypatch):
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: None)
+    monkeypatch.setattr(server, "_ACTIVITY_SETTLE_SECONDS", 3.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    server._ACTIVITY_CACHE["s27"] = {
+        "created": 1.0,
+        "reported": "idle",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("idle", "pane"),
+    }
+    try:
+        _tick("s27", "working")
+        clock["t"] += 4
+        _tick("s27", "idle")  # parked
+        assert server._EVENT_SNAPSHOT["s27"]["activity"] == "working"
+        clock["t"] += 4
+        _tick("s27", "idle")  # settled
+        assert server._EVENT_SNAPSHOT["s27"]["activity"] == "idle"
+    finally:
+        server._ACTIVITY_CACHE.pop("s27", None)
+        server._EVENT_SNAPSHOT.pop("s27", None)
+
+
+def test_a_chained_turn_boundary_is_not_swallowed(bus, monkeypatch):
+    # Stop then UserPromptSubmit inside one drain pass (a queue picking up the
+    # next prompt): the authoritative idle adopts in ONE sighting and the
+    # working that follows immediately must also emit — neither leg of the
+    # boundary may vanish into a settle window.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: None)
+    monkeypatch.setattr(server, "_ACTIVITY_SETTLE_SECONDS", 3.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    server._ACTIVITY_CACHE["s33"] = {
+        "created": 1.0,
+        "reported": "idle",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("idle", "marker"),
+    }
+    try:
+        _tick("s33", "working")
+        clock["t"] += 4
+        _tick("s33", "idle")  # Stop hook — adopted on one sighting
+        server._ACTIVITY_CACHE["s33"]["reading"] = ("working", "marker")
+        _tick("s33", "working")  # UserPromptSubmit, the very next tick
+        acts = [e["new"] for e in got if e["event"] == "session.activity_changed"]
+        assert "idle" in acts, "the Stop leg emitted"
+        assert acts and acts[-1] == "working", "the restart leg emitted after it"
+        assert server._EVENT_SNAPSHOT["s33"]["activity"] == "working"
+    finally:
+        server._ACTIVITY_CACHE.pop("s33", None)
+        server._EVENT_SNAPSHOT.pop("s33", None)
+
+
+def test_marker_clarify_skips_the_settle_and_limit_never_does(bus, monkeypatch):
+    """The two settle-skip cases that feed DEFAULT-ON pushes.
+
+    A marker clarify (Notification/PermissionRequest hook) is the CLI's own
+    word — the "needs your input" push may fire on one sighting. A "limit"
+    reading never skips, whatever its tag: both marker-branch limit
+    reclassifications are really pane captures matched against the limit
+    patterns, and a single frame CAN misread those (copy-mode scrollback,
+    agent output quoting a banner) — the "ran out of usage" push keeps its
+    two-sighting guard.
+    """
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: None)
+    monkeypatch.setattr(server, "_ACTIVITY_SETTLE_SECONDS", 3.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    server._ACTIVITY_CACHE["s31"] = {
+        "created": 1.0,
+        "reported": "clarify",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("clarify", "marker"),
+    }
+    server._ACTIVITY_CACHE["s32"] = {
+        "created": 1.0,
+        "reported": "limit",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("limit", "marker"),
+    }
+    try:
+        _tick("s31", "working")
+        _tick("s32", "working")
+        clock["t"] += 4
+        _tick("s31", "clarify")
+        _tick("s32", "limit")
+        assert (
+            server._EVENT_SNAPSHOT["s31"]["activity"] == "clarify"
+        ), "the CLI's own needs-input is adopted in one sighting"
+        assert (
+            server._EVENT_SNAPSHOT["s32"]["activity"] == "working"
+        ), "limit is a pane fact whatever its tag — it keeps the settle"
+    finally:
+        for t in ("s31", "s32"):
+            server._ACTIVITY_CACHE.pop(t, None)
+            server._EVENT_SNAPSHOT.pop(t, None)
+
+
+def test_an_incarnation_reset_drops_reading_authority():
+    # A relaunched tmux session must not inherit the dead run's authority any
+    # more than its work evidence: the reset wipes the (value, source) pair,
+    # and until the fresh incarnation's first _verdict there is nothing to
+    # skip a settle on.
+    rec = agent_state._activity_record("s", 100.0)
+    agent_state._verdict(rec, "idle", 1000.0, source="marker")
+    assert agent_state.reading_is_authoritative("s", "idle")
+    agent_state._activity_record("s", 200.0)  # new tmux incarnation
+    assert not agent_state.reading_is_authoritative("s", "idle")
+
+
+def test_a_stale_memo_cannot_borrow_a_fresh_readings_authority(bus, monkeypatch):
+    # The record says the CURRENT reading is "working" (a fresh uncached drain
+    # probe); the ticker arrives with a memoized "idle". The mismatch must
+    # take the guarded path — value and source travel together or not at all.
+    got = []
+    bus.subscribe(got.append)
+    monkeypatch.setattr(server._agent_state, "worked_at", lambda t: None)
+    monkeypatch.setattr(server, "_ACTIVITY_SETTLE_SECONDS", 3.0)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["t"])
+    server._ACTIVITY_CACHE["s28"] = {
+        "created": 1.0,
+        "reported": "working",
+        "state_since": 0.0,
+        "worked_at": None,
+        "reading": ("working", "marker"),
+    }
+    try:
+        _tick("s28", "working")
+        clock["t"] += 4
+        _tick("s28", "idle")
+        assert (
+            server._EVENT_SNAPSHOT["s28"]["activity"] == "working"
+        ), "a memoized idle with mismatched provenance must park"
+    finally:
+        server._ACTIVITY_CACHE.pop("s28", None)
+        server._EVENT_SNAPSHOT.pop("s28", None)
 
 
 def test_clarify_after_work_keeps_the_EARLIER_stamp():
@@ -379,7 +1151,7 @@ def test_clarify_after_work_keeps_the_EARLIER_stamp():
     # dwell every time a permission prompt redrew, and clearing it would lose a
     # genuine turn to a mid-turn confirmation.
     rec = agent_state._activity_record("s", 100.0)
-    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True)
     agent_state._verdict(rec, "clarify", 1200.0)
     assert agent_state.worked_at("s") == 1000.0
     agent_state._verdict(rec, "idle", 1210.0)
@@ -392,7 +1164,7 @@ def test_a_garbage_incarnation_stamp_does_not_retire_the_record():
     # not read as "a different session" — that would discard a live run's
     # history on a single bad poll.
     rec = agent_state._activity_record("s", 100.0)
-    agent_state._verdict(rec, "working", 1000.0)
+    agent_state._verdict(rec, "working", 1000.0, arms=True)
     for junk in ("not-a-number", object(), [1, 2]):
         assert agent_state._activity_record("s", junk) is rec
         assert agent_state.worked_at("s") == 1000.0


### PR DESCRIPTION
- Introduced `session.turn_ended` event to accurately signal when a session's work is genuinely complete, ensuring it only fires after the agent has been observed working, has been idle for 45 seconds, and has no queued prompts.
- Updated notification rules to reflect this change, improving clarity for users by distinguishing between idle states and actual completion of work.
- Fixed issues with the break clock to ensure it only counts active time, resetting appropriately when the app is reopened or when significant gaps in activity are detected.
- Improved documentation to clarify the new event and its implications for user notifications and session management.

This update enhances user experience by reducing noise from unnecessary notifications and ensuring accurate tracking of session states.