### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-02
+
 ### Added
 
 - **Window rows are first-class sidebar rows.** The Assistant chat, the log
@@ -193,6 +195,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the clicked box just took — so it unticks a run as readily as it ticks one.
   Deleting twenty rows was twenty clicks. The anchor is the last row you ticked
   plainly, and it survives the extend; a new page of rows clears it.
+- **The web UI is built with Vite 8** (Rolldown + Oxc, replacing Rollup +
+  esbuild), which also unblocks `@vitejs/plugin-react` 6 — the plugin major
+  that 0.1.x had to pin away from because it requires vite 8. The shipped
+  bundle is smaller for it: 2.00 MB to 1.77 MB, 458 kB to 371 kB gzipped,
+  most of it source comments that the old toolchain dropped and the new one
+  preserved until told not to. Nothing in the UI changes.
 
 ## [0.2.1] - 2026-08-28
 
@@ -1908,7 +1916,8 @@ coding agent, supervised from one desktop app.
 - Native Windows is not a supported host for the engine (no tmux, no Unix
   PTYs) — WSL2 is required, and the Windows installer bootstraps it.
 
-[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/MindFlock/MindFlock/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/MindFlock/MindFlock/releases/tag/v0.3.0
 [0.2.1]: https://github.com/MindFlock/MindFlock/releases/tag/v0.2.1
 [0.2.0]: https://github.com/MindFlock/MindFlock/releases/tag/v0.2.0
 [0.1.17]: https://github.com/MindFlock/MindFlock/releases/tag/v0.1.17

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-desktop",
   "productName": "MindFlock",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "private": true,
   "description": "Native desktop shell for the MindFlock web UI (Electron).",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mindflock-frontend",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "description": "MindFlock web UI — React + TypeScript source; builds into backend/web/static/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mindflock"
-version = "0.2.1"
+version = "0.3.0"
 description = "MindFlock — a private flock of AI coding agents, each in its own git worktree on your own machine; started by your ticket queue (GitHub Issues, Jira, Linear, Shortcut, Asana), merged by you"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "mindflock"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump only — every change in this release already landed on `main` via its own PR. This moves the three manifests (plus `uv.lock`) to **0.3.0** and rolls the CHANGELOG's `[Unreleased]` heading to `[0.3.0] - 2026-09-02`.

**Minor, not patch:** the section is 22 entries and mostly new capability — Extensions (Addon API v3), the Database Client built on it, first-class window rows, the Recently-closed page, and new endpoints (`GET /api/recent`, `POST /api/workspaces/prune-worktrees`).

One CHANGELOG line was added here rather than in its feature PR, since #93 shipped without one:

> **The web UI is built with Vite 8** (Rolldown + Oxc, replacing Rollup + esbuild), which also unblocks `@vitejs/plugin-react` 6 — the plugin major that 0.1.x had to pin away from because it requires vite 8. The shipped bundle is smaller for it: 2.00 MB to 1.77 MB, 458 kB to 371 kB gzipped. Nothing in the UI changes.

That closes out the `npm ci` failure the 0.1.x CHANGELOG records as a pin-and-wait workaround.

## Checks run locally

- `bump-version.py --check --expect v0.3.0` — the same guard `release.yml` runs on the tag
- 5364 backend tests, `black --check` clean, `check-bundle-fresh.sh` green
- The version string is served by the API, not baked into the bundle, so the bump needs no rebuild (verified: no `0.2.1` in `app.js`)

After merge: tag `v0.3.0` on the merge commit and push it — that is what triggers `release.yml` to build the wheel, sdist and the three desktop installers and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df4kq1267jfEDgZS5sbNvE